### PR TITLE
Use node interface pointers in the TransformListener class

### DIFF
--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -29,9 +29,11 @@
 
 /** \author Tully Foote */
 
-#ifndef TF2_ROS_TRANSFORMLISTENER_H
-#define TF2_ROS_TRANSFORMLISTENER_H
+#ifndef TF2_ROS__TRANSFORM_LISTENER_H_
+#define TF2_ROS__TRANSFORM_LISTENER_H_
 
+#include <memory>
+#include <string>
 #include <thread>
 #include "tf2_msgs/msg/tf_message.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -40,32 +42,32 @@
 #include "tf2_ros/visibility_control.h"
 
 
-namespace tf2_ros{
+namespace tf2_ros
+{
 
 /** \brief This class provides an easy way to request and receive coordinate frame transform information.
  */
 class TransformListener
 {
-
 public:
   /**@brief Constructor for transform listener */
   TF2_ROS_PUBLIC
-  TransformListener(tf2::BufferCore& buffer, bool spin_thread = true);
-  
-  TF2_ROS_PUBLIC
-  TransformListener(tf2::BufferCore& buffer, rclcpp::Node::SharedPtr nh, bool spin_thread = true);
+  TransformListener(tf2::BufferCore & buffer, bool spin_thread = true);
 
   TF2_ROS_PUBLIC
-  TransformListener(tf2::BufferCore& buffer,
-                           const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr & node_base,
-                           const rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr & node_topics,
-                           bool spin_thread = true);
+  TransformListener(tf2::BufferCore & buffer, rclcpp::Node::SharedPtr nh, bool spin_thread = true);
+
+  TF2_ROS_PUBLIC
+  TransformListener(
+    tf2::BufferCore & buffer,
+    const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr & node_base,
+    const rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr & node_topics,
+    bool spin_thread = true);
 
   TF2_ROS_PUBLIC
   ~TransformListener();
 
 private:
-
   /// Initialize this transform listener, subscribing, advertising services, etc.
   void init();
   void initThread();
@@ -86,7 +88,7 @@ private:
     typename rclcpp::message_memory_strategy::MessageMemoryStrategy<
       typename rclcpp::subscription_traits::has_message_type<CallbackT>::type, Alloc>::SharedPtr
     msg_mem_strat = nullptr,
-    std::shared_ptr<Alloc> allocator = nullptr );
+    std::shared_ptr<Alloc> allocator = nullptr);
 
   /// Callback function for ros message subscriptoin
   void subscription_callback(const tf2_msgs::msg::TFMessage::SharedPtr msg);
@@ -94,27 +96,25 @@ private:
   void subscription_callback_impl(const tf2_msgs::msg::TFMessage::SharedPtr msg, bool is_static);
 
   // ros::CallbackQueue tf_message_callback_queue_;
-  std::thread* dedicated_listener_thread_;
+  std::thread * dedicated_listener_thread_;
   const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_;
   const rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_;
 
   rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr message_subscription_tf_;
   rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr message_subscription_tf_static_;
-  tf2::BufferCore& buffer_;
+  tf2::BufferCore & buffer_;
   bool using_dedicated_thread_;
   tf2::TimePoint last_update_;
- 
+
   void dedicatedListenerThread()
   {
-    while (using_dedicated_thread_)
-    {
+    while (using_dedicated_thread_) {
       break;
-      //TODO(tfoote) reenable callback queue processing 
-      //tf_message_callback_queue_.callAvailable(ros::WallDuration(0.01));
+      // TODO(tfoote) reenable callback queue processing
+      // tf_message_callback_queue_.callAvailable(ros::WallDuration(0.01));
     }
-  };
-
+  }
 };
-}
+}  // namespace tf2_ros
 
-#endif //TF_TRANSFORMLISTENER_H
+#endif  // TF2_ROS__TRANSFORM_LISTENER_H_

--- a/tf2_ros/src/transform_listener.cpp
+++ b/tf2_ros/src/transform_listener.cpp
@@ -29,80 +29,91 @@
 
 /** \author Tully Foote */
 
+#include <memory>
+#include <string>
+#include <utility>
+
 #include "tf2_ros/transform_listener.h"
 
 
 using namespace tf2_ros;
 
-//TODO(tfoote replace these terrible macros)
+// TODO(tfoote replace these terrible macros)
 #define ROS_ERROR printf
 #define ROS_FATAL printf
 #define ROS_INFO printf
 #define ROS_WARN printf
 
-TransformListener::TransformListener(tf2::BufferCore& buffer, bool spin_thread)
+TransformListener::TransformListener(tf2::BufferCore & buffer, bool spin_thread)
 : TransformListener(buffer, rclcpp::Node::make_shared("transform_listener_impl"), spin_thread)
 {
 }
 
-TransformListener::TransformListener(tf2::BufferCore& buffer, rclcpp::Node::SharedPtr nh, bool spin_thread)
-: TransformListener(buffer, nh->get_node_base_interface(), nh->get_node_topics_interface(), spin_thread)
+TransformListener::TransformListener(
+  tf2::BufferCore & buffer, rclcpp::Node::SharedPtr nh,
+  bool spin_thread)
+: TransformListener(buffer, nh->get_node_base_interface(),
+    nh->get_node_topics_interface(), spin_thread)
 {
 }
 
-TransformListener::TransformListener(tf2::BufferCore& buffer,
-                                            const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr & node_base,
-                                            const rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr & node_topics,
-                                            bool spin_thread)
-: dedicated_listener_thread_(NULL)
-, node_base_(node_base)
-, node_topics_(node_topics)
-, buffer_(buffer)
-, using_dedicated_thread_(false)
+TransformListener::TransformListener(
+  tf2::BufferCore & buffer,
+  const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr & node_base,
+  const rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr & node_topics,
+  bool spin_thread)
+: dedicated_listener_thread_(NULL),
+  node_base_(node_base),
+  node_topics_(node_topics),
+  buffer_(buffer),
+  using_dedicated_thread_(false)
 {
   init();
-  if (spin_thread)
+  if (spin_thread) {
     initThread();
+  }
 }
 
 TransformListener::~TransformListener()
 {
   using_dedicated_thread_ = false;
-  if (dedicated_listener_thread_)
-  {
+  if (dedicated_listener_thread_) {
     dedicated_listener_thread_->join();
     delete dedicated_listener_thread_;
   }
 }
 
-void test_callback(const tf2_msgs::msg::TFMessage::SharedPtr msg){
-  return;
+void test_callback(const tf2_msgs::msg::TFMessage::SharedPtr msg)
+{
 }
 
 void TransformListener::init()
 {
-
   rmw_qos_profile_t custom_qos_profile = rmw_qos_profile_default;
   custom_qos_profile.depth = 100;
-  std::function<void(const tf2_msgs::msg::TFMessage::SharedPtr)> standard_callback = std::bind(&TransformListener::subscription_callback, this, std::placeholders::_1);
-  message_subscription_tf_ = create_subscription<tf2_msgs::msg::TFMessage>("/tf", standard_callback, custom_qos_profile);
-  std::function<void(const tf2_msgs::msg::TFMessage::SharedPtr)> static_callback = std::bind(&TransformListener::static_subscription_callback, this, std::placeholders::_1);
-  message_subscription_tf_static_ = create_subscription<tf2_msgs::msg::TFMessage>("/tf_static", static_callback, custom_qos_profile);
+  std::function<void(const tf2_msgs::msg::TFMessage::SharedPtr)> standard_callback = std::bind(
+    &TransformListener::subscription_callback, this, std::placeholders::_1);
+  message_subscription_tf_ = create_subscription<tf2_msgs::msg::TFMessage>("/tf", standard_callback,
+      custom_qos_profile);
+  std::function<void(const tf2_msgs::msg::TFMessage::SharedPtr)> static_callback = std::bind(
+    &TransformListener::static_subscription_callback, this, std::placeholders::_1);
+  message_subscription_tf_static_ = create_subscription<tf2_msgs::msg::TFMessage>("/tf_static",
+      static_callback,
+      custom_qos_profile);
 }
 
 void TransformListener::initThread()
 {
-
   using_dedicated_thread_ = true;
   // This lambda is required because `std::thread` cannot infer the correct
   // rclcpp::spin, since there are more than one versions of it (overloaded).
   // see: http://stackoverflow.com/a/27389714/671658
   // I (wjwwood) chose to use the lamda rather than the static cast solution.
   auto run_func = [](rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base) {
-    return rclcpp::spin(node_base);
-  };
+      return rclcpp::spin(node_base);
+    };
   dedicated_listener_thread_ = new std::thread(run_func, node_base_);
-  //Tell the buffer we have a dedicated thread to enable timeouts
+  // Tell the buffer we have a dedicated thread to enable timeouts
   buffer_.setUsingDedicatedThread(true);
 }
 
@@ -121,28 +132,29 @@ TransformListener::create_subscription(
   typename rclcpp::message_memory_strategy::MessageMemoryStrategy<
     typename rclcpp::subscription_traits::has_message_type<CallbackT>::type, Alloc>::SharedPtr
   msg_mem_strat,
-  std::shared_ptr<Alloc> allocator )
+  std::shared_ptr<Alloc> allocator)
 {
-    using CallbackMessageT = typename rclcpp::subscription_traits::has_message_type<CallbackT>::type;
+  using CallbackMessageT = typename rclcpp::subscription_traits::has_message_type<CallbackT>::type;
 
-    if (!allocator) {
-      allocator = std::make_shared<Alloc>();
-    }
+  if (!allocator) {
+    allocator = std::make_shared<Alloc>();
+  }
 
-    if (!msg_mem_strat) {
-      using rclcpp::message_memory_strategy::MessageMemoryStrategy;
-      msg_mem_strat = MessageMemoryStrategy<CallbackMessageT, Alloc>::create_default();
-    }
+  if (!msg_mem_strat) {
+    using rclcpp::message_memory_strategy::MessageMemoryStrategy;
+    msg_mem_strat = MessageMemoryStrategy<CallbackMessageT, Alloc>::create_default();
+  }
 
-  return rclcpp::create_subscription<MessageT, CallbackT, Alloc, CallbackMessageT, SubscriptionT>(node_topics_.get(),
-                              topic_name,
-                              std::forward<CallbackT>(callback),
-                              qos_profile,
-                              nullptr,
-                              false,
-                              false,
-                              msg_mem_strat,
-                              allocator);
+  return rclcpp::create_subscription<MessageT, CallbackT, Alloc, CallbackMessageT, SubscriptionT>(
+    node_topics_.get(),
+    topic_name,
+    std::forward<CallbackT>(callback),
+    qos_profile,
+    nullptr,
+    false,
+    false,
+    msg_mem_strat,
+    allocator);
 }
 
 void TransformListener::subscription_callback(const tf2_msgs::msg::TFMessage::SharedPtr msg)
@@ -154,23 +166,22 @@ void TransformListener::static_subscription_callback(const tf2_msgs::msg::TFMess
   subscription_callback_impl(msg, true);
 }
 
-void TransformListener::subscription_callback_impl(const tf2_msgs::msg::TFMessage::SharedPtr msg, bool is_static)
+void TransformListener::subscription_callback_impl(
+  const tf2_msgs::msg::TFMessage::SharedPtr msg,
+  bool is_static)
 {
-  const tf2_msgs::msg::TFMessage& msg_in = *msg;
-  //TODO(tfoote) find a way to get the authority
-  std::string authority = "Authority undetectable"; //msg_evt.getPublisherName(); // lookup the authority
-  for (unsigned int i = 0; i < msg_in.transforms.size(); i++)
-  {
-    try
-    {
+  const tf2_msgs::msg::TFMessage & msg_in = *msg;
+  // TODO(tfoote) find a way to get the authority
+  std::string authority = "Authority undetectable";  // msg_evt.getPublisherName();  // lookup the authority
+  for (unsigned int i = 0; i < msg_in.transforms.size(); i++) {
+    try {
       buffer_.setTransform(msg_in.transforms[i], authority, is_static);
-    }
-    
-    catch (tf2::TransformException& ex)
-    {
-      ///\todo Use error reporting
+    } catch (tf2::TransformException & ex) {
+      // /\todo Use error reporting
       std::string temp = ex.what();
-      ROS_ERROR("Failure to set recieved transform from %s to %s with error: %s\n", msg_in.transforms[i].child_frame_id.c_str(), msg_in.transforms[i].header.frame_id.c_str(), temp.c_str());
+      ROS_ERROR("Failure to set recieved transform from %s to %s with error: %s\n",
+        msg_in.transforms[i].child_frame_id.c_str(),
+        msg_in.transforms[i].header.frame_id.c_str(), temp.c_str());
     }
   }
-};
+}


### PR DESCRIPTION
In the TransformListener class, use node interfaces instead of using the node directly so that the code works with either rclcpp::Node or rclcpp_lifecycle::LifecycleNode. Retain the existing node-based interface for backwards compatibility.
This change fixes the issue reported here - https://github.com/ros2/geometry2/issues/94