### PR TITLE
stop spinning TransformListener thread node in destructor

### DIFF
--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -61,7 +61,8 @@ public:
     const rclcpp::QoS & qos = rclcpp::QoS(100),
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options =
       rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>())
-  : buffer_(buffer)
+  : buffer_(buffer),
+    stop_thread_(false)
   {
     init(node, spin_thread, qos, options);
   }
@@ -116,6 +117,7 @@ private:
   rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr message_subscription_tf_;
   rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr message_subscription_tf_static_;
   tf2::BufferCore & buffer_;
+  std::atomic<bool> stop_thread_;
   tf2::TimePoint last_update_;
 };
 }  // namespace tf2_ros

--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -61,8 +61,7 @@ public:
     const rclcpp::QoS & qos = rclcpp::QoS(100),
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options =
       rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>())
-  : buffer_(buffer),
-    stop_thread_(false)
+  : buffer_(buffer)
   {
     init(node, spin_thread, qos, options);
   }
@@ -117,7 +116,7 @@ private:
   rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr message_subscription_tf_;
   rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr message_subscription_tf_static_;
   tf2::BufferCore & buffer_;
-  std::atomic<bool> stop_thread_;
+  std::atomic<bool> stop_thread_{false};
   tf2::TimePoint last_update_;
 };
 }  // namespace tf2_ros

--- a/tf2_ros/src/transform_listener.cpp
+++ b/tf2_ros/src/transform_listener.cpp
@@ -66,7 +66,7 @@ void TransformListener::initThread(
   // see: http://stackoverflow.com/a/27389714/671658
   // I (wjwwood) chose to use the lamda rather than the static cast solution.
   auto run_func = [&](rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface) {
-      while (!stop_thread_) {rclcpp::spin_some(node_base_interface);}
+      while (!stop_thread_ && rclcpp::ok()) {rclcpp::spin_some(node_base_interface);}
     };
   dedicated_listener_thread_ = thread_ptr(
     new std::thread(run_func, node_base_interface),

--- a/tf2_ros/src/transform_listener.cpp
+++ b/tf2_ros/src/transform_listener.cpp
@@ -54,17 +54,19 @@ TransformListener::TransformListener(tf2::BufferCore & buffer, bool spin_thread)
 
 TransformListener::~TransformListener()
 {
+  stop_thread_ = true;
 }
 
 void TransformListener::initThread(
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface)
 {
+  stop_thread_ = false;
   // This lambda is required because `std::thread` cannot infer the correct
   // rclcpp::spin, since there are more than one versions of it (overloaded).
   // see: http://stackoverflow.com/a/27389714/671658
   // I (wjwwood) chose to use the lamda rather than the static cast solution.
-  auto run_func = [](rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface) {
-      return rclcpp::spin(node_base_interface);
+  auto run_func = [&](rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface) {
+      while (!stop_thread_) {rclcpp::spin_some(node_base_interface);}
     };
   dedicated_listener_thread_ = thread_ptr(
     new std::thread(run_func, node_base_interface),


### PR DESCRIPTION
The `TransformListener` thread spins a node and cannot be cleanly deleted until `rclcpp::shutdown` is called . This causes hanging issues if trying to do cleanup and destruction before`rclcpp::shutdown`, particularly an issue when creating gtests. This PR stops the thread spinning the node when the destructor is called.

Signed-off-by: bpwilcox <bpwilcox@eng.ucsd.edu>
