### PR TITLE
Remove stray semicolon causing compiler error when using -Werror=pedantic

### DIFF
--- a/tf2_ros/include/tf2_ros/transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/transform_broadcaster.h
@@ -57,7 +57,7 @@ public:
   {
     publisher_ = rclcpp::create_publisher<tf2_msgs::msg::TFMessage>(
       node, "/tf", qos, options);
-  };
+  }
 
   /** \brief Send a StampedTransform
    * The stamped data structure includes frame_id, and time, and parent_id already.  */


### PR DESCRIPTION
No semi required after class method. 