### PR TITLE
Fix tf_monitor subscription

### DIFF
--- a/tf2_ros/src/tf2_monitor.cpp
+++ b/tf2_ros/src/tf2_monitor.cpp
@@ -124,11 +124,11 @@ public:
     
   };
 
-  TFMonitor(bool using_specific_chain, std::string framea  = "", std::string frameb = ""):
-    framea_(framea), frameb_(frameb),
+  TFMonitor(rclcpp::node::Node::SharedPtr node, bool using_specific_chain,
+            std::string framea  = "", std::string frameb = ""):
+    node_(node), framea_(framea), frameb_(frameb),
     using_specific_chain_(using_specific_chain)
   {
-    node_ = rclcpp::node::Node::make_shared("tf_monitor");
     tf_ = std::make_shared<tf2_ros::TransformListener>(buffer_);
     
     if (using_specific_chain_)
@@ -307,8 +307,9 @@ int main(int argc, char ** argv)
   auto run_func = [](rclcpp::node::Node::SharedPtr node) {
     return rclcpp::spin(node);
   };
+  TFMonitor monitor(nh, using_specific_chain, framea, frameb);
   std::thread spinner(run_func, nh);
-  TFMonitor monitor(using_specific_chain, framea, frameb);
+
   monitor.spin();
   spinner.join();
   return 0;

--- a/tf2_ros/src/tf2_monitor.cpp
+++ b/tf2_ros/src/tf2_monitor.cpp
@@ -69,7 +69,7 @@ public:
   {
     const tf2_msgs::msg::TFMessage& message = *(msg);
     //TODO(tfoote) recover authority info
-    std::string authority = "No authority available"; //msg_evt.getPublisherName(); // lookup the authority
+    std::string authority = "<no authority availabile>"; //msg_evt.getPublisherName(); // lookup the authority 
 
     double average_offset = 0;
     std::unique_lock<std::mutex> my_lock(map_mutex_);  
@@ -133,7 +133,7 @@ public:
     
     if (using_specific_chain_)
     {
-      std::cout << "Waiting for transform chain to become available between "<< framea_ << " and " << frameb_<< " " << std::flush;
+      std::cout << "Waiting for transform chain to become available between " << framea_ << " and " << frameb_<< " " << std::flush;
       while (rclcpp::ok() && !buffer_.canTransform(framea_, frameb_, tf2::TimePointZero, tf2::durationFromSec(1.0)))
         std::cout << "." << std::flush;
       std::cout << std::endl;
@@ -178,7 +178,7 @@ public:
       max_delay = std::max(max_delay, it->second[i]);
     }
     average_delay /= it->second.size();
-    ss << "Frame: " << it->first <<" published by "<< frame_authority << " Average Delay: " << average_delay << " Max Delay: " << max_delay << std::endl;
+    ss << "Frame: " << it->first << ", published by "<< frame_authority << ", Average Delay: " << average_delay << ", Max Delay: " << max_delay << std::endl;
     return ss.str();
   }
   

--- a/tf2_ros/src/tf2_monitor.cpp
+++ b/tf2_ros/src/tf2_monitor.cpp
@@ -69,7 +69,7 @@ public:
   {
     const tf2_msgs::msg::TFMessage& message = *(msg);
     //TODO(tfoote) recover authority info
-    std::string authority = "<no authority availabile>"; //msg_evt.getPublisherName(); // lookup the authority 
+    std::string authority = "<no authority available>"; //msg_evt.getPublisherName(); // lookup the authority 
 
     double average_offset = 0;
     std::unique_lock<std::mutex> my_lock(map_mutex_);  
@@ -124,16 +124,19 @@ public:
     
   };
 
-  TFMonitor(rclcpp::node::Node::SharedPtr node, bool using_specific_chain,
-            std::string framea  = "", std::string frameb = ""):
-    node_(node), framea_(framea), frameb_(frameb),
-    using_specific_chain_(using_specific_chain)
+  TFMonitor(
+    rclcpp::node::Node::SharedPtr node, bool using_specific_chain,
+    std::string framea  = "", std::string frameb = "")
+      : node_(node),
+        framea_(framea),
+        frameb_(frameb),
+        using_specific_chain_(using_specific_chain)
   {
     tf_ = std::make_shared<tf2_ros::TransformListener>(buffer_);
     
     if (using_specific_chain_)
     {
-      std::cout << "Waiting for transform chain to become available between " << framea_ << " and " << frameb_<< " " << std::flush;
+      std::cout << "Waiting for transform chain to become available between "<< framea_ << " and " << frameb_<< " " << std::flush;
       while (rclcpp::ok() && !buffer_.canTransform(framea_, frameb_, tf2::TimePointZero, tf2::durationFromSec(1.0)))
         std::cout << "." << std::flush;
       std::cout << std::endl;

--- a/tf2_ros/src/tf2_monitor.cpp
+++ b/tf2_ros/src/tf2_monitor.cpp
@@ -69,7 +69,7 @@ public:
   {
     const tf2_msgs::msg::TFMessage& message = *(msg);
     //TODO(tfoote) recover authority info
-    std::string authority = "<no authority available>"; //msg_evt.getPublisherName(); // lookup the authority 
+    std::string authority = "<no authority available>"; //msg_evt.getPublisherName(); // lookup the authority
 
     double average_offset = 0;
     std::unique_lock<std::mutex> my_lock(map_mutex_);  


### PR DESCRIPTION
Connects to #31. Allows tf_monitor to process callbacks from `tf` and `tf_static`.