### PR TITLE
Comment out python_orocos_kdl dependencies

### DIFF
--- a/tf2_geometry_msgs/package.xml
+++ b/tf2_geometry_msgs/package.xml
@@ -17,9 +17,11 @@
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
 
+  <!-- python support not yet ported
   <build_depend>python_orocos_kdl</build_depend>
 
   <exec_depend>python_orocos_kdl</exec_depend>
+  -->
 
   <!--<test_depend>rostest</test_depend> -->
 


### PR DESCRIPTION
Python support is [currently  disabled](https://github.com/ros2/geometry2/blob/e2392e0585b1d2d6cd7c704b5187d1b970cb6b39/tf2_geometry_msgs/CMakeLists.txt#L27)