### PR TITLE
Revert "work around console bridges odd lib path"

### DIFF
--- a/tf2_ros/CMakeLists.txt
+++ b/tf2_ros/CMakeLists.txt
@@ -21,12 +21,6 @@ find_package(tf2_msgs REQUIRED)
 
 find_package(rmw)
 
-# This is necessary due to console bridge installing to a non-standard location
-# https://github.com/ros2/ros2/issues/195
-if(UNIX AND NOT APPLE)
-  ament_environment_hooks(env_hook/console_bridge_libs.sh)
-endif()
-
 include_directories(include
   ${geometry_msgs_INCLUDE_DIRS}
   ${rclcpp_INCLUDE_DIRS}
@@ -56,6 +50,7 @@ target_link_libraries(${PROJECT_NAME}
   )
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE "TF2_ROS_BUILDING_DLL")
+
 # TODO(tfoote) port server client interfaces
 # # buffer_server executable
 # add_executable(buffer_server src/buffer_server_main.cpp)

--- a/tf2_ros/env_hook/console_bridge_libs.sh
+++ b/tf2_ros/env_hook/console_bridge_libs.sh
@@ -1,6 +1,0 @@
-# expanded from tf2_ros/env_hook/console_bridge_libs.sh
-
-# This is necessary due to console bridge installing to a non-standard location
-# https://github.com/ros2/ros2/issues/195
-PROCESSOR=`uname -p`
-ament_prepend_unique_value LD_LIBRARY_PATH "$AMENT_CURRENT_PREFIX/lib/$PROCESSOR-linux-gnu"


### PR DESCRIPTION
This reverts commit 0ca65d380ab2d123d5029c4a613ec4c3ff8f92c8.

This is a follow up on https://github.com/ros2/ros2/issues/195 reverting the workaround added in https://github.com/ros/geometry2/pull/157

This needs discussion before getting merged.

I don't think it's an issue anymore especially because we have many upstream packages using multiarch destination libraries these days. But I'm not sure how we expect to test this? Just install an upstream deb of console_bridge and build geometry 2 on top?

Not showing anything interesting, but at least this change doesn't break our current builds: http://ci.ros2.org/job/ci_linux/3224/