### PR TITLE
add a bridge mapping rule so tf/tfMessage maps to tf2_msgs/TFMessage

### DIFF
--- a/tf2_msgs/CMakeLists.txt
+++ b/tf2_msgs/CMakeLists.txt
@@ -28,4 +28,9 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   DEPENDENCIES builtin_interfaces std_msgs geometry_msgs
 )
 
+install(
+  FILES tfmessage_bridge_mapping_rule.yaml
+  DESTINATION share/${PROJECT_NAME}
+)
+
 ament_package()

--- a/tf2_msgs/package.xml
+++ b/tf2_msgs/package.xml
@@ -23,6 +23,7 @@
 
   <export>
     <build_type>ament_cmake</build_type>
+    <ros1_bridge mapping_rules="tfmessage_bridge_mapping_rule.yaml" />
   </export>
 
 </package>

--- a/tf2_msgs/tfmessage_bridge_mapping_rule.yaml
+++ b/tf2_msgs/tfmessage_bridge_mapping_rule.yaml
@@ -1,0 +1,5 @@
+-
+  ros1_package_name: 'tf'
+  ros1_message_name: 'tfMessage'
+  ros2_package_name: 'tf2_msgs'
+  ros2_message_name: 'TFMessage'

--- a/tf2_msgs/tfmessage_bridge_mapping_rule.yaml
+++ b/tf2_msgs/tfmessage_bridge_mapping_rule.yaml
@@ -1,3 +1,6 @@
+# This file defines mappings between ROS 1 and ROS 2 interfaces.
+# It is used with the ros1_bridge to allow for communcation between ROS 1 and ROS 2.
+
 -
   ros1_package_name: 'tf'
   ros1_message_name: 'tfMessage'


### PR DESCRIPTION
I did this according to this doc:

https://github.com/ros2/ros1_bridge/blob/master/doc/index.rst#how-can-i-install-mapping-rule-files

And some help from @dirk-thomas.

I tested this with our HSR demo.