### PR TITLE
Add (and use) durationFromSec and timeFromSec

### DIFF
--- a/test_tf2/test/buffer_core_test.cpp
+++ b/test_tf2/test/buffer_core_test.cpp
@@ -162,7 +162,7 @@ void push_back_1(std::vector<std::string>& children, std::vector<std::string>& p
   dy.push_back(0.0);
 }
 
-void setupTree(tf2::BufferCore& mBC, const std::string& mode, const builtin_interfaces::msg::Time & time, const tf2::Duration& interpolation_space = tf2::Duration())
+void setupTree(tf2::BufferCore& mBC, const std::string& mode, const builtin_interfaces::msg::Time & time, const tf2::Duration& interpolation_space = tf2::durationFromSec())
 {
   ROS_DEBUG("Clearing Buffer Core for new test setup");
   mBC.clear();
@@ -633,9 +633,9 @@ TEST(BufferCore_lookupTransform, i_configuration)
   permuter.addOptionSet(times, &eval_time);
 
   std::vector<tf2::Duration> durations;
-  durations.push_back(tf2::Duration(1.0));
-  durations.push_back(tf2::Duration(0.001));
-  durations.push_back(tf2::Duration(0.1));
+  durations.push_back(tf2::durationFromSec(1.0));
+  durations.push_back(tf2::durationFromSec(0.001));
+  durations.push_back(tf2::durationFromSec(0.1));
   tf2::Duration interpolation_space;
   //  permuter.addOptionSet(durations, &interpolation_space);
 
@@ -971,9 +971,9 @@ TEST(BufferCore_lookupTransform, one_link_configuration)
   permuter.addOptionSet(times, &eval_time);
 
   std::vector<tf2::Duration> durations;
-  durations.push_back(tf2::Duration(1.0));
-  durations.push_back(tf2::Duration(0.001));
-  durations.push_back(tf2::Duration(0.1));
+  durations.push_back(tf2::durationFromSec(1.0));
+  durations.push_back(tf2::durationFromSec(0.001));
+  durations.push_back(tf2::durationFromSec(0.1));
   tf2::Duration interpolation_space;
   //  permuter.addOptionSet(durations, &interpolation_space);
 
@@ -1015,9 +1015,9 @@ TEST(BufferCore_lookupTransform, v_configuration)
   permuter.addOptionSet(times, &eval_time);
 
   std::vector<tf2::Duration> durations;
-  durations.push_back(tf2::Duration(1.0));
-  durations.push_back(tf2::Duration(0.001));
-  durations.push_back(tf2::Duration(0.1));
+  durations.push_back(tf2::durationFromSec(1.0));
+  durations.push_back(tf2::durationFromSec(0.001));
+  durations.push_back(tf2::durationFromSec(0.1));
   tf2::Duration interpolation_space;
   //  permuter.addOptionSet(durations, &interpolation_space);
 
@@ -1062,9 +1062,9 @@ TEST(BufferCore_lookupTransform, y_configuration)
   permuter.addOptionSet(times, &eval_time);
 
   std::vector<tf2::Duration> durations;
-  durations.push_back(tf2::Duration(1.0));
-  durations.push_back(tf2::Duration(0.001));
-  durations.push_back(tf2::Duration(0.1));
+  durations.push_back(tf2::durationFromSec(1.0));
+  durations.push_back(tf2::durationFromSec(0.001));
+  durations.push_back(tf2::durationFromSec(0.1));
   tf2::Duration interpolation_space;
   //  permuter.addOptionSet(durations, &interpolation_space);
 
@@ -1108,9 +1108,9 @@ TEST(BufferCore_lookupTransform, multi_configuration)
   permuter.addOptionSet(times, &eval_time);
 
   std::vector<tf2::Duration> durations;
-  durations.push_back(tf2::Duration(1.0));
-  durations.push_back(tf2::Duration(0.001));
-  durations.push_back(tf2::Duration(0.1));
+  durations.push_back(tf2::durationFromSec(1.0));
+  durations.push_back(tf2::durationFromSec(0.001));
+  durations.push_back(tf2::durationFromSec(0.1));
   tf2::Duration interpolation_space;
   //  permuter.addOptionSet(durations, &interpolation_space);
 
@@ -1319,10 +1319,10 @@ TEST(BufferCore_lookupTransform, helix_configuration)
 
     tf2::BufferCore mBC;
 
-    builtin_interfaces::msg::Time     t0        = builtin_interfaces::msg::Time() + tf2::Duration(10);
-    tf2::Duration step      = tf2::Duration(0.05);
-    tf2::Duration half_step = tf2::Duration(0.025);
-    builtin_interfaces::msg::Time     t1        = t0 + tf2::Duration(5.0);
+    builtin_interfaces::msg::Time     t0        = builtin_interfaces::msg::Time() + tf2::durationFromSec(10);
+    tf2::Duration step      = tf2::durationFromSec(0.05);
+    tf2::Duration half_step = tf2::durationFromSec(0.025);
+    builtin_interfaces::msg::Time     t1        = t0 + tf2::durationFromSec(5.0);
 
     /*
      * a->b->c
@@ -1436,9 +1436,9 @@ TEST(BufferCore_lookupTransform, ring_45_configuration)
   permuter.addOptionSet(times, &eval_time);
 
   std::vector<tf2::Duration> durations;
-  durations.push_back(tf2::Duration(1.0));
-  durations.push_back(tf2::Duration(0.001));
-  durations.push_back(tf2::Duration(0.1));
+  durations.push_back(tf2::durationFromSec(1.0));
+  durations.push_back(tf2::durationFromSec(0.001));
+  durations.push_back(tf2::durationFromSec(0.1));
   tf2::Duration interpolation_space;
   //  permuter.addOptionSet(durations, &interpolation_space);
 

--- a/test_tf2/test/test_buffer_client.cpp
+++ b/test_tf2/test/test_buffer_client.cpp
@@ -48,7 +48,7 @@ TEST(tf2_ros, buffer_client)
   tf2_ros::BufferClient client("tf_action");
 
   //make sure that things are set up
-  ASSERT_TRUE(client.waitForServer(tf2::Duration(4.0)));
+  ASSERT_TRUE(client.waitForServer(tf2::durationFromSec(4.0)));
 
   geometry_msgs::PointStamped p1;
   p1.header.frame_id = "a";
@@ -79,7 +79,7 @@ TEST(tf2_ros, buffer_client_different_types)
   tf2_ros::BufferClient client("tf_action");
 
   //make sure that things are set up
-  ASSERT_TRUE(client.waitForServer(tf2::Duration(4.0)));
+  ASSERT_TRUE(client.waitForServer(tf2::durationFromSec(4.0)));
 
   tf2::Stamped<KDL::Vector> k1(KDL::Vector(0, 0, 0), builtin_interfaces::msg::Time(), "a");
 

--- a/test_tf2/test/test_message_filter.cpp
+++ b/test_tf2/test/test_message_filter.cpp
@@ -223,7 +223,7 @@ TEST(MessageFilter, multipleTargetFrames)
 
   EXPECT_EQ(0, n.count_); // frame1->frame3 exists, frame2->frame3 does not (yet)
 
-  //builtin_interfaces::msg::Time::setNow(builtin_interfaces::msg::Time::now() + tf2::Duration(1.0));
+  //builtin_interfaces::msg::Time::setNow(builtin_interfaces::msg::Time::now() + tf2::durationFromSec(1.0));
 
   bc.setTransform(createTransform(Quaternion(0,0,0,1), Vector3(1,2,3), stamp, "frame1", "frame2"), "me");
 
@@ -268,7 +268,7 @@ TEST(MessageFilter, outTheBackFailure)
 
   builtin_interfaces::msg::Time stamp(1);
   bc.setTransform(createTransform(Quaternion(0,0,0,1), Vector3(1,2,3), stamp, "frame1", "frame2"), "me");
-  bc.setTransform(createTransform(Quaternion(0,0,0,1), Vector3(1,2,3), stamp + tf2::Duration(10000), "frame1", "frame2"), "me");
+  bc.setTransform(createTransform(Quaternion(0,0,0,1), Vector3(1,2,3), stamp + tf2::durationFromSec(10000), "frame1", "frame2"), "me");
 
   geometry_msgs::PointStampedPtr msg(new geometry_msgs::PointStamped);
   msg->header.stamp = stamp;
@@ -295,7 +295,7 @@ TEST(MessageFilter, outTheBackFailure2)
   EXPECT_EQ(0, n.count_);
   EXPECT_EQ(0, n.failure_count_);
 
-  bc.setTransform(createTransform(Quaternion(0,0,0,1), Vector3(1,2,3), stamp + tf2::Duration(10000), "frame1", "frame2"), "me");
+  bc.setTransform(createTransform(Quaternion(0,0,0,1), Vector3(1,2,3), stamp + tf2::durationFromSec(10000), "frame1", "frame2"), "me");
 
   EXPECT_EQ(1, n.failure_count_);
 }

--- a/test_tf2/test/test_static_publisher.cpp
+++ b/test_tf2/test/test_static_publisher.cpp
@@ -40,18 +40,18 @@ TEST(StaticTransformPublisher, a_b_different_times)
 {
   tf2_ros::Buffer mB;
   tf2_ros::TransformListener tfl(mB);
-  EXPECT_TRUE(mB.canTransform("a", "b", builtin_interfaces::msg::Time(), tf2::Duration(1.0)));
-  EXPECT_TRUE(mB.canTransform("a", "b", builtin_interfaces::msg::Time(100), tf2::Duration(1.0)));
-  EXPECT_TRUE(mB.canTransform("a", "b", builtin_interfaces::msg::Time(1000), tf2::Duration(1.0)));
+  EXPECT_TRUE(mB.canTransform("a", "b", builtin_interfaces::msg::Time(), tf2::durationFromSec(1.0)));
+  EXPECT_TRUE(mB.canTransform("a", "b", builtin_interfaces::msg::Time(100), tf2::durationFromSec(1.0)));
+  EXPECT_TRUE(mB.canTransform("a", "b", builtin_interfaces::msg::Time(1000), tf2::durationFromSec(1.0)));
 };
 
 TEST(StaticTransformPublisher, a_c_different_times)
 {
   tf2_ros::Buffer mB;
   tf2_ros::TransformListener tfl(mB);
-  EXPECT_TRUE(mB.canTransform("a", "c", builtin_interfaces::msg::Time(), tf2::Duration(1.0)));
-  EXPECT_TRUE(mB.canTransform("a", "c", builtin_interfaces::msg::Time(100), tf2::Duration(1.0)));
-  EXPECT_TRUE(mB.canTransform("a", "c", builtin_interfaces::msg::Time(1000), tf2::Duration(1.0)));
+  EXPECT_TRUE(mB.canTransform("a", "c", builtin_interfaces::msg::Time(), tf2::durationFromSec(1.0)));
+  EXPECT_TRUE(mB.canTransform("a", "c", builtin_interfaces::msg::Time(100), tf2::durationFromSec(1.0)));
+  EXPECT_TRUE(mB.canTransform("a", "c", builtin_interfaces::msg::Time(1000), tf2::durationFromSec(1.0)));
 };
 
 TEST(StaticTransformPublisher, a_d_different_times)
@@ -65,18 +65,19 @@ TEST(StaticTransformPublisher, a_d_different_times)
   ts.child_frame_id = "d";
 
   // make sure listener has populated
-  EXPECT_TRUE(mB.canTransform("a", "c", builtin_interfaces::msg::Time(), tf2::Duration(1.0)));
-  EXPECT_TRUE(mB.canTransform("a", "c", builtin_interfaces::msg::Time(100), tf2::Duration(1.0)));
-  EXPECT_TRUE(mB.canTransform("a", "c", builtin_interfaces::msg::Time(1000), tf2::Duration(1.0)));
+  EXPECT_TRUE(mB.canTransform("a", "c", builtin_interfaces::msg::Time(), tf2::durationFromSec(1.0)));
+  EXPECT_TRUE(mB.canTransform("a", "c", builtin_interfaces::msg::Time(100), tf2::durationFromSec(1.0)));
+  EXPECT_TRUE(mB.canTransform("a", "c", builtin_interfaces::msg::Time(1000), tf2::durationFromSec(1.0)));
 
   mB.setTransform(ts, "authority");
   //printf("%s\n", mB.allFramesAsString().c_str());
-  EXPECT_TRUE(mB.canTransform("c", "d", builtin_interfaces::msg::Time(10), tf2::Duration(0)));
+  EXPECT_TRUE(mB.canTransform("c", "d", builtin_interfaces::msg::Time(10), tf2::durationFromSec(0)));
 
-  EXPECT_TRUE(mB.canTransform("a", "d", builtin_interfaces::msg::Time(), tf2::Duration(0)));
-  EXPECT_FALSE(mB.canTransform("a", "d", builtin_interfaces::msg::Time(1), tf2::Duration(0)));
-  EXPECT_TRUE(mB.canTransform("a", "d", builtin_interfaces::msg::Time(10), tf2::Duration(0)));
-  EXPECT_FALSE(mB.canTransform("a", "d", builtin_interfaces::msg::Time(100), tf2::Duration(0)));
+  EXPECT_TRUE(mB.canTransform("a", "d", builtin_interfaces::msg::Time(), tf2::durationFromSec(0)));
+  EXPECT_FALSE(mB.canTransform("a", "d", builtin_interfaces::msg::Time(1), tf2::durationFromSec(0)));
+  EXPECT_TRUE(mB.canTransform("a", "d", builtin_interfaces::msg::Time(10), tf2::durationFromSec(0)));
+  EXPECT_FALSE(mB.canTransform("a", "d", builtin_interfaces::msg::Time(100), tf2::durationFromSec(0)));
+
 };
 
 TEST(StaticTransformPublisher, multiple_parent_test)
@@ -93,9 +94,9 @@ TEST(StaticTransformPublisher, multiple_parent_test)
   stb.sendTransform(ts);
 
   // make sure listener has populated
-  EXPECT_TRUE(mB.canTransform("a", "d", builtin_interfaces::msg::Time(), tf2::Duration(1.0)));
-  EXPECT_TRUE(mB.canTransform("a", "d", builtin_interfaces::msg::Time(100), tf2::Duration(1.0)));
-  EXPECT_TRUE(mB.canTransform("a", "d", builtin_interfaces::msg::Time(1000), tf2::Duration(1.0)));
+  EXPECT_TRUE(mB.canTransform("a", "d", builtin_interfaces::msg::Time(), tf2::durationFromSec(1.0)));
+  EXPECT_TRUE(mB.canTransform("a", "d", builtin_interfaces::msg::Time(100), tf2::durationFromSec(1.0)));
+  EXPECT_TRUE(mB.canTransform("a", "d", builtin_interfaces::msg::Time(1000), tf2::durationFromSec(1.0)));
 
   // Publish new transform with child 'd', should replace old one in static tf
   ts.header.frame_id = "new_parent";
@@ -105,10 +106,10 @@ TEST(StaticTransformPublisher, multiple_parent_test)
   ts.child_frame_id = "other_child2";
   stb.sendTransform(ts);
 
-  EXPECT_TRUE(mB.canTransform("new_parent", "d", builtin_interfaces::msg::Time(), tf2::Duration(1.0)));
-  EXPECT_TRUE(mB.canTransform("new_parent", "other_child", builtin_interfaces::msg::Time(), tf2::Duration(1.0)));
-  EXPECT_TRUE(mB.canTransform("new_parent", "other_child2", builtin_interfaces::msg::Time(), tf2::Duration(1.0)));
-  EXPECT_FALSE(mB.canTransform("a", "d", builtin_interfaces::msg::Time(), tf2::Duration(1.0)));
+  EXPECT_TRUE(mB.canTransform("new_parent", "d", builtin_interfaces::msg::Time(), tf2::durationFromSec(1.0)));
+  EXPECT_TRUE(mB.canTransform("new_parent", "other_child", builtin_interfaces::msg::Time(), tf2::durationFromSec(1.0)));
+  EXPECT_TRUE(mB.canTransform("new_parent", "other_child2", builtin_interfaces::msg::Time(), tf2::durationFromSec(1.0)));
+  EXPECT_FALSE(mB.canTransform("a", "d", builtin_interfaces::msg::Time(), tf2::durationFromSec(1.0)));
 };
 
 TEST(StaticTransformPublisher, tf_from_param_server_valid)

--- a/test_tf2/test/test_tf2_bullet.cpp
+++ b/test_tf2/test/test_tf2_bullet.cpp
@@ -44,14 +44,14 @@ TEST(TfBullet, Transform)
   tf2::Stamped<btTransform> v1(btTransform(btQuaternion(1,0,0,0), btVector3(1,2,3)), builtin_interfaces::msg::Time(2.0), "A");
 
   // simple api
-  btTransform v_simple = tf_buffer->transform(v1, "B", tf2::Duration(2.0));
+  btTransform v_simple = tf_buffer->transform(v1, "B", tf2::durationFromSec(2.0));
   EXPECT_NEAR(v_simple.getOrigin().getX(), -9, EPS);
   EXPECT_NEAR(v_simple.getOrigin().getY(), 18, EPS);
   EXPECT_NEAR(v_simple.getOrigin().getZ(), 27, EPS);
 
   // advanced api
   btTransform v_advanced = tf_buffer->transform(v1, "B", builtin_interfaces::msg::Time(2.0),
-					       "B", tf2::Duration(3.0));
+					       "B", tf2::durationFromSec(3.0));
   EXPECT_NEAR(v_advanced.getOrigin().getX(), -9, EPS);
   EXPECT_NEAR(v_advanced.getOrigin().getY(), 18, EPS);
   EXPECT_NEAR(v_advanced.getOrigin().getZ(), 27, EPS);
@@ -64,14 +64,14 @@ TEST(TfBullet, Vector)
   tf2::Stamped<btVector3>  v1(btVector3(1,2,3), builtin_interfaces::msg::Time(2.0), "A");
 
   // simple api
-  btVector3 v_simple = tf_buffer->transform(v1, "B", tf2::Duration(2.0));
+  btVector3 v_simple = tf_buffer->transform(v1, "B", tf2::durationFromSec(2.0));
   EXPECT_NEAR(v_simple.getX(), -9, EPS);
   EXPECT_NEAR(v_simple.getY(), 18, EPS);
   EXPECT_NEAR(v_simple.getZ(), 27, EPS);
 
   // advanced api
   btVector3 v_advanced = tf_buffer->transform(v1, "B", builtin_interfaces::msg::Time(2.0),
-  					     "B", tf2::Duration(3.0));
+  					     "B", tf2::durationFromSec(3.0));
   EXPECT_NEAR(v_advanced.getX(), -9, EPS);
   EXPECT_NEAR(v_advanced.getY(), 18, EPS);
   EXPECT_NEAR(v_advanced.getZ(), 27, EPS);

--- a/tf2/include/tf2/time.h
+++ b/tf2/include/tf2/time.h
@@ -71,7 +71,13 @@ namespace tf2
   }
 
   inline double durationToSec(const tf2::Duration& input){
-    return (double)std::chrono::duration_cast<std::chrono::seconds>(input).count();
+    int count = input.count();
+    long int sec;
+    int64_t nsec;
+    nsec = count % 1000000000ul;
+    sec = (count - nsec) / 1000000000ul;
+    double nsec_double = 1e-9 * (double)nsec;
+    return (double)sec + nsec_double;
   }
 
   inline double timeToSec(const TimePoint& timepoint)

--- a/tf2/include/tf2/time.h
+++ b/tf2/include/tf2/time.h
@@ -35,6 +35,7 @@
 #include <stdio.h>
 #include <string>
 #include <thread>
+#include <iostream>
 
 #include <tf2/visibility_control.h>
 
@@ -61,8 +62,7 @@ namespace tf2
     // avoid rounding errors
     sec += (nsec / 1000000000ul);
     nsec %= 1000000000ul;
-    Duration d = std::chrono::seconds(sec) + std::chrono::nanoseconds(nsec);
-    return d;
+    return std::chrono::seconds(sec) + std::chrono::nanoseconds(nsec);
   }
 
   inline TimePoint timeFromSec(double t_sec)
@@ -71,13 +71,18 @@ namespace tf2
   }
 
   inline double durationToSec(const tf2::Duration& input){
-    int count = input.count();
-    long int sec;
-    int64_t nsec;
+    int64_t count = input.count();
+    int32_t sec;
+    uint32_t nsec;
     nsec = count % 1000000000ul;
     sec = (count - nsec) / 1000000000ul;
     double nsec_double = 1e-9 * (double)nsec;
-    return (double)sec + nsec_double;
+    double sec_double = (double)sec;
+    fprintf(stdout, "sec_double: %0.16f\n", sec_double);
+    fprintf(stdout, "nsec_double: %0.16f\n", nsec_double);
+    double d = sec_double + nsec_double;
+    fprintf(stdout, "Returning double of: %0.16f\n", d);
+    return d;
   }
 
   inline double timeToSec(const TimePoint& timepoint)

--- a/tf2/include/tf2/time.h
+++ b/tf2/include/tf2/time.h
@@ -58,7 +58,7 @@ namespace tf2
   {
     int32_t sec, nsec;
     sec = static_cast<int32_t>(floor(t_sec));
-    nsec = static_cast<int32_t>(std::nearbyint((t_sec-sec) * 1e9));
+    nsec = static_cast<int32_t>(std::round((t_sec - sec) * 1e9));
     // avoid rounding errors
     sec += (nsec / 1000000000l);
     nsec %= 1000000000l;

--- a/tf2/include/tf2/time.h
+++ b/tf2/include/tf2/time.h
@@ -57,8 +57,8 @@ namespace tf2
   inline Duration durationFromSec(double t_sec)
   {
     int32_t sec, nsec;
-    sec = (int32_t)floor(t_sec);
-    nsec = (int32_t)std::nearbyint((t_sec-sec) * 1e9);
+    sec = static_cast<int32_t>(floor(t_sec));
+    nsec = static_cast<int32_t>(std::nearbyint((t_sec-sec) * 1e9));
     // avoid rounding errors
     sec += (nsec / 1000000000l);
     nsec %= 1000000000l;
@@ -73,12 +73,12 @@ namespace tf2
   inline double durationToSec(const tf2::Duration& input){
     int64_t count = input.count();
     int32_t sec, nsec;
-    nsec = (int32_t)(count % 1000000000l);
-    sec = (int32_t)((count - nsec) / 1000000000l);
+    nsec = static_cast<int32_t>(count % 1000000000l);
+    sec = static_cast<int32_t>((count - nsec) / 1000000000l);
 
     double sec_double, nsec_double;
-    nsec_double = 1e-9 * (double)nsec;
-    sec_double = (double)sec;
+    nsec_double = 1e-9 * static_cast<double>(nsec);
+    sec_double = static_cast<double>(sec);
     return sec_double + nsec_double;
   }
 

--- a/tf2/include/tf2/time.h
+++ b/tf2/include/tf2/time.h
@@ -53,11 +53,11 @@ namespace tf2
     return std::chrono::system_clock::now();
   }
 
-  inline Duration durationFromSec(double t)
+  inline Duration durationFromSec(double t_sec)
   {
     uint32_t sec, nsec;
-    sec = (uint32_t)floor(t);
-    nsec = (uint32_t)std::round((t-sec) * 1e9);
+    sec = (uint32_t)floor(t_sec);
+    nsec = (uint32_t)std::round((t_sec-sec) * 1e9);
     // avoid rounding errors
     sec += (nsec / 1000000000ul);
     nsec %= 1000000000ul;
@@ -65,12 +65,12 @@ namespace tf2
     return d;
   }
 
-  inline TimePoint timeFromSec(double t)
+  inline TimePoint timeFromSec(double t_sec)
   {
-    return tf2::TimePoint(durationFromSec(t));
+    return tf2::TimePoint(durationFromSec(t_sec));
   }
 
-  inline double durationToSec(const tf2::Duration & input){
+  inline double durationToSec(const tf2::Duration& input){
     return (double)std::chrono::duration_cast<std::chrono::seconds>(input).count();
   }
 

--- a/tf2/include/tf2/time.h
+++ b/tf2/include/tf2/time.h
@@ -67,7 +67,7 @@ namespace tf2
 
   inline TimePoint timeFromSec(double t)
   {
-    return get_now() + durationFromSec(t);
+    return tf2::TimePoint(durationFromSec(t));
   }
 
   inline double durationToSec(const tf2::Duration & input){

--- a/tf2/include/tf2/time.h
+++ b/tf2/include/tf2/time.h
@@ -31,6 +31,7 @@
  #define TF2_TIME_H
 
 #include <chrono>
+#include <cmath>
 #include <stdio.h>
 #include <string>
 #include <thread>
@@ -50,6 +51,23 @@ namespace tf2
   inline TimePoint get_now()
   {
     return std::chrono::system_clock::now();
+  }
+
+  inline Duration durationFromSec(double t)
+  {
+    uint32_t sec, nsec;
+    sec = (uint32_t)floor(t);
+    nsec = (uint32_t)std::round((t-sec) * 1e9);
+    // avoid rounding errors
+    sec += (nsec / 1000000000ul);
+    nsec %= 1000000000ul;
+    Duration d = std::chrono::seconds(sec) + std::chrono::nanoseconds(nsec);
+    return d;
+  }
+
+  inline TimePoint timeFromSec(double t)
+  {
+    return get_now() + durationFromSec(t);
   }
 
   inline double durationToSec(const tf2::Duration & input){

--- a/tf2/include/tf2/time.h
+++ b/tf2/include/tf2/time.h
@@ -40,7 +40,7 @@
 
 namespace tf2
 {
-  using Duration = std::chrono::duration<double, std::nano>;
+  using Duration = std::chrono::nanoseconds;
   using TimePoint = std::chrono::time_point<std::chrono::system_clock, Duration>;
 
 

--- a/tf2/include/tf2/time.h
+++ b/tf2/include/tf2/time.h
@@ -73,8 +73,8 @@ namespace tf2
   inline double durationToSec(const tf2::Duration& input){
     int64_t count = input.count();
     int32_t sec, nsec;
-    nsec = count % 1000000000l;
-    sec = (count - nsec) / 1000000000l;
+    nsec = (int32_t)(count % 1000000000l);
+    sec = (int32_t)((count - nsec) / 1000000000l);
 
     double sec_double, nsec_double;
     nsec_double = 1e-9 * (double)nsec;

--- a/tf2/include/tf2/time.h
+++ b/tf2/include/tf2/time.h
@@ -40,7 +40,7 @@
 namespace tf2
 {
   using Duration = std::chrono::duration<double, std::nano>;
-  using TimePoint = std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>;
+  using TimePoint = std::chrono::time_point<std::chrono::system_clock, Duration>;
 
 
   using IDuration = std::chrono::duration<int, std::nano>;

--- a/tf2/include/tf2/time.h
+++ b/tf2/include/tf2/time.h
@@ -56,12 +56,12 @@ namespace tf2
 
   inline Duration durationFromSec(double t_sec)
   {
-    uint32_t sec, nsec;
-    sec = (uint32_t)floor(t_sec);
-    nsec = (uint32_t)std::round((t_sec-sec) * 1e9);
+    int32_t sec, nsec;
+    sec = (int32_t)floor(t_sec);
+    nsec = (int32_t)std::nearbyint((t_sec-sec) * 1e9);
     // avoid rounding errors
-    sec += (nsec / 1000000000ul);
-    nsec %= 1000000000ul;
+    sec += (nsec / 1000000000l);
+    nsec %= 1000000000l;
     return std::chrono::seconds(sec) + std::chrono::nanoseconds(nsec);
   }
 
@@ -72,17 +72,14 @@ namespace tf2
 
   inline double durationToSec(const tf2::Duration& input){
     int64_t count = input.count();
-    int32_t sec;
-    uint32_t nsec;
-    nsec = count % 1000000000ul;
-    sec = (count - nsec) / 1000000000ul;
-    double nsec_double = 1e-9 * (double)nsec;
-    double sec_double = (double)sec;
-    fprintf(stdout, "sec_double: %0.16f\n", sec_double);
-    fprintf(stdout, "nsec_double: %0.16f\n", nsec_double);
-    double d = sec_double + nsec_double;
-    fprintf(stdout, "Returning double of: %0.16f\n", d);
-    return d;
+    int32_t sec, nsec;
+    nsec = count % 1000000000l;
+    sec = (count - nsec) / 1000000000l;
+
+    double sec_double, nsec_double;
+    nsec_double = 1e-9 * (double)nsec;
+    sec_double = (double)sec;
+    return sec_double + nsec_double;
   }
 
   inline double timeToSec(const TimePoint& timepoint)

--- a/tf2/test/simple_tf2_core.cpp
+++ b/tf2/test/simple_tf2_core.cpp
@@ -158,15 +158,24 @@ TEST(tf2_time, Display_Time_Point)
 
 TEST(tf2_time, To_From_Sec)
 {
-  tf2::TimePoint t = tf2::get_now();
-  std::cout << t.time_since_epoch().count() << std::endl;
-  std::cout << "t: " << tf2::displayTimePoint(t) << std::endl;
-  tf2::TimePoint t2 = tf2::timeFromSec(tf2::timeToSec(t));
-  std::cout << "t2: " << tf2::displayTimePoint(t2) << std::endl;
-  std::cout << t2.time_since_epoch().count() << std::endl;
-  auto diff = tf2::timeFromSec(tf2::timeToSec(t)) - t;
-  EXPECT_EQ(t, t2);
-  //EXPECT_TRUE(tf2::durationToSec(diff) == 0);
+  // Exact representation of a time.
+  tf2::TimePoint t1 = tf2::get_now();
+
+  // Approximate representation of the time in seconds as a double (floating point error introduced).
+  double t1_sec = tf2::timeToSec(t1);
+
+  // Time point from the t1_sec approximation.
+  tf2::TimePoint t2 = tf2::timeFromSec(t1_sec);
+
+  // Check that the difference due to t1_sec being approximate is small.
+  tf2::Duration diff = t2 > t1 ? t2 - t1 : t1 - t2;
+  std::cout << "Difference (ns): " << diff.count() << std::endl;
+  EXPECT_TRUE(diff < tf2::Duration(std::chrono::nanoseconds(200)));
+
+  // No new floating point errors are expected after converting to and from time points.
+  double t2_sec = tf2::timeToSec(t2);
+  EXPECT_EQ(t1_sec, t2_sec);
+  EXPECT_EQ(tf2::timeFromSec(t1_sec), tf2::timeFromSec(t2_sec));
 }
 
 

--- a/tf2/test/simple_tf2_core.cpp
+++ b/tf2/test/simple_tf2_core.cpp
@@ -159,8 +159,14 @@ TEST(tf2_time, Display_Time_Point)
 TEST(tf2_time, To_From_Sec)
 {
   tf2::TimePoint t = tf2::get_now();
+  std::cout << t.time_since_epoch().count() << std::endl;
+  std::cout << "t: " << tf2::displayTimePoint(t) << std::endl;
   tf2::TimePoint t2 = tf2::timeFromSec(tf2::timeToSec(t));
+  std::cout << "t2: " << tf2::displayTimePoint(t2) << std::endl;
+  std::cout << t2.time_since_epoch().count() << std::endl;
+  auto diff = tf2::timeFromSec(tf2::timeToSec(t)) - t;
   EXPECT_EQ(t, t2);
+  //EXPECT_TRUE(tf2::durationToSec(diff) == 0);
 }
 
 

--- a/tf2/test/simple_tf2_core.cpp
+++ b/tf2/test/simple_tf2_core.cpp
@@ -169,7 +169,6 @@ TEST(tf2_time, To_From_Sec)
 
   // Check that the difference due to t1_sec being approximate is small.
   tf2::Duration diff = t2 > t1 ? t2 - t1 : t1 - t2;
-  std::cout << "Difference (ns): " << diff.count() << std::endl;
   EXPECT_TRUE(diff < tf2::Duration(std::chrono::nanoseconds(200)));
 
   // No new floating point errors are expected after converting to and from time points.
@@ -208,7 +207,8 @@ TEST(tf2_time, To_From_Duration)
     // Get the absolute difference between Durations.
     error_duration = error_duration > tf2::Duration(0) ? error_duration : -error_duration;
     // Increased tolerance for larger differences.
-    int32_t tol_ns = std::abs(expected_diff_sec) > 100000 ? 5 : 1;
+    int32_t tol_ns = std::abs(expected_diff_sec) > 100000 ? 10 : 1;
+
     EXPECT_TRUE(error_duration < tf2::Duration(std::chrono::nanoseconds(tol_ns)));
   }
 }

--- a/tf2/test/simple_tf2_core.cpp
+++ b/tf2/test/simple_tf2_core.cpp
@@ -156,6 +156,13 @@ TEST(tf2_time, Display_Time_Point)
   std::string s = tf2::displayTimePoint(t);
 }
 
+TEST(tf2_time, To_From_Sec)
+{
+  tf2::TimePoint t = tf2::get_now();
+  tf2::TimePoint t2 = tf2::timeFromSec(tf2::timeToSec(t));
+  EXPECT_EQ(t, t2);
+}
+
 
 int main(int argc, char **argv){
   testing::InitGoogleTest(&argc, argv);

--- a/tf2/test/simple_tf2_core.cpp
+++ b/tf2/test/simple_tf2_core.cpp
@@ -178,6 +178,32 @@ TEST(tf2_time, To_From_Sec)
   EXPECT_EQ(tf2::timeFromSec(t1_sec), tf2::timeFromSec(t2_sec));
 }
 
+TEST(tf2_time, Negative_Durations)
+{
+  tf2::TimePoint t1 = tf2::get_now();
+  // Create a time in the past.
+  double expected_diff_sec = -0.7;
+  tf2::TimePoint t2 = tf2::timeFromSec(tf2::timeToSec(t1) + expected_diff_sec);
+
+  // Check durationToSec.
+  // Create a negative duration.
+  tf2::Duration duration = t2 - t1;
+  EXPECT_TRUE(duration.count() < 0);
+  std::cout << "Difference (ns): " << duration.count() << std::endl;
+  std::cout << "Difference (s): " << tf2::durationToSec(duration) << std::endl;
+
+  double error_sec = tf2::durationToSec(duration) - expected_diff_sec;
+  EXPECT_TRUE(std::abs(error_sec) < 0.001);
+
+  // Check durationFromSec.
+  tf2::Duration duration2 = tf2::durationFromSec(tf2::durationToSec(duration));
+  tf2::Duration error_duration = duration - duration2;
+  // Get the absolute difference between Durations.
+  error_duration = error_duration > tf2::Duration(0) ? error_duration : -error_duration;
+  std::cout << "Error (ns): " << error_duration.count() << std::endl;
+  EXPECT_TRUE(error_duration < tf2::Duration(std::chrono::nanoseconds(1)));
+}
+
 
 int main(int argc, char **argv){
   testing::InitGoogleTest(&argc, argv);

--- a/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
+++ b/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
@@ -52,7 +52,7 @@ TEST(TfGeometry, Frame)
   v1.header.frame_id = "A";
 
   // simple api
-  geometry_msgs::msg::PoseStamped v_simple = tf_buffer->transform(v1, "B", tf2::Duration(2.0));
+  geometry_msgs::msg::PoseStamped v_simple = tf_buffer->transform(v1, "B", tf2::durationFromSec(2.0));
   EXPECT_NEAR(v_simple.pose.position.x, -9, EPS);
   EXPECT_NEAR(v_simple.pose.position.y, 18, EPS);
   EXPECT_NEAR(v_simple.pose.position.z, 27, EPS);
@@ -64,7 +64,7 @@ TEST(TfGeometry, Frame)
 
   // advanced api
   geometry_msgs::msg::PoseStamped v_advanced = tf_buffer->transform(v1, "B", builtin_interfaces::msg::Time(2.0),
-							      "A", tf2::Duration(3.0));
+							      "A", tf2::durationFromSec(3.0));
   EXPECT_NEAR(v_advanced.pose.position.x, -9, EPS);
   EXPECT_NEAR(v_advanced.pose.position.y, 18, EPS);
   EXPECT_NEAR(v_advanced.pose.position.z, 27, EPS);
@@ -86,14 +86,14 @@ TEST(TfGeometry, Vector)
   v1.header.frame_id = "A";
 
   // simple api
-  geometry_msgs::msg::Vector3Stamped v_simple = tf_buffer->transform(v1, "B", tf2::Duration(2.0));
+  geometry_msgs::msg::Vector3Stamped v_simple = tf_buffer->transform(v1, "B", tf2::durationFromSec(2.0));
   EXPECT_NEAR(v_simple.vector.x, 1, EPS);
   EXPECT_NEAR(v_simple.vector.y, -2, EPS);
   EXPECT_NEAR(v_simple.vector.z, -3, EPS);
 
   // advanced api
   geometry_msgs::msg::Vector3Stamped v_advanced = tf_buffer->transform(v1, "B", builtin_interfaces::msg::Time(2.0),
-								 "A", tf2::Duration(3.0));
+								 "A", tf2::durationFromSec(3.0));
   EXPECT_NEAR(v_advanced.vector.x, 1, EPS);
   EXPECT_NEAR(v_advanced.vector.y, -2, EPS);
   EXPECT_NEAR(v_advanced.vector.z, -3, EPS);
@@ -110,14 +110,14 @@ TEST(TfGeometry, Point)
   v1.header.frame_id = "A";
 
   // simple api
-  geometry_msgs::msg::PointStamped v_simple = tf_buffer->transform(v1, "B", tf2::Duration(2.0));
+  geometry_msgs::msg::PointStamped v_simple = tf_buffer->transform(v1, "B", tf2::durationFromSec(2.0));
   EXPECT_NEAR(v_simple.point.x, -9, EPS);
   EXPECT_NEAR(v_simple.point.y, 18, EPS);
   EXPECT_NEAR(v_simple.point.z, 27, EPS);
 
   // advanced api
   geometry_msgs::msg::PointStamped v_advanced = tf_buffer->transform(v1, "B", builtin_interfaces::msg::Time(2.0),
-								 "A", tf2::Duration(3.0));
+								 "A", tf2::durationFromSec(3.0));
   EXPECT_NEAR(v_advanced.point.x, -9, EPS);
   EXPECT_NEAR(v_advanced.point.y, 18, EPS);
   EXPECT_NEAR(v_advanced.point.z, 27, EPS);

--- a/tf2_kdl/test/test_tf2_kdl.cpp
+++ b/tf2_kdl/test/test_tf2_kdl.cpp
@@ -45,7 +45,7 @@ TEST(TfKDL, Frame)
 
 
   // simple api
-  KDL::Frame v_simple = tf_buffer->transform(v1, "B", tf2::Duration(2.0));
+  KDL::Frame v_simple = tf_buffer->transform(v1, "B", tf2::durationFromSec(2.0));
   EXPECT_NEAR(v_simple.p[0], -9, EPS);
   EXPECT_NEAR(v_simple.p[1], 18, EPS);
   EXPECT_NEAR(v_simple.p[2], 27, EPS);
@@ -58,7 +58,7 @@ TEST(TfKDL, Frame)
 
   // advanced api
   KDL::Frame v_advanced = tf_buffer->transform(v1, "B", builtin_interfaces::msg::Time(2.0),
-					       "A", tf2::Duration(3.0));
+					       "A", tf2::durationFromSec(3.0));
   EXPECT_NEAR(v_advanced.p[0], -9, EPS);
   EXPECT_NEAR(v_advanced.p[1], 18, EPS);
   EXPECT_NEAR(v_advanced.p[2], 27, EPS);
@@ -77,14 +77,14 @@ TEST(TfKDL, Vector)
 
 
   // simple api
-  KDL::Vector v_simple = tf_buffer->transform(v1, "B", tf2::Duration(2.0));
+  KDL::Vector v_simple = tf_buffer->transform(v1, "B", tf2::durationFromSec(2.0));
   EXPECT_NEAR(v_simple[0], -9, EPS);
   EXPECT_NEAR(v_simple[1], 18, EPS);
   EXPECT_NEAR(v_simple[2], 27, EPS);
 
   // advanced api
   KDL::Vector v_advanced = tf_buffer->transform(v1, "B", builtin_interfaces::msg::Time(2.0),
-					       "A", tf2::Duration(3.0));
+					       "A", tf2::durationFromSec(3.0));
   EXPECT_NEAR(v_advanced[0], -9, EPS);
   EXPECT_NEAR(v_advanced[1], 18, EPS);
   EXPECT_NEAR(v_advanced[2], 27, EPS);

--- a/tf2_ros/include/tf2_ros/buffer_client.h
+++ b/tf2_ros/include/tf2_ros/buffer_client.h
@@ -61,7 +61,7 @@ namespace tf2_ros
        * \param timeout_padding The amount of time to allow passed the desired timeout on the client side for communication lag
        */
       TF2_ROS_PUBLIC
-      BufferClient(std::string ns, double check_frequency = 10.0, tf2::Duration timeout_padding = tf2::Duration(2.0));
+      BufferClient(std::string ns, double check_frequency = 10.0, tf2::Duration timeout_padding = tf2::durationFromSec(2.0));
 
       /** \brief Get the transform between two frames by frame ID.
        * \param target_frame The frame to which data should be transformed

--- a/tf2_ros/include/tf2_ros/buffer_client.h
+++ b/tf2_ros/include/tf2_ros/buffer_client.h
@@ -76,7 +76,7 @@ namespace tf2_ros
       TF2_ROS_PUBLIC
       virtual geometry_msgs::TransformStamped
         lookupTransform(const std::string& target_frame, const std::string& source_frame,
-            const tf2::TimePoint& time, const tf2::Duration timeout = tf2::Duration(0.0)) const;
+            const tf2::TimePoint& time, const tf2::Duration timeout = tf2::durationFromSec(0.0)) const;
 
       /** \brief Get the transform between two frames by frame ID assuming fixed frame.
        * \param target_frame The frame to which data should be transformed
@@ -94,7 +94,7 @@ namespace tf2_ros
       virtual geometry_msgs::TransformStamped 
         lookupTransform(const std::string& target_frame, const tf2::TimePoint& target_time,
             const std::string& source_frame, const tf2::TimePoint& source_time,
-            const std::string& fixed_frame, const tf2::Duration timeout = tf2::Duration(0.0)) const;
+            const std::string& fixed_frame, const tf2::Duration timeout = tf2::durationFromSec(0.0)) const;
 
       /** \brief Test if a transform is possible
        * \param target_frame The frame into which to transform
@@ -107,7 +107,7 @@ namespace tf2_ros
       TF2_ROS_PUBLIC
       virtual bool
         canTransform(const std::string& target_frame, const std::string& source_frame, 
-            const tf2::TimePoint& time, const tf2::Duration timeout = tf2::Duration(0.0), std::string* errstr = NULL) const;
+            const tf2::TimePoint& time, const tf2::Duration timeout = tf2::durationFromSec(0.0), std::string* errstr = NULL) const;
 
       /** \brief Test if a transform is possible
        * \param target_frame The frame into which to transform
@@ -123,14 +123,14 @@ namespace tf2_ros
       virtual bool
         canTransform(const std::string& target_frame, const tf2::TimePoint& target_time,
             const std::string& source_frame, const tf2::TimePoint& source_time,
-            const std::string& fixed_frame, const tf2::Duration timeout = tf2::Duration(0.0), std::string* errstr = NULL) const;
+            const std::string& fixed_frame, const tf2::Duration timeout = tf2::durationFromSec(0.0), std::string* errstr = NULL) const;
 
       /** \brief Block until the action server is ready to respond to requests.
        * \param timeout Time to wait for the server.
        * \return True if the server is ready, false otherwise.
        */
       TF2_ROS_PUBLIC
-      bool waitForServer(const tf2::Duration& timeout = tf2::Duration(0))
+      bool waitForServer(const tf2::Duration& timeout = tf2::durationFromSec(0))
       {
         return client_.waitForServer(timeout);
       }

--- a/tf2_ros/include/tf2_ros/buffer_interface.h
+++ b/tf2_ros/include/tf2_ros/buffer_interface.h
@@ -58,7 +58,8 @@ namespace tf2_ros
   inline tf2::TimePoint fromMsg(const builtin_interfaces::msg::Time & time_msg)
   {
     int64_t d = time_msg.sec * 1000000000ull + time_msg.nanosec;
-    return tf2::TimePoint(std::chrono::nanoseconds(d));
+    std::chrono::nanoseconds ns(d);
+    return tf2::TimePoint(std::chrono::duration_cast<tf2::Duration>(ns));
   }
 
   inline double timeToSec(const builtin_interfaces::msg::Time & time_msg)

--- a/tf2_ros/include/tf2_ros/buffer_server.h
+++ b/tf2_ros/include/tf2_ros/buffer_server.h
@@ -69,7 +69,7 @@ namespace tf2_ros
        * \param check_period How often to check for changes to known transforms (via a timer event).
        */
       BufferServer(const Buffer& buffer, const std::string& ns,
-          bool auto_start = true, tf2::Duration check_period = tf2::Duration(0.01));
+          bool auto_start = true, tf2::Duration check_period = tf2::durationFromSec(0.01));
 
       /** \brief Start the action server.
        */

--- a/tf2_ros/include/tf2_ros/message_filter.h
+++ b/tf2_ros/include/tf2_ros/message_filter.h
@@ -454,7 +454,7 @@ private:
     transform_message_count_ = 0;
     incoming_message_count_ = 0;
     dropped_message_count_ = 0;
-    time_tolerance_ = tf2::Duration(0.0);
+    time_tolerance_ = tf2::durationFromSec(0.0);
     warned_about_empty_frame_id_ = false;
     expected_success_count_ = 1;
 

--- a/tf2_ros/src/buffer.cpp
+++ b/tf2_ros/src/buffer.cpp
@@ -136,11 +136,11 @@ Buffer::canTransform(const std::string& target_frame, const std::string& source_
   tf2::TimePoint start_time = now_fallback_to_wall();
   while (now_fallback_to_wall() < start_time + timeout && 
          !canTransform(target_frame, source_frame, time) &&
-         (now_fallback_to_wall()+tf2::Duration(3.0) >= start_time) &&  //don't wait when we detect a bag loop
+         (now_fallback_to_wall()+tf2::durationFromSec(3.0) >= start_time) &&  //don't wait when we detect a bag loop
          (rclcpp::ok()// || !ros::isInitialized() //TODO(tfoote) restore
        )) // Make sure we haven't been stopped (won't work for pytf)
     {
-      sleep_fallback_to_wall(tf2::Duration(0.01));
+      sleep_fallback_to_wall(tf2::durationFromSec(0.01));
     }
   bool retval = canTransform(target_frame, source_frame, time, errstr);
   conditionally_append_timeout_info(errstr, start_time, timeout);
@@ -160,12 +160,12 @@ Buffer::canTransform(const std::string& target_frame, const tf2::TimePoint& targ
   tf2::TimePoint start_time = now_fallback_to_wall();
   while (now_fallback_to_wall() < start_time + timeout && 
          !canTransform(target_frame, target_time, source_frame, source_time, fixed_frame) &&
-         (now_fallback_to_wall()+tf2::Duration(3.0) >= start_time) &&  //don't wait when we detect a bag loop
+         (now_fallback_to_wall()+tf2::durationFromSec(3.0) >= start_time) &&  //don't wait when we detect a bag loop
          (rclcpp::ok() //|| !ros::isInitialized() //TODO(tfoote) restore
           )
         ) // Make sure we haven't been stopped (won't work for pytf)
          {  
-           sleep_fallback_to_wall(tf2::Duration(0.01));
+           sleep_fallback_to_wall(tf2::durationFromSec(0.01));
          }
   bool retval = canTransform(target_frame, target_time, source_frame, source_time, fixed_frame, errstr);
   conditionally_append_timeout_info(errstr, start_time, timeout);

--- a/tf2_ros/src/buffer_server_main.cpp
+++ b/tf2_ros/src/buffer_server_main.cpp
@@ -61,7 +61,7 @@ int main(int argc, char** argv)
   nh.param("buffer_size", buffer_size, 120.0);
 
   // WIM: this works fine:
-  tf2_ros::Buffer buffer_core(tf2::Duration(buffer_size+0)); // WTF??
+  tf2_ros::Buffer buffer_core(tf2::durationFromSec(buffer_size+0)); // WTF??
   tf2_ros::TransformListener listener(buffer_core);
   tf2_ros::BufferServer buffer_server(buffer_core, "tf2_buffer_server", false);
   buffer_server.start();

--- a/tf2_ros/src/tf2_echo.cpp
+++ b/tf2_ros/src/tf2_echo.cpp
@@ -102,7 +102,7 @@ int main(int argc, char ** argv)
   std::string target_frameid = std::string(argv[2]);
 
   // Wait for up to one second for the first transforms to become avaiable. 
-  echoListener.buffer_.canTransform(source_frameid, target_frameid, tf2::TimePoint(), tf2::Duration(1.0));
+  echoListener.buffer_.canTransform(source_frameid, target_frameid, tf2::TimePoint(), tf2::durationFromSec(1.0));
 
   //Nothing needs to be done except wait for a quit
   //The callbacks withing the listener class

--- a/tf2_ros/src/tf2_monitor.cpp
+++ b/tf2_ros/src/tf2_monitor.cpp
@@ -134,7 +134,7 @@ public:
     if (using_specific_chain_)
     {
       std::cout << "Waiting for transform chain to become available between "<< framea_ << " and " << frameb_<< " " << std::flush;
-      while (rclcpp::ok() && !buffer_.canTransform(framea_, frameb_, tf2::TimePointZero, tf2::Duration(1.0e9)))
+      while (rclcpp::ok() && !buffer_.canTransform(framea_, frameb_, tf2::TimePointZero, tf2::durationFromSec(1.0)))
         std::cout << "." << std::flush;
       std::cout << std::endl;
      

--- a/tf2_sensor_msgs/test/test_tf2_sensor_msgs.cpp
+++ b/tf2_sensor_msgs/test/test_tf2_sensor_msgs.cpp
@@ -58,7 +58,7 @@ TEST(Tf2Sensor, PointCloud2)
   cloud.header.frame_id = "A";
 
   // simple api
-  sensor_msgs::PointCloud2 cloud_simple = tf_buffer->transform(cloud, "B", tf2::Duration(2.0));
+  sensor_msgs::PointCloud2 cloud_simple = tf_buffer->transform(cloud, "B", tf2::durationFromSec(2.0));
   sensor_msgs::PointCloud2Iterator<float> iter_x_after(cloud_simple, "x");
   sensor_msgs::PointCloud2Iterator<float> iter_y_after(cloud_simple, "y");
   sensor_msgs::PointCloud2Iterator<float> iter_z_after(cloud_simple, "z");
@@ -68,7 +68,7 @@ TEST(Tf2Sensor, PointCloud2)
 
   // advanced api
   sensor_msgs::PointCloud2 cloud_advanced = tf_buffer->transform(cloud, "B", builtin_interfaces::msg::Time(2.0),
-                                                                 "A", tf2::Duration(3.0));
+                                                                 "A", tf2::durationFromSec(3.0));
   sensor_msgs::PointCloud2Iterator<float> iter_x_advanced(cloud_advanced, "x");
   sensor_msgs::PointCloud2Iterator<float> iter_y_advanced(cloud_advanced, "y");
   sensor_msgs::PointCloud2Iterator<float> iter_z_advanced(cloud_advanced, "z");


### PR DESCRIPTION
connects to ros2/navigation#5

I wanted to use tf2::timeFromSec and tf2::durationFromSec but they weren't implemented, so I added them in https://github.com/ros2/geometry2/commit/c7bac5b4d838e7de5900b3da200f256effbc615c (the code is copied [from this ros1 code](https://github.com/ros/roscpp_core/blob/057f7fa5c36df67757c6cb91c319faa67cefd6e6/rostime/include/ros/time.h#L153..L158))

In order to do implement those, (in particular [this line](https://github.com/ros2/geometry2/commit/c7bac5b4d838e7de5900b3da200f256effbc615c#diff-0ef30af0e2721678e4eb9da85f795979R70)) I made [this change to use `tf2::Duration` underneath `tf2::TimePoint`](https://github.com/ros2/geometry2/commit/958138e2fe11802c8771a580587a5b5c93adf3e4#diff-0ef30af0e2721678e4eb9da85f795979R43), so `double`s are used everywhere and not `long int`s from `std::chrono::nanoseconds` (thank you @Karsten1987 !!)

In doing this I noticed that with the exception of a few places (e.g. https://github.com/ros2/geometry2/commit/db4574a6564946a025630fc7cec49d2834cc689b#diff-473dd6a6d7f5086c80694ac302fd9f8eL137), we are accidentally initialising nanosecond durations instead of seconds. @clalancette idk if this is the underlying source of any of your TF issues.

There is still a question about why `double` is being used underneath `tf2::Duration` instead of the more standard `std::chrono::nanoseconds`. I think it was for 'nice' constructors e.g. `tf2::Duration(1.5)`, but that seems to have just led to mistakenly thinking it represented seconds. We could switch it or make a constructor that takes seconds.