### PR TITLE
Restore usage of '/' in tf topics for namespaces.

### DIFF
--- a/tf2_ros/src/static_transform_broadcaster.cpp
+++ b/tf2_ros/src/static_transform_broadcaster.cpp
@@ -43,7 +43,7 @@ StaticTransformBroadcaster::StaticTransformBroadcaster(rclcpp::Node::SharedPtr n
   rmw_qos_profile_t custom_qos_profile = rmw_qos_profile_default;
   custom_qos_profile.depth = 100;
   // TODO(tfoote) latched equivalent
-  publisher_ = node_->create_publisher<tf2_msgs::msg::TFMessage>("tf_static", custom_qos_profile);
+  publisher_ = node_->create_publisher<tf2_msgs::msg::TFMessage>("/tf_static", custom_qos_profile);
 }
 
 void StaticTransformBroadcaster::sendTransform(const geometry_msgs::msg::TransformStamped & msgtf)

--- a/tf2_ros/src/tf2_monitor.cpp
+++ b/tf2_ros/src/tf2_monitor.cpp
@@ -161,9 +161,9 @@ public:
     custom_qos_profile.depth = 100;
     
     std::function<void(const tf2_msgs::msg::TFMessage::SharedPtr)> standard_callback = std::bind(&TFMonitor::callback, this, std::placeholders::_1);
-    subscriber_tf_ = node_->create_subscription<tf2_msgs::msg::TFMessage>("tf", standard_callback, custom_qos_profile);
+    subscriber_tf_ = node_->create_subscription<tf2_msgs::msg::TFMessage>("/tf", standard_callback, custom_qos_profile);
     std::function<void(const tf2_msgs::msg::TFMessage::SharedPtr)> static_callback = std::bind(&TFMonitor::callback, this, std::placeholders::_1);
-    subscriber_tf_message_ = node_->create_subscription<tf2_msgs::msg::TFMessage>("tf_static", static_callback, custom_qos_profile);
+    subscriber_tf_message_ = node_->create_subscription<tf2_msgs::msg::TFMessage>("/tf_static", static_callback, custom_qos_profile);
 
     // subscriber_tf_ = node_->create_subscriber.subscribe<tf::tfMessage>("tf", 100, boost::bind(&TFMonitor::callback, this, _1));
     // subscriber_tf_message_ = node_.subscribe<tf::tfMessage>("tf_message", 100, boost::bind(&TFMonitor::callback, this, _1));

--- a/tf2_ros/src/tf2_ros/transform_broadcaster.py
+++ b/tf2_ros/src/tf2_ros/transform_broadcaster.py
@@ -37,11 +37,11 @@ from geometry_msgs.msg import TransformStamped
 
 class TransformBroadcaster:
     """
-    :class:`TransformBroadcaster` is a convenient way to send transformation updates on the ``"tf"`` message topic.
+    :class:`TransformBroadcaster` is a convenient way to send transformation updates on the ``"/tf"`` message topic.
     """
 
     def __init__(self):
-        self.pub_tf = rospy.Publisher("tf", TFMessage, queue_size=100)
+        self.pub_tf = rospy.Publisher("/tf", TFMessage, queue_size=100)
 
     def sendTransform(self, transform):
         """

--- a/tf2_ros/src/transform_broadcaster.cpp
+++ b/tf2_ros/src/transform_broadcaster.cpp
@@ -42,7 +42,7 @@ TransformBroadcaster::TransformBroadcaster(rclcpp::Node::SharedPtr node) :
 {
   rmw_qos_profile_t custom_qos_profile = rmw_qos_profile_default;
   custom_qos_profile.depth = 100;
-  publisher_ = node_->create_publisher<tf2_msgs::msg::TFMessage>("tf", custom_qos_profile);
+  publisher_ = node_->create_publisher<tf2_msgs::msg::TFMessage>("/tf", custom_qos_profile);
 };
 
 void TransformBroadcaster::sendTransform(const geometry_msgs::msg::TransformStamped & msgtf)

--- a/tf2_ros/src/transform_listener.cpp
+++ b/tf2_ros/src/transform_listener.cpp
@@ -81,9 +81,9 @@ void TransformListener::init()
   rmw_qos_profile_t custom_qos_profile = rmw_qos_profile_default;
   custom_qos_profile.depth = 100;
   std::function<void(const tf2_msgs::msg::TFMessage::SharedPtr)> standard_callback = std::bind(&TransformListener::subscription_callback, this, std::placeholders::_1);
-  message_subscription_tf_ = node_->create_subscription<tf2_msgs::msg::TFMessage>("tf", standard_callback, custom_qos_profile);
+  message_subscription_tf_ = node_->create_subscription<tf2_msgs::msg::TFMessage>("/tf", standard_callback, custom_qos_profile);
   std::function<void(const tf2_msgs::msg::TFMessage::SharedPtr)> static_callback = std::bind(&TransformListener::static_subscription_callback, this, std::placeholders::_1);
-  message_subscription_tf_static_ = node_->create_subscription<tf2_msgs::msg::TFMessage>("tf_static", static_callback, custom_qos_profile);
+  message_subscription_tf_static_ = node_->create_subscription<tf2_msgs::msg::TFMessage>("/tf_static", static_callback, custom_qos_profile);
 }
 
 void TransformListener::initThread()


### PR DESCRIPTION
Fixes ros2/geometry2#54

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3932)](http://ci.ros2.org/job/ci_linux/3932/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1050)](http://ci.ros2.org/job/ci_linux-aarch64/1050/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3259)](http://ci.ros2.org/job/ci_osx/3259/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4030)](http://ci.ros2.org/job/ci_windows/4030/)
