### PR TITLE
Reenable tf2 geometry msgs tests

### DIFF
--- a/tf2_geometry_msgs/CMakeLists.txt
+++ b/tf2_geometry_msgs/CMakeLists.txt
@@ -27,21 +27,18 @@ link_directories(${orocos_kdl_LIBRARY_DIRS})
 # TODO(dhood): enable python support once ported to ROS 2
 # catkin_python_setup()
 
-# TODO(dhood): enable tests once ported to ROS 2
-# if(CATKIN_ENABLE_TESTING)
-#
-# find_package(catkin REQUIRED COMPONENTS geometry_msgs rostest tf2_ros tf2)
-#
-# add_executable(test_geometry_msgs EXCLUDE_FROM_ALL test/test_tf2_geometry_msgs.cpp)
-# target_link_libraries(test_geometry_msgs ${catkin_LIBRARIES} ${GTEST_LIBRARIES} ${orocos_kdl_LIBRARIES})
-# add_rostest(${CMAKE_CURRENT_SOURCE_DIR}/test/test.launch)
-# add_rostest(${CMAKE_CURRENT_SOURCE_DIR}/test/test_python.launch)
-#
-#
-# if(TARGET tests)
-#   add_dependencies(tests test_geometry_msgs)
-# endif()
-#
-#
-# endif()
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_tf2_geometry_msgs test/test_tf2_geometry_msgs.cpp)
+  if(TARGET test_tf2_geometry_msgs)
+    target_link_libraries(test_tf2_geometry_msgs
+      ${geometry_msgs_LIBRARIES}
+      ${orocos_kdl_LIBRARIES}
+      ${tf2_LIBRARIES}
+      ${tf2_ros_LIBRARIES}
+      ${GTEST_LIBRARIES}
+    )
+  endif()
+endif()
+
 ament_auto_package()

--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
@@ -488,6 +488,39 @@ void fromMsg(const geometry_msgs::msg::TransformStamped& msg, geometry_msgs::msg
   out = msg;
 }
 
+/** \brief Convert a TransformStamped message to its equivalent tf2 representation.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param msg A TransformStamped message type.
+ * \param out The TransformStamped converted to the equivalent tf2 type.
+ */
+inline
+void fromMsg(const geometry_msgs::msg::TransformStamped& in, tf2::Stamped <tf2::Transform>& out)
+{
+  out.stamp_ = tf2_ros::fromMsg(in.header.stamp);
+  out.frame_id_ = in.header.frame_id;
+  tf2::Transform tmp;
+  fromMsg(in.transform, tmp);
+  out.setData(tmp);
+}
+
+/** \brief Convert as stamped tf2 Transform type to its equivalent geometry_msgs representation.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param in An instance of the tf2::Transform specialization of the tf2::Stamped template.
+ * \return The TransformStamped converted to a geometry_msgs TransformStamped message type.
+ */
+template <>
+inline
+geometry_msgs::msg::TransformStamped toMsg(const tf2::Stamped<tf2::Transform>& in)
+{
+  geometry_msgs::msg::TransformStamped out;
+  out.header.stamp = tf2_ros::toMsg(in.stamp_);
+  out.header.frame_id = in.frame_id_;
+  out.transform.translation.x = in.getOrigin().getX();
+  out.transform.translation.y = in.getOrigin().getY();
+  out.transform.translation.z = in.getOrigin().getZ();
+  out.transform.rotation = toMsg(in.getRotation());
+  return out;
+}
 
 /**********/
 /** Pose **/

--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
@@ -385,6 +385,40 @@ void fromMsg(const geometry_msgs::msg::QuaternionStamped& in, tf2::Stamped<tf2::
 }
 
 
+/***************/
+/** Transform **/
+/***************/
+
+/** \brief Convert a tf2 Transform type to its equivalent geometry_msgs representation.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param in A tf2 Transform object.
+ * \return The Transform converted to a geometry_msgs message type.
+ */
+inline
+geometry_msgs::msg::Transform toMsg(const tf2::Transform& in)
+{
+  geometry_msgs::msg::Transform out;
+  out.translation.x = in.getOrigin().getX();
+  out.translation.y = in.getOrigin().getY();
+  out.translation.z = in.getOrigin().getZ();
+  out.rotation = toMsg(in.getRotation());
+  return out;
+}
+
+/** \brief Convert a Transform message to its equivalent tf2 representation.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param in A Transform message type.
+ * \param out The Transform converted to a tf2 type.
+ */
+inline
+void fromMsg(const geometry_msgs::msg::Transform& in, tf2::Transform& out)
+{
+  out.setOrigin(tf2::Vector3(in.translation.x, in.translation.y, in.translation.z));
+  // w at the end in the constructor
+  out.setRotation(tf2::Quaternion(in.rotation.x, in.rotation.y, in.rotation.z, in.rotation.w));
+}
+
+
 /**********************/
 /** TransformStamped **/
 /**********************/
@@ -452,40 +486,6 @@ inline
 void fromMsg(const geometry_msgs::msg::TransformStamped& msg, geometry_msgs::msg::TransformStamped& out)
 {
   out = msg;
-}
-
-
-/***************/
-/** Transform **/
-/***************/
-
-/** \brief Convert a tf2 Transform type to its equivalent geometry_msgs representation.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param in A tf2 Transform object.
- * \return The Transform converted to a geometry_msgs message type.
- */
-inline
-geometry_msgs::msg::Transform toMsg(const tf2::Transform& in)
-{
-  geometry_msgs::msg::Transform out;
-  out.translation.x = in.getOrigin().getX();
-  out.translation.y = in.getOrigin().getY();
-  out.translation.z = in.getOrigin().getZ();
-  out.rotation = toMsg(in.getRotation());
-  return out;
-}
-
-/** \brief Convert a Transform message to its equivalent tf2 representation.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param in A Transform message type.
- * \param out The Transform converted to a tf2 type.
- */
-inline
-void fromMsg(const geometry_msgs::msg::Transform& in, tf2::Transform& out)
-{
-  out.setOrigin(tf2::Vector3(in.translation.x, in.translation.y, in.translation.z));
-  // w at the end in the constructor
-  out.setRotation(tf2::Quaternion(in.rotation.x, in.rotation.y, in.rotation.z, in.rotation.w));
 }
 
 

--- a/tf2_geometry_msgs/package.xml
+++ b/tf2_geometry_msgs/package.xml
@@ -23,7 +23,7 @@
   <exec_depend>python_orocos_kdl</exec_depend>
   -->
 
-  <!--<test_depend>rostest</test_depend> -->
+  <test_depend>ament_cmake_gtest</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
+++ b/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
@@ -30,9 +30,7 @@
 /** \author Wim Meeussen */
 
 
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <tf2_ros/transform_listener.h>
-#include <ros/ros.h>
 #include <gtest/gtest.h>
 #include <tf2_ros/buffer.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
@@ -48,7 +46,7 @@ TEST(TfGeometry, Frame)
   v1.pose.position.y = 2;
   v1.pose.position.z = 3;
   v1.pose.orientation.x = 1;
-  v1.header.stamp = builtin_interfaces::msg::Time(2);
+  v1.header.stamp = tf2_ros::toMsg(tf2::timeFromSec(2));
   v1.header.frame_id = "A";
 
   // simple api
@@ -60,10 +58,10 @@ TEST(TfGeometry, Frame)
   EXPECT_NEAR(v_simple.pose.orientation.y, 0.0, EPS);
   EXPECT_NEAR(v_simple.pose.orientation.z, 0.0, EPS);
   EXPECT_NEAR(v_simple.pose.orientation.w, 1.0, EPS);
-  
+
 
   // advanced api
-  geometry_msgs::msg::PoseStamped v_advanced = tf_buffer->transform(v1, "B", builtin_interfaces::msg::Time(2.0),
+  geometry_msgs::msg::PoseStamped v_advanced = tf_buffer->transform(v1, "B", tf2::timeFromSec(2.0),
 							      "A", tf2::durationFromSec(3.0));
   EXPECT_NEAR(v_advanced.pose.position.x, -9, EPS);
   EXPECT_NEAR(v_advanced.pose.position.y, 18, EPS);
@@ -82,7 +80,7 @@ TEST(TfGeometry, Vector)
   v1.vector.x = 1;
   v1.vector.y = 2;
   v1.vector.z = 3;
-  v1.header.stamp = builtin_interfaces::msg::Time(2.0);
+  v1.header.stamp = tf2_ros::toMsg(tf2::timeFromSec(2));
   v1.header.frame_id = "A";
 
   // simple api
@@ -92,7 +90,7 @@ TEST(TfGeometry, Vector)
   EXPECT_NEAR(v_simple.vector.z, -3, EPS);
 
   // advanced api
-  geometry_msgs::msg::Vector3Stamped v_advanced = tf_buffer->transform(v1, "B", builtin_interfaces::msg::Time(2.0),
+  geometry_msgs::msg::Vector3Stamped v_advanced = tf_buffer->transform(v1, "B", tf2::timeFromSec(2.0),
 								 "A", tf2::durationFromSec(3.0));
   EXPECT_NEAR(v_advanced.vector.x, 1, EPS);
   EXPECT_NEAR(v_advanced.vector.y, -2, EPS);
@@ -106,7 +104,7 @@ TEST(TfGeometry, Point)
   v1.point.x = 1;
   v1.point.y = 2;
   v1.point.z = 3;
-  v1.header.stamp = builtin_interfaces::msg::Time(2.0);
+  v1.header.stamp = tf2_ros::toMsg(tf2::timeFromSec(2));
   v1.header.frame_id = "A";
 
   // simple api
@@ -116,7 +114,7 @@ TEST(TfGeometry, Point)
   EXPECT_NEAR(v_simple.point.z, 27, EPS);
 
   // advanced api
-  geometry_msgs::msg::PointStamped v_advanced = tf_buffer->transform(v1, "B", builtin_interfaces::msg::Time(2.0),
+  geometry_msgs::msg::PointStamped v_advanced = tf_buffer->transform(v1, "B", tf2::timeFromSec(2.0),
 								 "A", tf2::durationFromSec(3.0));
   EXPECT_NEAR(v_advanced.point.x, -9, EPS);
   EXPECT_NEAR(v_advanced.point.y, 18, EPS);
@@ -126,10 +124,9 @@ TEST(TfGeometry, Point)
 
 int main(int argc, char **argv){
   testing::InitGoogleTest(&argc, argv);
-  ros::init(argc, argv, "test");
-  ros::NodeHandle n;
 
   tf_buffer = new tf2_ros::Buffer();
+  tf_buffer->setUsingDedicatedThread(true);
 
   // populate buffer
   geometry_msgs::msg::TransformStamped t;
@@ -137,7 +134,7 @@ int main(int argc, char **argv){
   t.transform.translation.y = 20;
   t.transform.translation.z = 30;
   t.transform.rotation.x = 1;
-  t.header.stamp = builtin_interfaces::msg::Time(2.0);
+  t.header.stamp = tf2_ros::toMsg(tf2::timeFromSec(2));
   t.header.frame_id = "A";
   t.child_frame_id = "B";
   tf_buffer->setTransform(t, "test");
@@ -146,8 +143,3 @@ int main(int argc, char **argv){
   delete tf_buffer;
   return ret;
 }
-
-
-
-
-

--- a/tf2_ros/include/tf2_ros/buffer_interface.h
+++ b/tf2_ros/include/tf2_ros/buffer_interface.h
@@ -39,7 +39,7 @@
 #include <tf2/exceptions.h>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <sstream>
-//TODO(tfoote)  review removal #include <tf2/convert.h>
+#include <tf2/convert.h>
 
 namespace tf2_ros
 {
@@ -139,7 +139,6 @@ public:
 		 const std::string& source_frame, const tf2::TimePoint& source_time,
 		 const std::string& fixed_frame, const tf2::Duration timeout, std::string* errstr = NULL) const = 0;
 
-  // TODO(tfoote) restore transform methods
   /** \brief Transform an input into the target frame.
    * This function is templated and can take as input any valid mathematical object that tf knows
    * how to apply a transform to, by way of the templated math conversions interface.
@@ -151,14 +150,14 @@ public:
    * \param target_frame The string identifer for the frame to transform into.
    * \param timeout How long to wait for the target frame. Default value is zero (no blocking).
    */
-  // template <class T>
-  //   T& transform(const T& in, T& out, 
-  //       	 const std::string& target_frame, tf2::Duration timeout=tf2::Duration(0.0)) const
-  // {
-  //   // do the transform
-  //   tf2::doTransform(in, out, lookupTransform(target_frame, tf2::getFrameId(in), tf2::getTimestamp(in), timeout));
-  //   return out;
-  // }
+  template <class T>
+    T& transform(const T& in, T& out, 
+        	 const std::string& target_frame, tf2::Duration timeout=tf2::durationFromSec(0.0)) const
+  {
+    // do the transform
+    tf2::doTransform(in, out, lookupTransform(target_frame, tf2::getFrameId(in), tf2::getTimestamp(in), timeout));
+    return out;
+  }
 
   /** \brief Transform an input into the target frame.
    * This function is templated and can take as input any valid mathematical object that tf knows
@@ -171,13 +170,13 @@ public:
    * \param timeout How long to wait for the target frame. Default value is zero (no blocking).
    * \return The transformed output.
    */
-  // template <class T>
-  //   T transform(const T& in, 
-  //       	const std::string& target_frame, tf2::Duration timeout=tf2::Duration(0.0)) const
-  // {
-  //   T out;
-  //   return transform(in, out, target_frame, timeout);
-  // }
+  template <class T>
+    T transform(const T& in, 
+        	const std::string& target_frame, tf2::Duration timeout=tf2::durationFromSec(0.0)) const
+  {
+    T out;
+    return transform(in, out, target_frame, timeout);
+  }
 
   /** \brief Transform an input into the target frame and convert to a specified output type.
    * It is templated on two types: the type of the input object and the type of the
@@ -196,14 +195,14 @@ public:
    * \param timeout How long to wait for the target frame. Default value is zero (no blocking).
    * \return The transformed output, converted to the specified type.
    */
-  // template <class A, class B>
-  //   B& transform(const A& in, B& out,
-  //       const std::string& target_frame, tf2::Duration timeout=tf2::Duration(0.0)) const
-  // {
-  //   A copy = transform(in, target_frame, timeout);
-  //   tf2::convert(copy, out);
-  //   return out;
-  // }
+  template <class A, class B>
+    B& transform(const A& in, B& out,
+        const std::string& target_frame, tf2::Duration timeout=tf2::durationFromSec(0.0)) const
+  {
+    A copy = transform(in, target_frame, timeout);
+    tf2::convert(copy, out);
+    return out;
+  }
 
   /** \brief Transform an input into the target frame (advanced).
    * This function is templated and can take as input any valid mathematical object that tf knows
@@ -220,17 +219,17 @@ public:
    * \param fixed_frame The frame in which to treat the transform as constant in time.
    * \param timeout How long to wait for the target frame. Default value is zero (no blocking).
    */
-  // template <class T>
-  //   T& transform(const T& in, T& out, 
-  //       	 const std::string& target_frame, const tf2::TimePoint& target_time,
-  //       	 const std::string& fixed_frame, tf2::Duration timeout=tf2::Duration(0.0)) const
-  // {
-  //   // do the transform
-  //   tf2::doTransform(in, out, lookupTransform(target_frame, target_time, 
-  //                                             tf2::getFrameId(in), tf2::getTimestamp(in), 
-  //                                             fixed_frame, timeout));
-  //   return out;
-  // }
+  template <class T>
+    T& transform(const T& in, T& out, 
+        	 const std::string& target_frame, const tf2::TimePoint& target_time,
+        	 const std::string& fixed_frame, tf2::Duration timeout=tf2::durationFromSec(0.0)) const
+  {
+    // do the transform
+    tf2::doTransform(in, out, lookupTransform(target_frame, target_time, 
+                                              tf2::getFrameId(in), tf2::getTimestamp(in), 
+                                              fixed_frame, timeout));
+    return out;
+  }
 
   /** \brief Transform an input into the target frame (advanced).
    * This function is templated and can take as input any valid mathematical object that tf knows
@@ -247,14 +246,14 @@ public:
    * \param timeout How long to wait for the target frame. Default value is zero (no blocking).
    * \return The transformed output.
    */
-  // template <class T>
-  //   T transform(const T& in, 
-  //       	 const std::string& target_frame, const tf2::TimePoint& target_time,
-  //       	 const std::string& fixed_frame, tf2::Duration timeout=tf2::Duration(0.0)) const
-  // {
-  //   T out;
-  //   return transform(in, out, target_frame, target_time, fixed_frame, timeout);
-  // }
+  template <class T>
+    T transform(const T& in, 
+        	 const std::string& target_frame, const tf2::TimePoint& target_time,
+        	 const std::string& fixed_frame, tf2::Duration timeout=tf2::durationFromSec(0.0)) const
+  {
+    T out;
+    return transform(in, out, target_frame, target_time, fixed_frame, timeout);
+  }
 
   /** \brief Transform an input into the target frame and convert to a specified output type (advanced).
    * It is templated on two types: the type of the input object and the type of the
@@ -277,16 +276,16 @@ public:
    * \param timeout How long to wait for the target frame. Default value is zero (no blocking).
    * \return The transformed output, converted to the specified output type.
    */
-  // template <class A, class B>
-  //   B& transform(const A& in, B& out, 
-  //       	 const std::string& target_frame, const tf2::TimePoint& target_time,
-  //       	 const std::string& fixed_frame, tf2::Duration timeout=tf2::Duration(0.0)) const
-  // {
-  //   // do the transform
-  //   A copy = transform(in, target_frame, target_time, fixed_frame, timeout);
-  //   tf2::convert(copy, out);
-  //   return out;
-  // }
+  template <class A, class B>
+    B& transform(const A& in, B& out, 
+        	 const std::string& target_frame, const tf2::TimePoint& target_time,
+        	 const std::string& fixed_frame, tf2::Duration timeout=tf2::durationFromSec(0.0)) const
+  {
+    // do the transform
+    A copy = transform(in, target_frame, target_time, fixed_frame, timeout);
+    tf2::convert(copy, out);
+    return out;
+  }
 
  }; // class
 


### PR DESCRIPTION
connects to ros2/navigation#5

This includes changes from https://github.com/ros2/geometry2/pull/16. I haven't put it in review for that reason (things might change over there); I'm opening it for visibility now and will rebase + label as in review when appropriate.

The addition of missing transform methods in https://github.com/ros2/geometry2/commit/b16d65da346364f1dfd55e55149d9cae487b0c1e is already proposed upstream in https://github.com/ros/geometry2/pull/202