### PR TITLE
fix compiler warnings required for rviz2

### DIFF
--- a/tf2/include/tf2/buffer_core.h
+++ b/tf2/include/tf2/buffer_core.h
@@ -444,6 +444,6 @@ private:
 
 
 
-};
+}
 
 #endif //TF2_CORE_H

--- a/tf2/include/tf2/transform_datatypes.h
+++ b/tf2/include/tf2/transform_datatypes.h
@@ -68,7 +68,7 @@ class Stamped : public T{
 template <typename T> 
 bool operator==(const Stamped<T> &a, const Stamped<T> &b) {
   return a.frame_id_ == b.frame_id_ && a.stamp_ == b.stamp_ && static_cast<const T&>(a) == static_cast<const T&>(b);
-};
+}
 
 
 }


### PR DESCRIPTION
Since compiling `rviz` uses `-Werror=pedantic` it needs to be warning-free.