### PR TITLE
use node interfaces throughout tf2_ros

### DIFF
--- a/tf2_ros/CMakeLists.txt
+++ b/tf2_ros/CMakeLists.txt
@@ -126,6 +126,14 @@ if(BUILD_TESTING)
   ament_add_gtest(${PROJECT_NAME}_test_message_filter test/message_filter_test.cpp)
   target_link_libraries(${PROJECT_NAME}_test_message_filter ${PROJECT_NAME})
 
+  ament_add_gtest(${PROJECT_NAME}_test_transform_listener test/test_transform_listener.cpp)
+  target_link_libraries(${PROJECT_NAME}_test_transform_listener ${PROJECT_NAME})
+
+  ament_add_gtest(${PROJECT_NAME}_test_static_transform_broadcaster test/test_static_transform_broadcaster.cpp)
+  target_link_libraries(${PROJECT_NAME}_test_static_transform_broadcaster ${PROJECT_NAME})
+
+  ament_add_gtest(${PROJECT_NAME}_test_transform_broadcaster test/test_transform_broadcaster.cpp)
+  target_link_libraries(${PROJECT_NAME}_test_transform_broadcaster ${PROJECT_NAME})
 # TODO(tfoote) port tests to use ROS2 instead of ROS1 api.
 if (false)
 

--- a/tf2_ros/include/tf2_ros/static_transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/static_transform_broadcaster.h
@@ -58,7 +58,7 @@ public:
       rclcpp::PublisherOptionsWithAllocator<AllocatorT>())
   {
     publisher_ = rclcpp::create_publisher<tf2_msgs::msg::TFMessage>(
-      std::forward<NodeT>(node), "/tf_static", qos, options);
+      node, "/tf_static", qos, options);
   };
 
   /** \brief Send a TransformStamped message

--- a/tf2_ros/include/tf2_ros/static_transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/static_transform_broadcaster.h
@@ -49,25 +49,17 @@ namespace tf2_ros
 
 class StaticTransformBroadcaster{
 public:
-
-  TF2_ROS_PUBLIC
-  StaticTransformBroadcaster(rclcpp::Node::SharedPtr node);
-
-  template<class AllocatorT = std::allocator<void>>
+  /** \brief Node interface constructor */
+  template<class NodeT, class AllocatorT = std::allocator<void>>
   StaticTransformBroadcaster(
-    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_interface)
+    NodeT && node,
+    const rclcpp::QoS & qos = rclcpp::QoS(100),
+    const rclcpp::PublisherOptionsWithAllocator<AllocatorT> & options =
+      rclcpp::PublisherOptionsWithAllocator<AllocatorT>())
   {
-    using MessageT = tf2_msgs::msg::TFMessage;
-    using PublisherT = ::rclcpp::Publisher<MessageT, AllocatorT>;
-
-    rmw_qos_profile_t custom_qos_profile = rmw_qos_profile_default;
-    custom_qos_profile.depth = 100;
-    // TODO(tfoote) latched equivalent
-    rclcpp::PublisherEventCallbacks callbacks;
-
-    publisher_ = rclcpp::create_publisher<MessageT, AllocatorT, PublisherT>(
-      node_topics_interface, "/tf_static", qos);
-  }
+    publisher_ = rclcpp::create_publisher<tf2_msgs::msg::TFMessage>(
+      std::forward<NodeT>(node), "/tf_static", qos, options);
+  };
 
   /** \brief Send a TransformStamped message
    * The stamped data structure includes frame_id, and time, and parent_id already.  */

--- a/tf2_ros/include/tf2_ros/static_transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/static_transform_broadcaster.h
@@ -43,9 +43,8 @@
 namespace tf2_ros
 {
 
-
-/** \brief This class provides an easy way to publish coordinate frame transform information.  
- * It will handle all the messaging and stuffing of messages.  And the function prototypes lay out all the 
+/** \brief This class provides an easy way to publish coordinate frame transform information.
+ * It will handle all the messaging and stuffing of messages.  And the function prototypes lay out all the
  * necessary data needed for each message.  */
 
 class StaticTransformBroadcaster{
@@ -58,11 +57,14 @@ public:
   StaticTransformBroadcaster(
     rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_interface)
   {
-    auto qos = rclcpp::QoS(rclcpp::KeepLast(100));
-    // TODO(tfoote) latched equivalent
-
     using MessageT = tf2_msgs::msg::TFMessage;
     using PublisherT = ::rclcpp::Publisher<MessageT, AllocatorT>;
+
+    rmw_qos_profile_t custom_qos_profile = rmw_qos_profile_default;
+    custom_qos_profile.depth = 100;
+    // TODO(tfoote) latched equivalent
+    rclcpp::PublisherEventCallbacks callbacks;
+
     publisher_ = rclcpp::create_publisher<MessageT, AllocatorT, PublisherT>(
       node_topics_interface, "/tf_static", qos);
   }

--- a/tf2_ros/include/tf2_ros/static_transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/static_transform_broadcaster.h
@@ -57,6 +57,7 @@ public:
     const rclcpp::PublisherOptionsWithAllocator<AllocatorT> & options =
       rclcpp::PublisherOptionsWithAllocator<AllocatorT>())
   {
+    // TODO(tfoote) latched equivalent
     publisher_ = rclcpp::create_publisher<tf2_msgs::msg::TFMessage>(
       node, "/tf_static", qos, options);
   };

--- a/tf2_ros/include/tf2_ros/transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/transform_broadcaster.h
@@ -56,7 +56,7 @@ public:
       rclcpp::PublisherOptionsWithAllocator<AllocatorT>())
   {
     publisher_ = rclcpp::create_publisher<tf2_msgs::msg::TFMessage>(
-      std::forward<NodeT>(node), "/tf", qos, options);
+      node, "/tf", qos, options);
   };
 
   /** \brief Send a StampedTransform

--- a/tf2_ros/include/tf2_ros/transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/transform_broadcaster.h
@@ -47,25 +47,16 @@ namespace tf2_ros
 
 class TransformBroadcaster{
 public:
-  /** \brief Constructor (needs a ros::Node reference) */
-  TF2_ROS_PUBLIC
-  TransformBroadcaster(rclcpp::Node::SharedPtr node);
-
   /** \brief Node interface constructor */
-  template<class AllocatorT = std::allocator<void>>
+  template<class NodeT, class AllocatorT = std::allocator<void>>
   TransformBroadcaster(
-    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_interface)
+    NodeT && node,
+    const rclcpp::QoS & qos = rclcpp::QoS(100),
+    const rclcpp::PublisherOptionsWithAllocator<AllocatorT> & options =
+      rclcpp::PublisherOptionsWithAllocator<AllocatorT>())
   {
-    using MessageT = tf2_msgs::msg::TFMessage;
-    using PublisherT = ::rclcpp::Publisher<MessageT, AllocatorT>;
-
-    rmw_qos_profile_t custom_qos_profile = rmw_qos_profile_default;
-    custom_qos_profile.depth = 100;
-    rclcpp::PublisherEventCallbacks  callbacks;
-
-    publisher_ = rclcpp::create_publisher<MessageT, AllocatorT, PublisherT>(
-      node_topics_interface.get(), "/tf",
-      custom_qos_profile, callbacks, nullptr, false, std::make_shared<AllocatorT>());
+    publisher_ = rclcpp::create_publisher<tf2_msgs::msg::TFMessage>(
+      std::forward<NodeT>(node), "/tf", qos, options);
   };
 
   /** \brief Send a StampedTransform

--- a/tf2_ros/include/tf2_ros/transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/transform_broadcaster.h
@@ -41,8 +41,8 @@
 namespace tf2_ros
 {
 
-/** \brief This class provides an easy way to publish coordinate frame transform information.  
- * It will handle all the messaging and stuffing of messages.  And the function prototypes lay out all the 
+/** \brief This class provides an easy way to publish coordinate frame transform information.
+ * It will handle all the messaging and stuffing of messages.  And the function prototypes lay out all the
  * necessary data needed for each message.  */
 
 class TransformBroadcaster{
@@ -51,11 +51,28 @@ public:
   TF2_ROS_PUBLIC
   TransformBroadcaster(rclcpp::Node::SharedPtr node);
 
-  /** \brief Send a StampedTransform 
+  /** \brief Node interface constructor */
+  template<class AllocatorT = std::allocator<void>>
+  TransformBroadcaster(
+    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_interface)
+  {
+    using MessageT = tf2_msgs::msg::TFMessage;
+    using PublisherT = ::rclcpp::Publisher<MessageT, AllocatorT>;
+
+    rmw_qos_profile_t custom_qos_profile = rmw_qos_profile_default;
+    custom_qos_profile.depth = 100;
+    rclcpp::PublisherEventCallbacks  callbacks;
+
+    publisher_ = rclcpp::create_publisher<MessageT, AllocatorT, PublisherT>(
+      node_topics_interface.get(), "/tf",
+      custom_qos_profile, callbacks, nullptr, false, std::make_shared<AllocatorT>());
+  };
+
+  /** \brief Send a StampedTransform
    * The stamped data structure includes frame_id, and time, and parent_id already.  */
   //  void sendTransform(const StampedTransform & transform);
 
-  /** \brief Send a vector of StampedTransforms 
+  /** \brief Send a vector of StampedTransforms
    * The stamped data structure includes frame_id, and time, and parent_id already.  */
   //void sendTransform(const std::vector<StampedTransform> & transforms);
 
@@ -70,8 +87,6 @@ public:
   void sendTransform(const std::vector<geometry_msgs::msg::TransformStamped> & transforms);
 
 private:
-  /// Internal reference to ros::Node
-  rclcpp::Node::SharedPtr node_;
   rclcpp::Publisher<tf2_msgs::msg::TFMessage>::SharedPtr publisher_;
 
 };

--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -101,6 +101,7 @@ private:
     }
   }
 
+  TF2_ROS_PUBLIC
   void initThread(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface);
 
   /// Callback function for ros message subscriptoin

--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -84,13 +84,13 @@ private:
     callback_t static_cb = std::bind(&TransformListener::subscription_callback, this, std::placeholders::_1, true);
 
     message_subscription_tf_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
-      std::forward<NodeT>(node),
+      node,
       "/tf",
       qos,
       std::move(cb),
       options);
     message_subscription_tf_static_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
-      std::forward<NodeT>(node),
+      node,
       "/tf_static",
       qos,
       std::move(static_cb),

--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -29,9 +29,11 @@
 
 /** \author Tully Foote */
 
-#ifndef TF2_ROS_TRANSFORMLISTENER_H
-#define TF2_ROS_TRANSFORMLISTENER_H
+#ifndef TF2_ROS__TRANSFORM_LISTENER_H_
+#define TF2_ROS__TRANSFORM_LISTENER_H_
 
+#include <memory>
+#include <string>
 #include <thread>
 #include "tf2_msgs/msg/tf_message.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -40,32 +42,32 @@
 #include "tf2_ros/visibility_control.h"
 
 
-namespace tf2_ros{
+namespace tf2_ros
+{
 
 /** \brief This class provides an easy way to request and receive coordinate frame transform information.
  */
 class TransformListener
 {
-
 public:
   /**@brief Constructor for transform listener */
   TF2_ROS_PUBLIC
-  TransformListener(tf2::BufferCore& buffer, bool spin_thread = true);
-  
-  TF2_ROS_PUBLIC
-  TransformListener(tf2::BufferCore& buffer, rclcpp::Node::SharedPtr nh, bool spin_thread = true);
+  TransformListener(tf2::BufferCore & buffer, bool spin_thread = true);
 
   TF2_ROS_PUBLIC
-  TransformListener(tf2::BufferCore& buffer,
-                           const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr & node_base,
-                           const rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr & node_topics,
-                           bool spin_thread = true);
+  TransformListener(tf2::BufferCore & buffer, rclcpp::Node::SharedPtr nh, bool spin_thread = true);
+
+  TF2_ROS_PUBLIC
+  TransformListener(
+    tf2::BufferCore & buffer,
+    const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr & node_base,
+    const rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr & node_topics,
+    bool spin_thread = true);
 
   TF2_ROS_PUBLIC
   ~TransformListener();
 
 private:
-
   /// Initialize this transform listener, subscribing, advertising services, etc.
   void init();
   void initThread();
@@ -86,7 +88,7 @@ private:
     typename rclcpp::message_memory_strategy::MessageMemoryStrategy<
       typename rclcpp::subscription_traits::has_message_type<CallbackT>::type, Alloc>::SharedPtr
     msg_mem_strat = nullptr,
-    std::shared_ptr<Alloc> allocator = nullptr );
+    std::shared_ptr<Alloc> allocator = nullptr);
 
   /// Callback function for ros message subscriptoin
   void subscription_callback(const tf2_msgs::msg::TFMessage::SharedPtr msg);
@@ -94,27 +96,25 @@ private:
   void subscription_callback_impl(const tf2_msgs::msg::TFMessage::SharedPtr msg, bool is_static);
 
   // ros::CallbackQueue tf_message_callback_queue_;
-  std::thread* dedicated_listener_thread_;
+  std::thread * dedicated_listener_thread_;
   const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_;
   const rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_;
 
   rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr message_subscription_tf_;
   rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr message_subscription_tf_static_;
-  tf2::BufferCore& buffer_;
+  tf2::BufferCore & buffer_;
   bool using_dedicated_thread_;
   tf2::TimePoint last_update_;
- 
+
   void dedicatedListenerThread()
   {
-    while (using_dedicated_thread_)
-    {
+    while (using_dedicated_thread_) {
       break;
-      //TODO(tfoote) reenable callback queue processing 
-      //tf_message_callback_queue_.callAvailable(ros::WallDuration(0.01));
+      // TODO(tfoote) reenable callback queue processing
+      // tf_message_callback_queue_.callAvailable(ros::WallDuration(0.01));
     }
-  };
-
+  }
 };
-}
+}  // namespace tf2_ros
 
-#endif //TF_TRANSFORMLISTENER_H
+#endif  // TF2_ROS__TRANSFORM_LISTENER_H_

--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -105,6 +105,7 @@ private:
   void initThread(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface);
 
   /// Callback function for ros message subscriptoin
+  TF2_ROS_PUBLIC
   void subscription_callback(tf2_msgs::msg::TFMessage::SharedPtr msg, bool is_static);
 
   // ros::CallbackQueue tf_message_callback_queue_;

--- a/tf2_ros/src/static_transform_broadcaster.cpp
+++ b/tf2_ros/src/static_transform_broadcaster.cpp
@@ -37,10 +37,6 @@
 
 namespace tf2_ros {
 
-StaticTransformBroadcaster::StaticTransformBroadcaster(rclcpp::Node::SharedPtr node)
-: StaticTransformBroadcaster(node->get_node_topics_interface())
-{}
-
 void StaticTransformBroadcaster::sendTransform(const geometry_msgs::msg::TransformStamped & msgtf)
 {
   std::vector<geometry_msgs::msg::TransformStamped> v1;

--- a/tf2_ros/src/transform_broadcaster.cpp
+++ b/tf2_ros/src/transform_broadcaster.cpp
@@ -37,11 +37,9 @@
 
 namespace tf2_ros {
 
-TransformBroadcaster::TransformBroadcaster(rclcpp::Node::SharedPtr node) :
-  node_(node)
-{
-  publisher_ = node_->create_publisher<tf2_msgs::msg::TFMessage>("/tf", 100);
-};
+TransformBroadcaster::TransformBroadcaster(rclcpp::Node::SharedPtr node)
+: TransformBroadcaster(node->get_node_topics_interface())
+{}
 
 void TransformBroadcaster::sendTransform(const geometry_msgs::msg::TransformStamped & msgtf)
 {
@@ -49,7 +47,6 @@ void TransformBroadcaster::sendTransform(const geometry_msgs::msg::TransformStam
   v1.push_back(msgtf);
   sendTransform(v1);
 }
-
 
 void TransformBroadcaster::sendTransform(const std::vector<geometry_msgs::msg::TransformStamped> & msgtf)
 {
@@ -60,6 +57,5 @@ void TransformBroadcaster::sendTransform(const std::vector<geometry_msgs::msg::T
   }
   publisher_->publish(message);
 }
-
 
 }

--- a/tf2_ros/src/transform_listener.cpp
+++ b/tf2_ros/src/transform_listener.cpp
@@ -40,19 +40,23 @@ using namespace tf2_ros;
 #define ROS_INFO printf
 #define ROS_WARN printf
 
-TransformListener::TransformListener(tf2::BufferCore& buffer, bool spin_thread):
-  dedicated_listener_thread_(NULL), buffer_(buffer), using_dedicated_thread_(false)
+TransformListener::TransformListener(tf2::BufferCore& buffer, bool spin_thread)
+: TransformListener(buffer, rclcpp::Node::make_shared("transform_listener_impl"), spin_thread)
 {
-  //TODO(tfoote)make this anonymous
-  node_ = rclcpp::Node::make_shared("transform_listener_impl");
-  init();
-  if (spin_thread)
-    initThread();
 }
 
 TransformListener::TransformListener(tf2::BufferCore& buffer, rclcpp::Node::SharedPtr nh, bool spin_thread)
+: TransformListener(buffer, nh->get_node_base_interface(), nh->get_node_topics_interface(), spin_thread)
+{
+}
+
+TransformListener::TransformListener(tf2::BufferCore& buffer,
+                                            const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr & node_base,
+                                            const rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr & node_topics,
+                                            bool spin_thread)
 : dedicated_listener_thread_(NULL)
-, node_(nh)
+, node_base_(node_base)
+, node_topics_(node_topics)
 , buffer_(buffer)
 , using_dedicated_thread_(false)
 {
@@ -60,7 +64,6 @@ TransformListener::TransformListener(tf2::BufferCore& buffer, rclcpp::Node::Shar
   if (spin_thread)
     initThread();
 }
-
 
 TransformListener::~TransformListener()
 {
@@ -78,30 +81,68 @@ void test_callback(const tf2_msgs::msg::TFMessage::SharedPtr msg){
 
 void TransformListener::init()
 {
-  message_subscription_tf_ = node_->create_subscription<tf2_msgs::msg::TFMessage>(
-    "/tf", 100, std::bind(&TransformListener::subscription_callback, this, std::placeholders::_1));
-  message_subscription_tf_static_ = node_->create_subscription<tf2_msgs::msg::TFMessage>(
-    "/tf_static",
-    100,
-    std::bind(&TransformListener::static_subscription_callback, this, std::placeholders::_1));
+  rmw_qos_profile_t custom_qos_profile = rmw_qos_profile_default;
+  custom_qos_profile.depth = 100;
+  std::function<void(const tf2_msgs::msg::TFMessage::SharedPtr)> standard_callback = std::bind(&TransformListener::subscription_callback, this, std::placeholders::_1);
+  message_subscription_tf_ = create_subscription<tf2_msgs::msg::TFMessage>("/tf", standard_callback, custom_qos_profile);
+  std::function<void(const tf2_msgs::msg::TFMessage::SharedPtr)> static_callback = std::bind(&TransformListener::static_subscription_callback, this, std::placeholders::_1);
+  message_subscription_tf_static_ = create_subscription<tf2_msgs::msg::TFMessage>("/tf_static", static_callback, custom_qos_profile);
 }
 
 void TransformListener::initThread()
 {
+
   using_dedicated_thread_ = true;
   // This lambda is required because `std::thread` cannot infer the correct
   // rclcpp::spin, since there are more than one versions of it (overloaded).
   // see: http://stackoverflow.com/a/27389714/671658
   // I (wjwwood) chose to use the lamda rather than the static cast solution.
-  auto run_func = [](rclcpp::Node::SharedPtr node) {
-    return rclcpp::spin(node);
+  auto run_func = [](rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base) {
+    return rclcpp::spin(node_base);
   };
-  dedicated_listener_thread_ = new std::thread(run_func, node_);
+  dedicated_listener_thread_ = new std::thread(run_func, node_base_);
   //Tell the buffer we have a dedicated thread to enable timeouts
   buffer_.setUsingDedicatedThread(true);
 }
 
+template<
+  typename MessageT,
+  typename CallbackT,
+  typename Alloc,
+  typename SubscriptionT>
+std::shared_ptr<SubscriptionT>
+TransformListener::create_subscription(
+  const std::string & topic_name,
+  CallbackT && callback,
+  const rmw_qos_profile_t & qos_profile,
+  rclcpp::callback_group::CallbackGroup::SharedPtr group,
+  bool ignore_local_publications,
+  typename rclcpp::message_memory_strategy::MessageMemoryStrategy<
+    typename rclcpp::subscription_traits::has_message_type<CallbackT>::type, Alloc>::SharedPtr
+  msg_mem_strat,
+  std::shared_ptr<Alloc> allocator )
+{
+    using CallbackMessageT = typename rclcpp::subscription_traits::has_message_type<CallbackT>::type;
 
+    if (!allocator) {
+      allocator = std::make_shared<Alloc>();
+    }
+
+    if (!msg_mem_strat) {
+      using rclcpp::message_memory_strategy::MessageMemoryStrategy;
+      msg_mem_strat = MessageMemoryStrategy<CallbackMessageT, Alloc>::create_default();
+    }
+
+  return rclcpp::create_subscription<MessageT, CallbackT, Alloc, CallbackMessageT, SubscriptionT>(node_topics_.get(),
+                              topic_name,
+                              std::forward<CallbackT>(callback),
+                              qos_profile,
+                              nullptr,
+                              false,
+                              false,
+                              msg_mem_strat,
+                              allocator);
+}
 
 void TransformListener::subscription_callback(const tf2_msgs::msg::TFMessage::SharedPtr msg)
 {

--- a/tf2_ros/src/transform_listener.cpp
+++ b/tf2_ros/src/transform_listener.cpp
@@ -29,79 +29,91 @@
 
 /** \author Tully Foote */
 
+#include <memory>
+#include <string>
+#include <utility>
+
 #include "tf2_ros/transform_listener.h"
 
 
 using namespace tf2_ros;
 
-//TODO(tfoote replace these terrible macros)
+// TODO(tfoote replace these terrible macros)
 #define ROS_ERROR printf
 #define ROS_FATAL printf
 #define ROS_INFO printf
 #define ROS_WARN printf
 
-TransformListener::TransformListener(tf2::BufferCore& buffer, bool spin_thread)
+TransformListener::TransformListener(tf2::BufferCore & buffer, bool spin_thread)
 : TransformListener(buffer, rclcpp::Node::make_shared("transform_listener_impl"), spin_thread)
 {
 }
 
-TransformListener::TransformListener(tf2::BufferCore& buffer, rclcpp::Node::SharedPtr nh, bool spin_thread)
-: TransformListener(buffer, nh->get_node_base_interface(), nh->get_node_topics_interface(), spin_thread)
+TransformListener::TransformListener(
+  tf2::BufferCore & buffer, rclcpp::Node::SharedPtr nh,
+  bool spin_thread)
+: TransformListener(buffer, nh->get_node_base_interface(),
+    nh->get_node_topics_interface(), spin_thread)
 {
 }
 
-TransformListener::TransformListener(tf2::BufferCore& buffer,
-                                            const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr & node_base,
-                                            const rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr & node_topics,
-                                            bool spin_thread)
-: dedicated_listener_thread_(NULL)
-, node_base_(node_base)
-, node_topics_(node_topics)
-, buffer_(buffer)
-, using_dedicated_thread_(false)
+TransformListener::TransformListener(
+  tf2::BufferCore & buffer,
+  const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr & node_base,
+  const rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr & node_topics,
+  bool spin_thread)
+: dedicated_listener_thread_(NULL),
+  node_base_(node_base),
+  node_topics_(node_topics),
+  buffer_(buffer),
+  using_dedicated_thread_(false)
 {
   init();
-  if (spin_thread)
+  if (spin_thread) {
     initThread();
+  }
 }
 
 TransformListener::~TransformListener()
 {
   using_dedicated_thread_ = false;
-  if (dedicated_listener_thread_)
-  {
+  if (dedicated_listener_thread_) {
     dedicated_listener_thread_->join();
     delete dedicated_listener_thread_;
   }
 }
 
-void test_callback(const tf2_msgs::msg::TFMessage::SharedPtr msg){
-  return;
+void test_callback(const tf2_msgs::msg::TFMessage::SharedPtr msg)
+{
 }
 
 void TransformListener::init()
 {
   rmw_qos_profile_t custom_qos_profile = rmw_qos_profile_default;
   custom_qos_profile.depth = 100;
-  std::function<void(const tf2_msgs::msg::TFMessage::SharedPtr)> standard_callback = std::bind(&TransformListener::subscription_callback, this, std::placeholders::_1);
-  message_subscription_tf_ = create_subscription<tf2_msgs::msg::TFMessage>("/tf", standard_callback, custom_qos_profile);
-  std::function<void(const tf2_msgs::msg::TFMessage::SharedPtr)> static_callback = std::bind(&TransformListener::static_subscription_callback, this, std::placeholders::_1);
-  message_subscription_tf_static_ = create_subscription<tf2_msgs::msg::TFMessage>("/tf_static", static_callback, custom_qos_profile);
+  std::function<void(const tf2_msgs::msg::TFMessage::SharedPtr)> standard_callback = std::bind(
+    &TransformListener::subscription_callback, this, std::placeholders::_1);
+  message_subscription_tf_ = create_subscription<tf2_msgs::msg::TFMessage>("/tf", standard_callback,
+      custom_qos_profile);
+  std::function<void(const tf2_msgs::msg::TFMessage::SharedPtr)> static_callback = std::bind(
+    &TransformListener::static_subscription_callback, this, std::placeholders::_1);
+  message_subscription_tf_static_ = create_subscription<tf2_msgs::msg::TFMessage>("/tf_static",
+      static_callback,
+      custom_qos_profile);
 }
 
 void TransformListener::initThread()
 {
-
   using_dedicated_thread_ = true;
   // This lambda is required because `std::thread` cannot infer the correct
   // rclcpp::spin, since there are more than one versions of it (overloaded).
   // see: http://stackoverflow.com/a/27389714/671658
   // I (wjwwood) chose to use the lamda rather than the static cast solution.
   auto run_func = [](rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base) {
-    return rclcpp::spin(node_base);
-  };
+      return rclcpp::spin(node_base);
+    };
   dedicated_listener_thread_ = new std::thread(run_func, node_base_);
-  //Tell the buffer we have a dedicated thread to enable timeouts
+  // Tell the buffer we have a dedicated thread to enable timeouts
   buffer_.setUsingDedicatedThread(true);
 }
 
@@ -120,28 +132,29 @@ TransformListener::create_subscription(
   typename rclcpp::message_memory_strategy::MessageMemoryStrategy<
     typename rclcpp::subscription_traits::has_message_type<CallbackT>::type, Alloc>::SharedPtr
   msg_mem_strat,
-  std::shared_ptr<Alloc> allocator )
+  std::shared_ptr<Alloc> allocator)
 {
-    using CallbackMessageT = typename rclcpp::subscription_traits::has_message_type<CallbackT>::type;
+  using CallbackMessageT = typename rclcpp::subscription_traits::has_message_type<CallbackT>::type;
 
-    if (!allocator) {
-      allocator = std::make_shared<Alloc>();
-    }
+  if (!allocator) {
+    allocator = std::make_shared<Alloc>();
+  }
 
-    if (!msg_mem_strat) {
-      using rclcpp::message_memory_strategy::MessageMemoryStrategy;
-      msg_mem_strat = MessageMemoryStrategy<CallbackMessageT, Alloc>::create_default();
-    }
+  if (!msg_mem_strat) {
+    using rclcpp::message_memory_strategy::MessageMemoryStrategy;
+    msg_mem_strat = MessageMemoryStrategy<CallbackMessageT, Alloc>::create_default();
+  }
 
-  return rclcpp::create_subscription<MessageT, CallbackT, Alloc, CallbackMessageT, SubscriptionT>(node_topics_.get(),
-                              topic_name,
-                              std::forward<CallbackT>(callback),
-                              qos_profile,
-                              nullptr,
-                              false,
-                              false,
-                              msg_mem_strat,
-                              allocator);
+  return rclcpp::create_subscription<MessageT, CallbackT, Alloc, CallbackMessageT, SubscriptionT>(
+    node_topics_.get(),
+    topic_name,
+    std::forward<CallbackT>(callback),
+    qos_profile,
+    nullptr,
+    false,
+    false,
+    msg_mem_strat,
+    allocator);
 }
 
 void TransformListener::subscription_callback(const tf2_msgs::msg::TFMessage::SharedPtr msg)
@@ -153,23 +166,22 @@ void TransformListener::static_subscription_callback(const tf2_msgs::msg::TFMess
   subscription_callback_impl(msg, true);
 }
 
-void TransformListener::subscription_callback_impl(const tf2_msgs::msg::TFMessage::SharedPtr msg, bool is_static)
+void TransformListener::subscription_callback_impl(
+  const tf2_msgs::msg::TFMessage::SharedPtr msg,
+  bool is_static)
 {
-  const tf2_msgs::msg::TFMessage& msg_in = *msg;
-  //TODO(tfoote) find a way to get the authority
-  std::string authority = "Authority undetectable"; //msg_evt.getPublisherName(); // lookup the authority
-  for (unsigned int i = 0; i < msg_in.transforms.size(); i++)
-  {
-    try
-    {
+  const tf2_msgs::msg::TFMessage & msg_in = *msg;
+  // TODO(tfoote) find a way to get the authority
+  std::string authority = "Authority undetectable";  // msg_evt.getPublisherName();  // lookup the authority
+  for (unsigned int i = 0; i < msg_in.transforms.size(); i++) {
+    try {
       buffer_.setTransform(msg_in.transforms[i], authority, is_static);
-    }
-    
-    catch (tf2::TransformException& ex)
-    {
-      ///\todo Use error reporting
+    } catch (tf2::TransformException & ex) {
+      // /\todo Use error reporting
       std::string temp = ex.what();
-      ROS_ERROR("Failure to set recieved transform from %s to %s with error: %s\n", msg_in.transforms[i].child_frame_id.c_str(), msg_in.transforms[i].header.frame_id.c_str(), temp.c_str());
+      ROS_ERROR("Failure to set recieved transform from %s to %s with error: %s\n",
+        msg_in.transforms[i].child_frame_id.c_str(),
+        msg_in.transforms[i].header.frame_id.c_str(), temp.c_str());
     }
   }
-};
+}

--- a/tf2_ros/src/transform_listener.cpp
+++ b/tf2_ros/src/transform_listener.cpp
@@ -46,16 +46,10 @@ using namespace tf2_ros;
 #define ROS_WARN printf
 
 TransformListener::TransformListener(tf2::BufferCore & buffer, bool spin_thread)
-: TransformListener(buffer, rclcpp::Node::make_shared("transform_listener_impl"), spin_thread)
+: buffer_(buffer),
+  optional_default_node_(rclcpp::Node::make_shared("transform_listener_impl"))
 {
-}
-
-TransformListener::TransformListener(
-  tf2::BufferCore & buffer, rclcpp::Node::SharedPtr nh,
-  bool spin_thread)
-: TransformListener(buffer, nh->get_node_base_interface(),
-    nh->get_node_topics_interface(), spin_thread)
-{
+  init(optional_default_node_, spin_thread);
 }
 
 TransformListener::~TransformListener()

--- a/tf2_ros/test/listener_unittest.cpp
+++ b/tf2_ros/test/listener_unittest.cpp
@@ -56,18 +56,11 @@ TEST(tf2_ros_transform, transform_listener)
 {
   tf2_ros::Buffer buffer;
   tf2_ros::TransformListener tfl(buffer);
+  
 
 }
 
 
-TEST(tf2_ros_transform, transform_listener_custom_rclcpp_node)
-{
-  tf2_ros::Buffer buffer;
-  tf2_ros::TransformListener tfl(buffer);
-
-
-
-}
 
 
 int main(int argc, char **argv){

--- a/tf2_ros/test/listener_unittest.cpp
+++ b/tf2_ros/test/listener_unittest.cpp
@@ -56,11 +56,18 @@ TEST(tf2_ros_transform, transform_listener)
 {
   tf2_ros::Buffer buffer;
   tf2_ros::TransformListener tfl(buffer);
-  
 
 }
 
 
+TEST(tf2_ros_transform, transform_listener_custom_rclcpp_node)
+{
+  tf2_ros::Buffer buffer;
+  tf2_ros::TransformListener tfl(buffer);
+
+
+
+}
 
 
 int main(int argc, char **argv){

--- a/tf2_ros/test/node_wrapper.hpp
+++ b/tf2_ros/test/node_wrapper.hpp
@@ -27,50 +27,27 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifndef NODE_WRAPPER_HPP_
+#define NODE_WRAPPER_HPP_
+
 #include <gtest/gtest.h>
-#include <tf2_ros/static_transform_broadcaster.h>
+#include <rclcpp/rclcpp.hpp>
 
-#include "node_wrapper.hpp"
-
-class CustomNode : public rclcpp::Node
+class NodeWrapper
 {
 public:
-  CustomNode()
-  : rclcpp::Node("tf2_ros_test_static_transform_broadcaster_node")
+  explicit NodeWrapper(const std::string & name)
+  : node(std::make_shared<rclcpp::Node>(name))
   {}
 
-  void init_tf_broadcaster()
-  {
-    tf_broadcaster_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(shared_from_this());
-  }
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr
+  get_node_base_interface() {return this->node->get_node_base_interface();}
+
+  rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr
+  get_node_topics_interface() {return this->node->get_node_topics_interface();}
 
 private:
-  std::shared_ptr<tf2_ros::StaticTransformBroadcaster> tf_broadcaster_;
+  rclcpp::Node::SharedPtr node;
 };
 
-TEST(tf2_test_static_transform_broadcaster, transform_broadcaster_rclcpp_node)
-{
-  auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
-
-  tf2_ros::StaticTransformBroadcaster tfb(node);
-}
-
-TEST(tf2_test_static_transform_broadcaster, transform_broadcaster_custom_rclcpp_node)
-{
-  auto node = std::make_shared<NodeWrapper>("tf2_ros_message_filter");
-
-  tf2_ros::StaticTransformBroadcaster tfb(node);
-}
-
-TEST(tf2_test_static_transform_broadcaster, transform_broadcaster_as_member)
-{
-  auto custom_node = std::make_shared<CustomNode>();
-  custom_node->init_tf_broadcaster();
-}
-
-int main(int argc, char ** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  rclcpp::init(argc, argv);
-  return RUN_ALL_TESTS();
-}
+#endif  // NODE_WRAPPER_HPP_

--- a/tf2_ros/test/test_static_transform_broadcaster.cpp
+++ b/tf2_ros/test/test_static_transform_broadcaster.cpp
@@ -48,6 +48,22 @@ private:
   rclcpp::Node::SharedPtr node;
 };
 
+class CustomNode : public rclcpp::Node
+{
+public:
+  CustomNode()
+  : rclcpp::Node("tf2_ros_test_static_transform_broadcaster_node")
+  {}
+
+  void init_tf_broadcaster()
+  {
+    tf_broadcaster_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(shared_from_this());
+  }
+
+private:
+  std::shared_ptr<tf2_ros::StaticTransformBroadcaster> tf_broadcaster_;
+};
+
 TEST(tf2_test_static_transform_broadcaster, transform_broadcaster_rclcpp_node)
 {
   auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
@@ -60,6 +76,12 @@ TEST(tf2_test_static_transform_broadcaster, transform_broadcaster_custom_rclcpp_
   auto node = std::make_shared<NodeWrapper>("tf2_ros_message_filter");
 
   tf2_ros::StaticTransformBroadcaster tfb(node);
+}
+
+TEST(tf2_test_static_transform_broadcaster, transform_broadcaster_as_member)
+{
+  auto custom_node = std::make_shared<CustomNode>();
+  custom_node->init_tf_broadcaster();
 }
 
 int main(int argc, char ** argv)

--- a/tf2_ros/test/test_static_transform_broadcaster.cpp
+++ b/tf2_ros/test/test_static_transform_broadcaster.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Open Source Robotics Foundation
+ * Copyright (c) 2019, Open Source Robotics Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/tf2_ros/test/test_static_transform_broadcaster.cpp
+++ b/tf2_ros/test/test_static_transform_broadcaster.cpp
@@ -1,10 +1,10 @@
 /*
- * Copyright (c) 2008, Willow Garage, Inc.
+ * Copyright (c) 2014, Open Source Robotics Foundation
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright
  *       notice, this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright
@@ -13,7 +13,7 @@
  *     * Neither the name of the Willow Garage, Inc. nor the names of its
  *       contributors may be used to endorse or promote products derived from
  *       this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -27,31 +27,44 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <gtest/gtest.h>
+#include <rclcpp/rclcpp.hpp>
+#include <tf2_ros/static_transform_broadcaster.h>
 
-/** \author Tully Foote */
-
-
-#include "rclcpp/rclcpp.hpp"
-#include "tf2_msgs/msg/tf_message.hpp"
-#include "tf2_ros/transform_broadcaster.h"
-
-namespace tf2_ros {
-
-void TransformBroadcaster::sendTransform(const geometry_msgs::msg::TransformStamped & msgtf)
+class NodeWrapper
 {
-  std::vector<geometry_msgs::msg::TransformStamped> v1;
-  v1.push_back(msgtf);
-  sendTransform(v1);
+public:
+  explicit NodeWrapper(const std::string & name)
+  : node(std::make_shared<rclcpp::Node>(name))
+  {}
+
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr
+  get_node_base_interface() {return this->node->get_node_base_interface();}
+
+  rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr
+  get_node_topics_interface() {return this->node->get_node_topics_interface();}
+
+private:
+  rclcpp::Node::SharedPtr node;
+};
+
+TEST(tf2_test_static_transform_broadcaster, transform_broadcaster_rclcpp_node)
+{
+  auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
+
+  tf2_ros::StaticTransformBroadcaster tfb(node);
 }
 
-void TransformBroadcaster::sendTransform(const std::vector<geometry_msgs::msg::TransformStamped> & msgtf)
+TEST(tf2_test_static_transform_broadcaster, transform_broadcaster_custom_rclcpp_node)
 {
-  tf2_msgs::msg::TFMessage message;
-  for (std::vector<geometry_msgs::msg::TransformStamped>::const_iterator it = msgtf.begin(); it != msgtf.end(); ++it)
-  {
-    message.transforms.push_back(*it);
-  }
-  publisher_->publish(message);
+  auto node = std::make_shared<NodeWrapper>("tf2_ros_message_filter");
+
+  tf2_ros::StaticTransformBroadcaster tfb(node);
 }
 
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  return RUN_ALL_TESTS();
 }

--- a/tf2_ros/test/test_transform_broadcaster.cpp
+++ b/tf2_ros/test/test_transform_broadcaster.cpp
@@ -28,25 +28,9 @@
  */
 
 #include <gtest/gtest.h>
-#include <rclcpp/rclcpp.hpp>
 #include <tf2_ros/transform_broadcaster.h>
 
-class NodeWrapper
-{
-public:
-  explicit NodeWrapper(const std::string & name)
-  : node(std::make_shared<rclcpp::Node>(name))
-  {}
-
-  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr
-  get_node_base_interface() {return this->node->get_node_base_interface();}
-
-  rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr
-  get_node_topics_interface() {return this->node->get_node_topics_interface();}
-
-private:
-  rclcpp::Node::SharedPtr node;
-};
+#include "node_wrapper.hpp"
 
 class CustomNode : public rclcpp::Node
 {

--- a/tf2_ros/test/test_transform_broadcaster.cpp
+++ b/tf2_ros/test/test_transform_broadcaster.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Open Source Robotics Foundation
+ * Copyright (c) 2019, Open Source Robotics Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/tf2_ros/test/test_transform_broadcaster.cpp
+++ b/tf2_ros/test/test_transform_broadcaster.cpp
@@ -1,10 +1,10 @@
 /*
- * Copyright (c) 2008, Willow Garage, Inc.
+ * Copyright (c) 2014, Open Source Robotics Foundation
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright
  *       notice, this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright
@@ -13,7 +13,7 @@
  *     * Neither the name of the Willow Garage, Inc. nor the names of its
  *       contributors may be used to endorse or promote products derived from
  *       this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -27,31 +27,44 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <gtest/gtest.h>
+#include <rclcpp/rclcpp.hpp>
+#include <tf2_ros/transform_broadcaster.h>
 
-/** \author Tully Foote */
-
-
-#include "rclcpp/rclcpp.hpp"
-#include "tf2_msgs/msg/tf_message.hpp"
-#include "tf2_ros/transform_broadcaster.h"
-
-namespace tf2_ros {
-
-void TransformBroadcaster::sendTransform(const geometry_msgs::msg::TransformStamped & msgtf)
+class NodeWrapper
 {
-  std::vector<geometry_msgs::msg::TransformStamped> v1;
-  v1.push_back(msgtf);
-  sendTransform(v1);
+public:
+  explicit NodeWrapper(const std::string & name)
+  : node(std::make_shared<rclcpp::Node>(name))
+  {}
+
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr
+  get_node_base_interface() {return this->node->get_node_base_interface();}
+
+  rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr
+  get_node_topics_interface() {return this->node->get_node_topics_interface();}
+
+private:
+  rclcpp::Node::SharedPtr node;
+};
+
+TEST(tf2_test_transform_broadcaster, transform_broadcaster_rclcpp_node)
+{
+  auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
+
+  tf2_ros::TransformBroadcaster tfb(node);
 }
 
-void TransformBroadcaster::sendTransform(const std::vector<geometry_msgs::msg::TransformStamped> & msgtf)
+TEST(tf2_test_transform_broadcaster, transform_broadcaster_custom_rclcpp_node)
 {
-  tf2_msgs::msg::TFMessage message;
-  for (std::vector<geometry_msgs::msg::TransformStamped>::const_iterator it = msgtf.begin(); it != msgtf.end(); ++it)
-  {
-    message.transforms.push_back(*it);
-  }
-  publisher_->publish(message);
+  auto node = std::make_shared<NodeWrapper>("tf2_ros_message_filter");
+
+  tf2_ros::TransformBroadcaster tfb(node);
 }
 
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  return RUN_ALL_TESTS();
 }

--- a/tf2_ros/test/test_transform_broadcaster.cpp
+++ b/tf2_ros/test/test_transform_broadcaster.cpp
@@ -48,6 +48,22 @@ private:
   rclcpp::Node::SharedPtr node;
 };
 
+class CustomNode : public rclcpp::Node
+{
+public:
+  CustomNode()
+  : rclcpp::Node("tf2_ros_test_transform_broadcaster_node")
+  {}
+
+  void init_tf_broadcaster()
+  {
+    tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(shared_from_this());
+  }
+
+private:
+  std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
+};
+
 TEST(tf2_test_transform_broadcaster, transform_broadcaster_rclcpp_node)
 {
   auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
@@ -60,6 +76,12 @@ TEST(tf2_test_transform_broadcaster, transform_broadcaster_custom_rclcpp_node)
   auto node = std::make_shared<NodeWrapper>("tf2_ros_message_filter");
 
   tf2_ros::TransformBroadcaster tfb(node);
+}
+
+TEST(tf2_test_transform_broadcaster, transform_broadcaster_as_member)
+{
+  auto custom_node = std::make_shared<CustomNode>();
+  custom_node->init_tf_broadcaster();
 }
 
 int main(int argc, char ** argv)

--- a/tf2_ros/test/test_transform_listener.cpp
+++ b/tf2_ros/test/test_transform_listener.cpp
@@ -28,25 +28,9 @@
  */
 
 #include <gtest/gtest.h>
-#include <rclcpp/rclcpp.hpp>
 #include <tf2_ros/transform_listener.h>
 
-class NodeWrapper
-{
-public:
-  explicit NodeWrapper(const std::string & name)
-  : node(std::make_shared<rclcpp::Node>(name))
-  {}
-
-  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr
-  get_node_base_interface() {return this->node->get_node_base_interface();}
-
-  rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr
-  get_node_topics_interface() {return this->node->get_node_topics_interface();}
-
-private:
-  rclcpp::Node::SharedPtr node;
-};
+#include "node_wrapper.hpp"
 
 class CustomNode : public rclcpp::Node
 {

--- a/tf2_ros/test/test_transform_listener.cpp
+++ b/tf2_ros/test/test_transform_listener.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Open Source Robotics Foundation
+ * Copyright (c) 2019, Open Source Robotics Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/tf2_ros/test/test_transform_listener.cpp
+++ b/tf2_ros/test/test_transform_listener.cpp
@@ -1,10 +1,10 @@
 /*
- * Copyright (c) 2008, Willow Garage, Inc.
+ * Copyright (c) 2014, Open Source Robotics Foundation
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright
  *       notice, this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright
@@ -13,7 +13,7 @@
  *     * Neither the name of the Willow Garage, Inc. nor the names of its
  *       contributors may be used to endorse or promote products derived from
  *       this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -27,31 +27,48 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <gtest/gtest.h>
+#include <rclcpp/rclcpp.hpp>
+#include <tf2_ros/transform_listener.h>
 
-/** \author Tully Foote */
-
-
-#include "rclcpp/rclcpp.hpp"
-#include "tf2_msgs/msg/tf_message.hpp"
-#include "tf2_ros/transform_broadcaster.h"
-
-namespace tf2_ros {
-
-void TransformBroadcaster::sendTransform(const geometry_msgs::msg::TransformStamped & msgtf)
+class NodeWrapper
 {
-  std::vector<geometry_msgs::msg::TransformStamped> v1;
-  v1.push_back(msgtf);
-  sendTransform(v1);
+public:
+  explicit NodeWrapper(const std::string & name)
+  : node(std::make_shared<rclcpp::Node>(name))
+  {}
+
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr
+  get_node_base_interface() {return this->node->get_node_base_interface();}
+
+  rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr
+  get_node_topics_interface() {return this->node->get_node_topics_interface();}
+
+private:
+  rclcpp::Node::SharedPtr node;
+};
+
+TEST(tf2_test_transform_listener, transform_listener_rclcpp_node)
+{
+  auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
+
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+  tf2_ros::Buffer buffer(clock);
+  tf2_ros::TransformListener tfl(buffer, node, false);
 }
 
-void TransformBroadcaster::sendTransform(const std::vector<geometry_msgs::msg::TransformStamped> & msgtf)
+TEST(tf2_test_transform_listener, transform_listener_custom_rclcpp_node)
 {
-  tf2_msgs::msg::TFMessage message;
-  for (std::vector<geometry_msgs::msg::TransformStamped>::const_iterator it = msgtf.begin(); it != msgtf.end(); ++it)
-  {
-    message.transforms.push_back(*it);
-  }
-  publisher_->publish(message);
+  auto node = std::make_shared<NodeWrapper>("tf2_ros_message_filter");
+
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+  tf2_ros::Buffer buffer(clock);
+  tf2_ros::TransformListener tfl(buffer, node, false);
 }
 
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  return RUN_ALL_TESTS();
 }

--- a/tf2_ros/test/test_transform_listener.cpp
+++ b/tf2_ros/test/test_transform_listener.cpp
@@ -48,6 +48,24 @@ private:
   rclcpp::Node::SharedPtr node;
 };
 
+class CustomNode : public rclcpp::Node
+{
+public:
+  CustomNode()
+  : rclcpp::Node("tf2_ros_test_transform_listener_node")
+  {}
+
+  void init_tf_listener()
+  {
+    rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+    tf2_ros::Buffer buffer(clock);
+    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(buffer, shared_from_this(), false);
+  }
+
+private:
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+};
+
 TEST(tf2_test_transform_listener, transform_listener_rclcpp_node)
 {
   auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
@@ -64,6 +82,12 @@ TEST(tf2_test_transform_listener, transform_listener_custom_rclcpp_node)
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
   tf2_ros::Buffer buffer(clock);
   tf2_ros::TransformListener tfl(buffer, node, false);
+}
+
+TEST(tf2_test_transform_listener, transform_listener_as_member)
+{
+  auto custom_node = std::make_shared<CustomNode>();
+  custom_node->init_tf_listener();
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
this PR is based on https://github.com/ros2/geometry2/pull/100 and rebased on top of current ros2 master.

It is using the node interfaces consistently throughout the `static_transform_broadcaster`, `transform_broadcaster` and `transform_listener`.

this should fix, provide solutions for lifecycle nodes. See #94 and #70 