### PR TITLE
tf2_geometry_msgs needs to ament export dependencies

### DIFF
--- a/tf2_geometry_msgs/CMakeLists.txt
+++ b/tf2_geometry_msgs/CMakeLists.txt
@@ -7,6 +7,18 @@ endif()
 
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
+# Ensure that the required dependencies were successfully found
+set(required_dependencies
+  "geometry_msgs"
+  "orocos_kdl"
+  "tf2"
+  "tf2_ros"
+)
+foreach(dep ${required_dependencies})
+  if(NOT ${dep}_FOUND)
+    message(FATAL_ERROR "'${dep}' has not been successfully found")
+  endif()
+endforeach()
 
 include_directories(include
    ${orocos_kdl_INCLUDE_DIRS}

--- a/tf2_geometry_msgs/CMakeLists.txt
+++ b/tf2_geometry_msgs/CMakeLists.txt
@@ -5,11 +5,8 @@ if(NOT WIN32)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra")
 endif()
 
-find_package(orocos_kdl)
-find_package(ament_cmake REQUIRED)
-find_package(geometry_msgs REQUIRED)
-find_package(tf2 REQUIRED)
-find_package(tf2_ros REQUIRED)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
 include_directories(include
    ${orocos_kdl_INCLUDE_DIRS}
@@ -46,5 +43,4 @@ install(DIRECTORY include/${PROJECT_NAME}/
 #
 #
 # endif()
-ament_export_include_directories(include)
-ament_package()
+ament_auto_package()

--- a/tf2_geometry_msgs/CMakeLists.txt
+++ b/tf2_geometry_msgs/CMakeLists.txt
@@ -5,8 +5,11 @@ if(NOT WIN32)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra")
 endif()
 
+find_package(orocos_kdl)
 find_package(ament_cmake_auto REQUIRED)
-ament_auto_find_build_dependencies()
+find_package(geometry_msgs REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_ros REQUIRED)
 
 include_directories(include
    ${orocos_kdl_INCLUDE_DIRS}
@@ -43,4 +46,5 @@ install(DIRECTORY include/${PROJECT_NAME}/
 #
 #
 # endif()
+ament_auto_find_build_dependencies()
 ament_auto_package()

--- a/tf2_geometry_msgs/CMakeLists.txt
+++ b/tf2_geometry_msgs/CMakeLists.txt
@@ -6,19 +6,13 @@ if(NOT WIN32)
 endif()
 
 find_package(ament_cmake_auto REQUIRED)
-ament_auto_find_build_dependencies()
-# Ensure that the required dependencies were successfully found
 set(required_dependencies
   "geometry_msgs"
   "orocos_kdl"
   "tf2"
   "tf2_ros"
 )
-foreach(dep ${required_dependencies})
-  if(NOT ${dep}_FOUND)
-    message(FATAL_ERROR "'${dep}' has not been successfully found")
-  endif()
-endforeach()
+ament_auto_find_build_dependencies(REQUIRED ${required_dependencies})
 
 include_directories(include
    ${orocos_kdl_INCLUDE_DIRS}

--- a/tf2_geometry_msgs/CMakeLists.txt
+++ b/tf2_geometry_msgs/CMakeLists.txt
@@ -21,11 +21,6 @@ include_directories(include
 link_directories(${orocos_kdl_LIBRARY_DIRS})
 
 
-
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION include/${PROJECT_NAME}
-)
-
 # TODO(dhood): enable python support once ported to ROS 2
 # catkin_python_setup()
 

--- a/tf2_geometry_msgs/CMakeLists.txt
+++ b/tf2_geometry_msgs/CMakeLists.txt
@@ -5,11 +5,8 @@ if(NOT WIN32)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra")
 endif()
 
-find_package(orocos_kdl)
 find_package(ament_cmake_auto REQUIRED)
-find_package(geometry_msgs REQUIRED)
-find_package(tf2 REQUIRED)
-find_package(tf2_ros REQUIRED)
+ament_auto_find_build_dependencies()
 
 include_directories(include
    ${orocos_kdl_INCLUDE_DIRS}
@@ -41,5 +38,4 @@ link_directories(${orocos_kdl_LIBRARY_DIRS})
 #
 #
 # endif()
-ament_auto_find_build_dependencies()
 ament_auto_package()

--- a/tf2_geometry_msgs/package.xml
+++ b/tf2_geometry_msgs/package.xml
@@ -10,7 +10,7 @@
 
   <url type="website">http://www.ros.org/wiki/tf2_ros</url>
 
-  <buildtool_depend>ament_auto_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <depend>geometry_msgs</depend>
   <depend>orocos_kdl</depend>

--- a/tf2_geometry_msgs/package.xml
+++ b/tf2_geometry_msgs/package.xml
@@ -10,7 +10,7 @@
 
   <url type="website">http://www.ros.org/wiki/tf2_ros</url>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_auto_cmake</buildtool_depend>
 
   <depend>geometry_msgs</depend>
   <depend>orocos_kdl</depend>


### PR DESCRIPTION
Connects to ros2/navigation#5
requires ament/ament_cmake#93

The dependency on KDL wasn't being exported in CMake.
To make sure I haven't missed anything else, I switched to using [ament_auto_package](https://github.com/ament/ament_cmake/blob/40230914a02d209e2927a1b70e8be93d50db24b2/ament_cmake_auto/cmake/ament_auto_package.cmake) which takes care of things like this.