### PR TITLE
Initialize the quaternion in the tf2_geometry_msgs unit tests

### DIFF
--- a/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
+++ b/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
@@ -46,6 +46,9 @@ TEST(TfGeometry, Frame)
   v1.pose.position.y = 2;
   v1.pose.position.z = 3;
   v1.pose.orientation.x = 1;
+  v1.pose.orientation.y = 0;
+  v1.pose.orientation.z = 0;
+  v1.pose.orientation.w = 0;
   v1.header.stamp = tf2_ros::toMsg(tf2::timeFromSec(2));
   v1.header.frame_id = "A";
 


### PR DESCRIPTION
Connects to #24 

 - Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2766)](http://ci.ros2.org/job/ci_linux/2766/)
- Linux aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=299)](http://ci.ros2.org/job/ci_linux-aarch64/299/)
 - OSX [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2240)](http://ci.ros2.org/job/ci_osx/2240/)
 - Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2897)](http://ci.ros2.org/job/ci_windows/2897/)

