### PR TITLE
Use ros2 time

### DIFF
--- a/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
+++ b/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
@@ -125,7 +125,8 @@ TEST(TfGeometry, Point)
 int main(int argc, char **argv){
   testing::InitGoogleTest(&argc, argv);
 
-  tf_buffer = new tf2_ros::Buffer();
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+  tf_buffer = new tf2_ros::Buffer(clock);
   tf_buffer->setUsingDedicatedThread(true);
 
   // populate buffer

--- a/tf2_ros/CMakeLists.txt
+++ b/tf2_ros/CMakeLists.txt
@@ -125,7 +125,11 @@ install(DIRECTORY include/${PROJECT_NAME}/
 
 
 # Tests
-# if(BUILD_TESTING)
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_buffer test/test_buffer.cpp)
+  target_link_libraries(test_buffer ${PROJECT_NAME})
+
 # TODO(tfoote) port tests to use ROS2 instead of ROS1 api.
 if (false)
 
@@ -170,6 +174,8 @@ add_rostest(test/transform_listener_unittest.launch)
 add_rostest(test/transform_listener_time_reset_test.launch)
 
 endif()
+endif()
+
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})
 ament_export_dependencies(rclcpp)

--- a/tf2_ros/include/tf2_ros/buffer_interface.h
+++ b/tf2_ros/include/tf2_ros/buffer_interface.h
@@ -69,6 +69,12 @@ namespace tf2_ros
     return (s + std::chrono::duration_cast<std::chrono::duration<double>>(ns)).count();
   }
 
+  inline double timeToSec(const rclcpp::Time & rclcpp_time)
+  {
+    auto ns = std::chrono::duration<double, std::nano>(rclcpp_time.nanoseconds());
+    return std::chrono::duration_cast<std::chrono::duration<double>>(ns).count();
+  }
+
 /** \brief Abstract interface for wrapping tf2::BufferCore in a ROS-based API.
  * Implementations include tf2_ros::Buffer and tf2_ros::BufferClient.
  */

--- a/tf2_ros/include/tf2_ros/buffer_interface.h
+++ b/tf2_ros/include/tf2_ros/buffer_interface.h
@@ -69,12 +69,6 @@ namespace tf2_ros
     return (s + std::chrono::duration_cast<std::chrono::duration<double>>(ns)).count();
   }
 
-  inline double timeToSec(const rclcpp::Time & rclcpp_time)
-  {
-    auto ns = std::chrono::duration<double, std::nano>(rclcpp_time.nanoseconds());
-    return std::chrono::duration_cast<std::chrono::duration<double>>(ns).count();
-  }
-
 /** \brief Abstract interface for wrapping tf2::BufferCore in a ROS-based API.
  * Implementations include tf2_ros::Buffer and tf2_ros::BufferClient.
  */

--- a/tf2_ros/package.xml
+++ b/tf2_ros/package.xml
@@ -41,6 +41,8 @@
 
   <!-- <test_depend>rostest</test_depend> -->
 
+  <test_depend>ament_cmake_gtest</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/tf2_ros/src/tf2_echo.cpp
+++ b/tf2_ros/src/tf2_echo.cpp
@@ -43,7 +43,8 @@ public:
   std::shared_ptr<tf2_ros::TransformListener> tfl_;
 
   //constructor with name
-  echoListener()
+  echoListener(rclcpp::Clock::SharedPtr clock) :
+    buffer_(clock)
   {
     tfl_ = std::make_shared<tf2_ros::TransformListener>(buffer_);
   };
@@ -94,8 +95,9 @@ int main(int argc, char ** argv)
   }
   rclcpp::Rate rate(rate_hz);
 
+  rclcpp::Clock::SharedPtr clock = nh->get_clock();
   //Instantiate a local listener
-  echoListener echoListener;
+  echoListener echoListener(clock);
 
 
   std::string source_frameid = std::string(argv[1]);
@@ -133,7 +135,7 @@ int main(int argc, char ** argv)
       }
       catch(tf2::TransformException& ex)
       {
-        std::cout << "Failure at "<< tf2::displayTimePoint(tf2::get_now()) << std::endl;
+        std::cout << "Failure at "<< tf2_ros::timeToSec(clock->now()) << std::endl;
         std::cout << "Exception thrown:" << ex.what()<< std::endl;
         std::cout << "The current list of frames is:" <<std::endl;
         std::cout << echoListener.buffer_.allFramesAsString()<<std::endl;

--- a/tf2_ros/src/tf2_echo.cpp
+++ b/tf2_ros/src/tf2_echo.cpp
@@ -135,7 +135,7 @@ int main(int argc, char ** argv)
       }
       catch(tf2::TransformException& ex)
       {
-        std::cout << "Failure at "<< tf2_ros::timeToSec(clock->now()) << std::endl;
+        std::cout << "Failure at "<< clock->now().seconds() << std::endl;
         std::cout << "Exception thrown:" << ex.what()<< std::endl;
         std::cout << "The current list of frames is:" <<std::endl;
         std::cout << echoListener.buffer_.allFramesAsString()<<std::endl;

--- a/tf2_ros/src/tf2_monitor.cpp
+++ b/tf2_ros/src/tf2_monitor.cpp
@@ -60,6 +60,7 @@ public:
   std::map<std::string, std::vector<double> > authority_frequency_map;
   
   tf2_ros::Buffer buffer_;
+  rclcpp::Clock::SharedPtr clock_;
   std::shared_ptr<tf2_ros::TransformListener> tf_;
 
   tf2_msgs::msg::TFMessage message_;
@@ -77,7 +78,7 @@ public:
     {
       frame_authority_map[message.transforms[i].child_frame_id] = authority;
 
-      double offset = tf2::timeToSec(tf2::get_now()) - tf2_ros::timeToSec(message.transforms[i].header.stamp);
+      double offset = tf2_ros::timeToSec(clock_->now()) - tf2_ros::timeToSec(message.transforms[i].header.stamp);
       average_offset  += offset;
       
       std::map<std::string, std::vector<double> >::iterator it = delay_map.find(message.transforms[i].child_frame_id);
@@ -113,11 +114,11 @@ public:
     std::map<std::string, std::vector<double> >::iterator it3 = authority_frequency_map.find(authority);
     if (it3 == authority_frequency_map.end())
     {
-      authority_frequency_map[authority] = std::vector<double>(1,tf2::timeToSec(tf2::get_now()));
+      authority_frequency_map[authority] = std::vector<double>(1, tf2_ros::timeToSec(clock_->now()));
     }
     else
     {
-      it3->second.push_back(tf2::timeToSec(tf2::get_now()));
+      it3->second.push_back(tf2_ros::timeToSec(clock_->now()));
       if (it3->second.size() > 1000) 
         it3->second.erase(it3->second.begin());
     }
@@ -128,6 +129,8 @@ public:
     rclcpp::Node::SharedPtr node, bool using_specific_chain,
     std::string framea  = "", std::string frameb = "")
       : node_(node),
+        clock_(node->get_clock()),
+        buffer_(clock_),
         framea_(framea),
         frameb_(frameb),
         using_specific_chain_(using_specific_chain)
@@ -202,7 +205,7 @@ public:
     if (using_specific_chain_)
     {
       auto tmp = buffer_.lookupTransform(framea_, frameb_, tf2::TimePointZero);
-      double diff = tf2::timeToSec(tf2::get_now()) - tf2_ros::timeToSec(tmp.header.stamp);
+      double diff = tf2_ros::timeToSec(clock_->now()) - tf2_ros::timeToSec(tmp.header.stamp);
       avg_diff = lowpass * diff + (1-lowpass)*avg_diff;
       if (diff > max_diff) max_diff = diff;
     }

--- a/tf2_ros/src/tf2_monitor.cpp
+++ b/tf2_ros/src/tf2_monitor.cpp
@@ -59,8 +59,8 @@ public:
   std::map<std::string, std::vector<double> > authority_map;
   std::map<std::string, std::vector<double> > authority_frequency_map;
   
-  tf2_ros::Buffer buffer_;
   rclcpp::Clock::SharedPtr clock_;
+  tf2_ros::Buffer buffer_;
   std::shared_ptr<tf2_ros::TransformListener> tf_;
 
   tf2_msgs::msg::TFMessage message_;

--- a/tf2_ros/src/tf2_monitor.cpp
+++ b/tf2_ros/src/tf2_monitor.cpp
@@ -78,7 +78,7 @@ public:
     {
       frame_authority_map[message.transforms[i].child_frame_id] = authority;
 
-      double offset = tf2_ros::timeToSec(clock_->now()) - tf2_ros::timeToSec(message.transforms[i].header.stamp);
+      double offset = clock_->now().seconds() - tf2_ros::timeToSec(message.transforms[i].header.stamp);
       average_offset  += offset;
       
       std::map<std::string, std::vector<double> >::iterator it = delay_map.find(message.transforms[i].child_frame_id);
@@ -114,11 +114,11 @@ public:
     std::map<std::string, std::vector<double> >::iterator it3 = authority_frequency_map.find(authority);
     if (it3 == authority_frequency_map.end())
     {
-      authority_frequency_map[authority] = std::vector<double>(1, tf2_ros::timeToSec(clock_->now()));
+      authority_frequency_map[authority] = std::vector<double>(1, clock_->now().seconds());
     }
     else
     {
-      it3->second.push_back(tf2_ros::timeToSec(clock_->now()));
+      it3->second.push_back(clock_->now().seconds());
       if (it3->second.size() > 1000) 
         it3->second.erase(it3->second.begin());
     }
@@ -205,7 +205,7 @@ public:
     if (using_specific_chain_)
     {
       auto tmp = buffer_.lookupTransform(framea_, frameb_, tf2::TimePointZero);
-      double diff = tf2_ros::timeToSec(clock_->now()) - tf2_ros::timeToSec(tmp.header.stamp);
+      double diff = clock_->now().seconds() - tf2_ros::timeToSec(tmp.header.stamp);
       avg_diff = lowpass * diff + (1-lowpass)*avg_diff;
       if (diff > max_diff) max_diff = diff;
     }

--- a/tf2_ros/src/transform_listener.cpp
+++ b/tf2_ros/src/transform_listener.cpp
@@ -114,15 +114,6 @@ void TransformListener::static_subscription_callback(const tf2_msgs::msg::TFMess
 
 void TransformListener::subscription_callback_impl(const tf2_msgs::msg::TFMessage::SharedPtr msg, bool is_static)
 {
-  auto now = tf2::get_now();
-  if(now < last_update_){
-    ROS_WARN("Detected jump back in time. Clearing TF buffer.");
-    buffer_.clear();
-  }
-  last_update_ = now;
-
-
-
   const tf2_msgs::msg::TFMessage& msg_in = *msg;
   //TODO(tfoote) find a way to get the authority
   std::string authority = "Authority undetectable"; //msg_evt.getPublisherName(); // lookup the authority

--- a/tf2_ros/test/test_buffer.cpp
+++ b/tf2_ros/test/test_buffer.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2018, Open Source Robotics Foundation, Inc.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <exception>
+#include <chrono>
+#include <gtest/gtest.h>
+#include <tf2_ros/transform_listener.h>
+#include <rclcpp/rclcpp.hpp>
+
+
+using namespace tf2;
+
+TEST(test_buffer, construct_with_null_clock)
+{
+  EXPECT_THROW(tf2_ros::Buffer(nullptr), std::invalid_argument);
+}
+
+TEST(test_buffer, can_transform_valid_transform)
+{
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+  tf2_ros::Buffer buffer(clock);
+
+  rclcpp::Time rclcpp_time = clock->now();
+  tf2::TimePoint tf2_time(std::chrono::nanoseconds(rclcpp_time.nanoseconds()));
+
+  geometry_msgs::msg::TransformStamped transform;
+  transform.header.frame_id = "foo";
+  transform.header.stamp = builtin_interfaces::msg::Time(rclcpp_time);
+  transform.child_frame_id = "bar";
+  transform.transform.translation.x = 42.0;
+  transform.transform.translation.y = -3.14;
+  transform.transform.translation.z = 0.0;
+  transform.transform.rotation.w = 1.0;
+  transform.transform.rotation.x = 0.0;
+  transform.transform.rotation.y = 0.0;
+  transform.transform.rotation.z = 0.0;
+
+  EXPECT_TRUE(buffer.setTransform(transform, "unittest"));
+
+  EXPECT_TRUE(buffer.canTransform("bar", "foo", tf2_time));
+
+  auto output = buffer.lookupTransform("foo", "bar", tf2_time);
+  EXPECT_STREQ(transform.child_frame_id.c_str(), output.child_frame_id.c_str());
+  EXPECT_DOUBLE_EQ(transform.transform.translation.x, output.transform.translation.x);
+  EXPECT_DOUBLE_EQ(transform.transform.translation.y, output.transform.translation.y);
+  EXPECT_DOUBLE_EQ(transform.transform.translation.z, output.transform.translation.z);
+}
+
+int main(int argc, char **argv){
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+


### PR DESCRIPTION
This is updating tf2_ros to use `rclcpp::Time`. The `tf2_ros::Buffer` class requires a clock to be passed into it's constructor. `tf2_ros::Buffer` also registers time jump handlers and clears itself instead of relying on `tf2_ros::TransformListener` to do it.

Todo
* Change buffer_interface to use `rclcpp::Time` instead of `tf2::TimePoint`
* Make it easy to covert between `tf2::TimePoint` and `rclcpp::Time`
* Update all downstream code