### PR TITLE
Change spin_thread default to false

### DIFF
--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -52,7 +52,7 @@ public:
   TransformListener(tf2::BufferCore& buffer, bool spin_thread = true);
   
   TF2_ROS_PUBLIC
-  TransformListener(tf2::BufferCore& buffer, rclcpp::Node::SharedPtr nh, bool spin_thread = true);
+  TransformListener(tf2::BufferCore& buffer, rclcpp::Node::SharedPtr nh, bool spin_thread = false);
 
   TF2_ROS_PUBLIC
   ~TransformListener();


### PR DESCRIPTION
This changes the default value of `spin_thread` to `false` if the `TransformListener` is given a node. I'm assuming if a user has a node then they probably have an executor too. If so, then `true` for this parameter is potentially a problem because spinning on the same entities in two wait sets [is explicitly undefined behavior in rcl](https://github.com/ros2/rcl/blob/7f6b914ac41f0b20853aa84cd5a161952726de02/rcl/include/rcl/wait.h#L423-L427)

Noticed while looking at ros2/rcl#375. 