### PR TITLE
Update getTimestamp and getFramId to not return const references

### DIFF
--- a/tf2/include/tf2/convert.h
+++ b/tf2/include/tf2/convert.h
@@ -66,7 +66,7 @@ template <class T>
  * \return The frame_id associated with the data. 
  */
 template <class T>
-  const std::string& getFrameId(const T& t);
+  std::string getFrameId(const T& t);
 
 
 
@@ -79,7 +79,7 @@ template <class P>
 
 /* An implementation for Stamped<P> datatypes */
 template <class P>
-  const std::string& getFrameId(const tf2::Stamped<P>& t)
+  std::string getFrameId(const tf2::Stamped<P>& t)
   {
     return t.frame_id_;
   }

--- a/tf2/include/tf2/convert.h
+++ b/tf2/include/tf2/convert.h
@@ -59,7 +59,7 @@ template <class T>
  * \return The timestamp associated with the data. 
  */
 template <class T>
-  const tf2::TimePoint& getTimestamp(const T& t);
+  tf2::TimePoint getTimestamp(const T& t);
 
 /**\brief Get the frame_id from data 
  * \param t The data input.
@@ -72,7 +72,7 @@ template <class T>
 
 /* An implementation for Stamped<P> datatypes */
 template <class P>
-  const tf2::TimePoint& getTimestamp(const tf2::Stamped<P>& t)
+  tf2::TimePoint getTimestamp(const tf2::Stamped<P>& t)
   {
     return t.stamp_;
   }

--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
@@ -67,7 +67,7 @@ inline
 // method to extract frame id from object
 template <>
 inline
-  const std::string& getFrameId(const geometry_msgs::msg::Vector3Stamped& t) {return t.header.frame_id;}
+  std::string getFrameId(const geometry_msgs::msg::Vector3Stamped& t) {return t.header.frame_id;}
 
 // this method needs to be implemented by client library developers
 template <>
@@ -106,7 +106,7 @@ inline
 // method to extract frame id from object
 template <>
 inline
-  const std::string& getFrameId(const geometry_msgs::msg::PointStamped& t)  {return t.header.frame_id;}
+  std::string getFrameId(const geometry_msgs::msg::PointStamped& t)  {return t.header.frame_id;}
 
 // this method needs to be implemented by client library developers
 template <>
@@ -144,7 +144,7 @@ inline
 // method to extract frame id from object
 template <>
 inline
-  const std::string& getFrameId(const geometry_msgs::msg::PoseStamped& t)  {return t.header.frame_id;}
+  std::string getFrameId(const geometry_msgs::msg::PoseStamped& t)  {return t.header.frame_id;}
 
 // this method needs to be implemented by client library developers
 template <>
@@ -209,7 +209,7 @@ tf2::TimePoint getTimestamp(const geometry_msgs::msg::QuaternionStamped& t)  {re
 // method to extract frame id from object
 template <>
 inline
-const std::string& getFrameId(const geometry_msgs::msg::QuaternionStamped& t)  {return t.header.frame_id;}
+std::string getFrameId(const geometry_msgs::msg::QuaternionStamped& t)  {return t.header.frame_id;}
 
 // this method needs to be implemented by client library developers
 template <>
@@ -272,7 +272,7 @@ tf2::TimePoint getTimestamp(const geometry_msgs::msg::TransformStamped& t)  {ret
 // method to extract frame id from object
 template <>
 inline
-const std::string& getFrameId(const geometry_msgs::msg::TransformStamped& t)  {return t.header.frame_id;}
+std::string getFrameId(const geometry_msgs::msg::TransformStamped& t)  {return t.header.frame_id;}
 
 // this method needs to be implemented by client library developers
 template <>

--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
@@ -62,7 +62,7 @@ KDL::Frame gmTransformToKDL(const geometry_msgs::msg::TransformStamped& t)
 // method to extract timestamp from object
 template <>
 inline
-  const tf2::TimePoint& getTimestamp(const geometry_msgs::msg::Vector3Stamped& t) {return tf2_ros::fromMsg(t.header.stamp);}
+  tf2::TimePoint getTimestamp(const geometry_msgs::msg::Vector3Stamped& t) {return tf2_ros::fromMsg(t.header.stamp);}
 
 // method to extract frame id from object
 template <>
@@ -101,7 +101,7 @@ void fromMsg(const geometry_msgs::msg::Vector3Stamped& msg, geometry_msgs::msg::
 // method to extract timestamp from object
 template <>
 inline
-  const tf2::TimePoint& getTimestamp(const geometry_msgs::msg::PointStamped& t)  {return tf2_ros::fromMsg(t.header.stamp);}
+  tf2::TimePoint getTimestamp(const geometry_msgs::msg::PointStamped& t)  {return tf2_ros::fromMsg(t.header.stamp);}
 
 // method to extract frame id from object
 template <>
@@ -139,7 +139,7 @@ void fromMsg(const geometry_msgs::msg::PointStamped& msg, geometry_msgs::msg::Po
 // method to extract timestamp from object
 template <>
 inline
-  const tf2::TimePoint& getTimestamp(const geometry_msgs::msg::PoseStamped& t)  {return tf2_ros::fromMsg(t.header.stamp);}
+  tf2::TimePoint getTimestamp(const geometry_msgs::msg::PoseStamped& t)  {return tf2_ros::fromMsg(t.header.stamp);}
 
 // method to extract frame id from object
 template <>
@@ -204,7 +204,7 @@ void fromMsg(const geometry_msgs::msg::Quaternion& in, tf2::Quaternion& out)
 // method to extract timestamp from object
 template <>
 inline
-const tf2::TimePoint& getTimestamp(const geometry_msgs::msg::QuaternionStamped& t)  {return tf2_ros::fromMsg(t.header.stamp);}
+tf2::TimePoint getTimestamp(const geometry_msgs::msg::QuaternionStamped& t)  {return tf2_ros::fromMsg(t.header.stamp);}
 
 // method to extract frame id from object
 template <>
@@ -267,7 +267,7 @@ void fromMsg(const geometry_msgs::msg::QuaternionStamped& in, tf2::Stamped<tf2::
 // method to extract timestamp from object
 template <>
 inline
-const tf2::TimePoint& getTimestamp(const geometry_msgs::msg::TransformStamped& t)  {return tf2_ros::fromMsg(t.header.stamp);}
+tf2::TimePoint getTimestamp(const geometry_msgs::msg::TransformStamped& t)  {return tf2_ros::fromMsg(t.header.stamp);}
 
 // method to extract frame id from object
 template <>

--- a/tf2_ros/include/tf2_ros/buffer_interface.h
+++ b/tf2_ros/include/tf2_ros/buffer_interface.h
@@ -55,11 +55,10 @@ namespace tf2_ros
     return time_msg;
   }
 
-  inline const tf2::TimePoint& fromMsg(const builtin_interfaces::msg::Time & time_msg)
+  inline const tf2::TimePoint fromMsg(const builtin_interfaces::msg::Time & time_msg)
   {
     int64_t d = time_msg.sec * 1000000000ull + time_msg.nanosec;
-    tf2::TimePoint t = tf2::TimePoint(std::chrono::nanoseconds(d));
-    return std::move(t);
+    return tf2::Timepoint(std::chrono::nanoseconds(d));
   }
 
   inline double timeToSec(const builtin_interfaces::msg::Time & time_msg)

--- a/tf2_ros/include/tf2_ros/buffer_interface.h
+++ b/tf2_ros/include/tf2_ros/buffer_interface.h
@@ -55,10 +55,10 @@ namespace tf2_ros
     return time_msg;
   }
 
-  inline const tf2::TimePoint fromMsg(const builtin_interfaces::msg::Time & time_msg)
+  inline tf2::TimePoint fromMsg(const builtin_interfaces::msg::Time & time_msg)
   {
     int64_t d = time_msg.sec * 1000000000ull + time_msg.nanosec;
-    return tf2::Timepoint(std::chrono::nanoseconds(d));
+    return tf2::TimePoint(std::chrono::nanoseconds(d));
   }
 
   inline double timeToSec(const builtin_interfaces::msg::Time & time_msg)

--- a/tf2_sensor_msgs/include/tf2_sensor_msgs/tf2_sensor_msgs.h
+++ b/tf2_sensor_msgs/include/tf2_sensor_msgs/tf2_sensor_msgs.h
@@ -46,7 +46,7 @@ namespace tf2
 // method to extract timestamp from object
 template <>
 inline
-const builtin_interfaces::msg::Time& getTimestamp(const sensor_msgs::PointCloud2& p) {return p.header.stamp;}
+tf2::TimePoint getTimestamp(const sensor_msgs::PointCloud2& p) {return p.header.stamp;}
 
 // method to extract frame id from object
 template <>

--- a/tf2_sensor_msgs/include/tf2_sensor_msgs/tf2_sensor_msgs.h
+++ b/tf2_sensor_msgs/include/tf2_sensor_msgs/tf2_sensor_msgs.h
@@ -51,7 +51,7 @@ tf2::TimePoint getTimestamp(const sensor_msgs::PointCloud2& p) {return p.header.
 // method to extract frame id from object
 template <>
 inline
-const std::string& getFrameId(const sensor_msgs::PointCloud2 &p) {return p.header.frame_id;}
+std::string getFrameId(const sensor_msgs::PointCloud2 &p) {return p.header.frame_id;}
 
 // this method needs to be implemented by client library developers
 template <>


### PR DESCRIPTION
Connects to ros2/navigation#5
`getTimestamp` and `getFrameId` are safe (enough) to return `const ros::Time&` in ROS 1.

For ROS 2, we need to convert from `builtin_interfaces::msg::Time` to `tf2::TimePoint`, which involves more than just passing the timestamp through.

For that reason, this PR changes the signature of `getTimestamp` to not return const references. For good measure, I did the same for `getFrameId` because you never know what might need to happen underneath.