### PR TITLE
Make the failure test more like the old one.

### DIFF
--- a/tf2/test/simple_tf2_core.cpp
+++ b/tf2/test/simple_tf2_core.cpp
@@ -38,18 +38,18 @@ TEST(tf2, setTransformFail)
 {
   tf2::BufferCore tfc;
   geometry_msgs::msg::TransformStamped st;
-  st.header.frame_id = "foo";
+  st.header.frame_id = "";
   st.header.stamp = builtin_interfaces::msg::Time();
   st.header.stamp.sec = 1;
   st.header.stamp.nanosec = 1;
-  st.child_frame_id = "foo";
+  st.child_frame_id = "";
   st.transform.translation.x = 0;
   st.transform.translation.y = 0;
   st.transform.translation.z = 0;
   st.transform.rotation.x = 0;
   st.transform.rotation.y = 0;
   st.transform.rotation.z = 0;
-  st.transform.rotation.w = 1;
+  st.transform.rotation.w = 0;
   EXPECT_FALSE(tfc.setTransform(st, "authority1"));
   
 }


### PR DESCRIPTION
While we fixed the earlier errors, we changed the nature of
what the test was testing.  This change makes it so that
we are testing the same code paths as previously.

Signed-off-by: Chris Lalancette <clalancette@osrfoundation.org>