### PR TITLE
Only print out the LOOPING message every 30 seconds.

### DIFF
--- a/tf2_ros/src/static_transform_broadcaster_program.cpp
+++ b/tf2_ros/src/static_transform_broadcaster_program.cpp
@@ -151,10 +151,16 @@ int main(int argc, char ** argv)
   }
 
   rclcpp::WallRate loop_rate(0.2);
+  auto start = std::chrono::system_clock::from_time_t(0);
   while (rclcpp::ok())
   {
     //TODO(tfoote) reimplement latching
-    ROS_INFO("LOOPING due to no latching at the moment\n");
+    auto now = std::chrono::system_clock::now();
+    if (std::chrono::duration_cast<std::chrono::seconds>(now - start).count() >= 30)
+    {
+      ROS_INFO("LOOPING due to no latching at the moment\n");
+      start = now;
+    }
     broadcaster.sendTransform(msg);
     rclcpp::spin_some(node);
     loop_rate.sleep();

--- a/tf2_ros/src/static_transform_broadcaster_program.cpp
+++ b/tf2_ros/src/static_transform_broadcaster_program.cpp
@@ -35,10 +35,7 @@
 
 #include "builtin_interfaces/msg/time.hpp"
 
-//TODO(tfoote replace these terrible macros)
-#define ROS_ERROR printf
-#define ROS_FATAL printf
-#define ROS_INFO printf
+#include "rcutils/logging_macros.h"
 
 //TODO(clalancette re-enable this)
 // bool validateXmlRpcTf(XmlRpc::XmlRpcValue tf_data) {
@@ -138,29 +135,22 @@ int main(int argc, char ** argv)
     //printf("Usage: static_transform_publisher /param_name \n");
     //printf("\nThis transform is the transform of the coordinate frame from frame_id into the coordinate frame \n");
     //printf("of the child_frame_id.  \n");
-    ROS_ERROR("static_transform_publisher exited due to not having the right number of arguments");
+    RCUTILS_LOG_ERROR("static_transform_publisher exited due to not having the right number of arguments");
     return -1;
   }
 
   // Checks: frames should not be the same.
   if (msg.header.frame_id == msg.child_frame_id)
   {
-    ROS_FATAL("target_frame and source frame are the same (%s, %s) this cannot work",
-              msg.header.frame_id.c_str(), msg.child_frame_id.c_str());
+    RCUTILS_LOG_FATAL("target_frame and source frame are the same (%s, %s) this cannot work",
+                      msg.header.frame_id.c_str(), msg.child_frame_id.c_str());
     return 1;
   }
 
   rclcpp::WallRate loop_rate(0.2);
-  auto start = std::chrono::system_clock::from_time_t(0);
   while (rclcpp::ok())
   {
-    //TODO(tfoote) reimplement latching
-    auto now = std::chrono::system_clock::now();
-    if (std::chrono::duration_cast<std::chrono::seconds>(now - start).count() >= 30)
-    {
-      ROS_INFO("LOOPING due to no latching at the moment\n");
-      start = now;
-    }
+    RCUTILS_LOG_INFO_THROTTLE(RCUTILS_STEADY_TIME, 30000 /* ms */, "LOOPING due to no latching at the moment");
     broadcaster.sendTransform(msg);
     rclcpp::spin_some(node);
     loop_rate.sleep();


### PR DESCRIPTION
Partially fixes issue 12, but not linking it so that one doesn't get closed (there is other work to do there).

CI:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2891)](http://ci.ros2.org/job/ci_linux/2891/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=378)](http://ci.ros2.org/job/ci_linux-aarch64/378/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2330)](http://ci.ros2.org/job/ci_osx/2330/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3015)](http://ci.ros2.org/job/ci_windows/3015/)