### PR TITLE
revert now unnecessary message initializations

### DIFF
--- a/tf2/test/simple_tf2_core.cpp
+++ b/tf2/test/simple_tf2_core.cpp
@@ -38,18 +38,6 @@ TEST(tf2, setTransformFail)
 {
   tf2::BufferCore tfc;
   geometry_msgs::msg::TransformStamped st;
-  st.header.frame_id = "";
-  st.header.stamp = builtin_interfaces::msg::Time();
-  st.header.stamp.sec = 1;
-  st.header.stamp.nanosec = 1;
-  st.child_frame_id = "";
-  st.transform.translation.x = 0;
-  st.transform.translation.y = 0;
-  st.transform.translation.z = 0;
-  st.transform.rotation.x = 0;
-  st.transform.rotation.y = 0;
-  st.transform.rotation.z = 0;
-  st.transform.rotation.w = 0;
   EXPECT_FALSE(tfc.setTransform(st, "authority1"));
   
 }
@@ -61,14 +49,8 @@ TEST(tf2, setTransformValid)
   st.header.frame_id = "foo";
   st.header.stamp = builtin_interfaces::msg::Time();
   st.header.stamp.sec = 1;
-  st.header.stamp.nanosec = 1;
+  st.header.stamp.nanosec = 0;
   st.child_frame_id = "child";
-  st.transform.translation.x = 0;
-  st.transform.translation.y = 0;
-  st.transform.translation.z = 0;
-  st.transform.rotation.x = 0;
-  st.transform.rotation.y = 0;
-  st.transform.rotation.z = 0;
   st.transform.rotation.w = 1;
   EXPECT_TRUE(tfc.setTransform(st, "authority1"));
   
@@ -81,14 +63,8 @@ TEST(tf2, setTransformInvalidQuaternion)
   st.header.frame_id = "foo";
   st.header.stamp = builtin_interfaces::msg::Time();
   st.header.stamp.sec = 1;
-  st.header.stamp.nanosec = 1;
+  st.header.stamp.nanosec = 0;
   st.child_frame_id = "child";
-  st.transform.translation.x = 0;
-  st.transform.translation.y = 0;
-  st.transform.translation.z = 0;
-  st.transform.rotation.x = 0;
-  st.transform.rotation.y = 0;
-  st.transform.rotation.z = 0;
   st.transform.rotation.w = 0;
   EXPECT_FALSE(tfc.setTransform(st, "authority1"));
   
@@ -117,12 +93,6 @@ TEST(tf2_lookupTransform, LookupException_One_Exists)
   st.header.stamp.sec = 1;
   st.header.stamp.nanosec = 0;
   st.child_frame_id = "child";
-  st.transform.translation.x = 0;
-  st.transform.translation.y = 0;
-  st.transform.translation.z = 0;
-  st.transform.rotation.x = 0;
-  st.transform.rotation.y = 0;
-  st.transform.rotation.z = 0;
   st.transform.rotation.w = 1;
   EXPECT_TRUE(tfc.setTransform(st, "authority1"));
   EXPECT_THROW(tfc.lookupTransform("foo", "bar", tf2::TimePoint(std::chrono::seconds(1))), tf2::LookupException);
@@ -138,12 +108,6 @@ TEST(tf2_canTransform, One_Exists)
   st.header.stamp.sec = 1;
   st.header.stamp.nanosec = 0;
   st.child_frame_id = "child";
-  st.transform.translation.x = 0;
-  st.transform.translation.y = 0;
-  st.transform.translation.z = 0;
-  st.transform.rotation.x = 0;
-  st.transform.rotation.y = 0;
-  st.transform.rotation.z = 0;
   st.transform.rotation.w = 1;
   EXPECT_TRUE(tfc.setTransform(st, "authority1"));
   EXPECT_FALSE(tfc.canTransform("foo", "bar", tf2::TimePoint(std::chrono::seconds(1))));

--- a/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
+++ b/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
@@ -46,9 +46,6 @@ TEST(TfGeometry, Frame)
   v1.pose.position.y = 2;
   v1.pose.position.z = 3;
   v1.pose.orientation.x = 1;
-  v1.pose.orientation.y = 0;
-  v1.pose.orientation.z = 0;
-  v1.pose.orientation.w = 0;
   v1.header.stamp = tf2_ros::toMsg(tf2::timeFromSec(2));
   v1.header.frame_id = "A";
 
@@ -137,9 +134,6 @@ int main(int argc, char **argv){
   t.transform.translation.y = 20;
   t.transform.translation.z = 30;
   t.transform.rotation.x = 1;
-  t.transform.rotation.y = 0;
-  t.transform.rotation.z = 0;
-  t.transform.rotation.w = 0;
   t.header.stamp = tf2_ros::toMsg(tf2::timeFromSec(2));
   t.header.frame_id = "A";
   t.child_frame_id = "B";


### PR DESCRIPTION
This reverts all the message initialization that have been introduced during the ROS 2 port that are not necessary now that we zero initialize the messages by default.

 ros2/geometry2#19
 ros2/geometry2#18
 ros2/geometry2@31791b0
 ros2/geometry2#28
 ros2/geometry2@d957ba6

CI using `build_type` Debug and test argument `--retest-until-fail 30 --packages-select-regex tf2`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4853)](http://ci.ros2.org/job/ci_linux/4853/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1707)](http://ci.ros2.org/job/ci_linux-aarch64/1707/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4031)](http://ci.ros2.org/job/ci_osx/4031/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4898)](http://ci.ros2.org/job/ci_windows/4898/)

related to https://github.com/ros2/ros2/issues/422