### PR TITLE
initialize whole quaternion

### DIFF
--- a/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
+++ b/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
@@ -137,6 +137,9 @@ int main(int argc, char **argv){
   t.transform.translation.y = 20;
   t.transform.translation.z = 30;
   t.transform.rotation.x = 1;
+  t.transform.rotation.y = 0;
+  t.transform.rotation.z = 0;
+  t.transform.rotation.w = 0;
   t.header.stamp = tf2_ros::toMsg(tf2::timeFromSec(2));
   t.header.frame_id = "A";
   t.child_frame_id = "B";


### PR DESCRIPTION
Fixes #24 

This was only showing on Windows Debug builds. But was the same problem as #18 and #25 
It was very odd that it gave exactly 180 responses to what were expected. But also that the other arches passed is surprising too.

CI: 

- Linux: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2815)](http://ci.ros2.org/job/ci_linux/2815/)
- linux aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=322)](http://ci.ros2.org/job/ci_linux-aarch64/322/)
- osx [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2274)](http://ci.ros2.org/job/ci_osx/2274/)
- windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2952)](http://ci.ros2.org/job/ci_windows/2952/)