### PR TITLE
Add tf2_ros::async_wait_for_transform()

### DIFF
--- a/tf2_ros/CMakeLists.txt
+++ b/tf2_ros/CMakeLists.txt
@@ -33,7 +33,9 @@ include_directories(include
 
 # tf2_ros library
 add_library(${PROJECT_NAME} SHARED
+  src/async_wait_for_transform.cpp
   src/buffer.cpp
+  src/gated_callback_caller.cpp
   src/transform_listener.cpp
   # src/buffer_client.cpp
   # src/buffer_server.cpp
@@ -123,6 +125,9 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   ament_add_gtest(test_buffer test/test_buffer.cpp)
   target_link_libraries(test_buffer ${PROJECT_NAME})
+
+  ament_add_gtest(test_async_wait_for_transform test/test_async_wait_for_transform.cpp)
+  target_link_libraries(test_async_wait_for_transform ${PROJECT_NAME})
 
   # Adds a tf2_ros message_filter unittest that uses
   # multiple target frames and a non-zero time tolerance

--- a/tf2_ros/include/tf2_ros/async_wait_for_transform.hpp
+++ b/tf2_ros/include/tf2_ros/async_wait_for_transform.hpp
@@ -1,0 +1,101 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TF2_ROS__ASYNC_WAIT_FOR_TRANSFORM_HPP_
+#define TF2_ROS__ASYNC_WAIT_FOR_TRANSFORM_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+#include <tf2_ros/buffer_interface.h>
+#include <tf2_ros/visibility_control.h>
+
+#include <future>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace tf2_ros
+{
+typedef std::function<void (const geometry_msgs::msg::TransformStamped &)> TransformCallback;
+
+/// \brief Asyncronously wait for a transform (by polling).
+/// \internal
+///
+/// \param[in] base_interface A node base interface for a node that will be executed while waiting
+/// \param[in] timer_interface interface on the same node that will be executed
+/// \param[in] clock a clock to get the current time for detecting a timeout
+/// \param[in] buffer_ the tf2 buffer to use to lookup the transform
+/// \param[in] target_frame frame to transform to
+/// \param[in] source_frame frame to transform from
+/// \param[in] timeout how long to wait for the transform
+/// \param[in] callback a function to call when the timer is ready
+/// \param[in] period how often to check if the transform is ready
+/// \param[in] group the callback group to add the polling timer to
+TF2_ROS_PUBLIC
+std::shared_ptr<std::shared_future<geometry_msgs::msg::TransformStamped>>
+async_wait_for_transform(
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr base_interface,
+  rclcpp::node_interfaces::NodeTimersInterface::SharedPtr timer_interface,
+  rclcpp::Clock::SharedPtr clock,
+  std::shared_ptr<tf2_ros::BufferInterface> buffer_,
+  std::string target_frame,
+  std::string source_frame,
+  rclcpp::Time transform_time,
+  rclcpp::Duration timeout,
+  TransformCallback callback,
+  rclcpp::Duration period,
+  rclcpp::callback_group::CallbackGroup::SharedPtr group);
+
+/// \brief Asyncronously wait for a transform (by polling).
+///
+/// The returned share_ptr must be kept alive while waiting for the transform.
+/// The callback will only be called if the transform was successfully gotten.
+/// A timeout will result in an exception on the returned future.
+///
+/// \param[in] node a node class that will be executed while waiting
+/// \param[in] target_frame frame to transform to
+/// \param[in] source_frame frame to transform from
+/// \param[in] timeout how long to wait for the transform
+/// \param[in] callback a function to call when the timer is ready
+/// \param[in] period how often to check if the transform is ready
+/// \param[in] group the callback group to add the polling timer to
+/// \return a shared_ptr to a future that holds the result.
+template<typename NodePtr>
+std::shared_ptr<std::shared_future<geometry_msgs::msg::TransformStamped>>
+async_wait_for_transform(
+  NodePtr node,
+  std::shared_ptr<tf2_ros::BufferInterface> buffer,
+  std::string target_frame,
+  std::string source_frame,
+  rclcpp::Time transform_time,
+  rclcpp::Duration timeout,
+  TransformCallback callback = nullptr,
+  rclcpp::Duration period = std::chrono::milliseconds(10),  // 100Hz
+  rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr)
+{
+  return async_wait_for_transform(
+    node->get_node_base_interface(),
+    node->get_node_timers_interface(),
+    node->get_node_clock_interface()->get_clock(),
+    buffer,
+    target_frame,
+    source_frame,
+    transform_time,
+    timeout,
+    callback,
+    period,
+    group);
+}
+}  // namespace tf2_ros
+
+#endif  // TF2_ROS__ASYNC_WAIT_FOR_TRANSFORM_HPP_

--- a/tf2_ros/include/tf2_ros/gated_callback_caller.hpp
+++ b/tf2_ros/include/tf2_ros/gated_callback_caller.hpp
@@ -1,0 +1,63 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TF2_ROS__GATED_CALLBACK_CALLER_HPP_
+#define TF2_ROS__GATED_CALLBACK_CALLER_HPP_
+
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <tf2_ros/async_wait_for_transform.hpp>
+#include <tf2_ros/visibility_control.h>
+
+#include <functional>
+#include <mutex>
+#include <vector>
+
+namespace tf2_ros
+{
+/// \brief Helper to call callback only after all transforms have been received.
+class GatedCallbackCaller
+{
+public:
+  using GatedCallback = std::function<void (const std::vector<geometry_msgs::msg::TransformStamped> &)>;
+
+  /// \brief Create a helper that calls callback once a number of transforms have been received
+  /// \param[in] expected_transforms the number of transforms to wait for
+  /// \param[in] callback the callback to call once all transforms are ready
+  TF2_ROS_PUBLIC
+  GatedCallbackCaller(size_t expected_transforms, GatedCallback callback);
+
+  TF2_ROS_PUBLIC
+  virtual ~GatedCallbackCaller() = default;
+
+  /// \brief Get a callback for a specific call to `async_wait_for_transform()`
+  /// \param[in] idx index in vector passed to gated callback of transform received by this callback
+  TF2_ROS_PUBLIC
+  TransformCallback
+  callback_at(size_t idx);
+
+private:
+  TF2_ROS_LOCAL
+  void
+  operator()(size_t idx, const geometry_msgs::msg::TransformStamped & transform);
+
+  std::mutex mtx_;
+
+  size_t callbacks_rx_ = 0;
+  const size_t expected_transforms_;
+  const GatedCallback callback_;
+  std::vector<geometry_msgs::msg::TransformStamped> transforms_;
+};
+}  // namespace tf2_ros
+
+#endif  // TF2_ROS__GATED_CALLBACK_CALLER_HPP_

--- a/tf2_ros/src/async_wait_for_transform.cpp
+++ b/tf2_ros/src/async_wait_for_transform.cpp
@@ -1,0 +1,130 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <tf2_ros/async_wait_for_transform.hpp>
+
+namespace tf2_ros
+{
+/// \brief Helper class that creates a timer to poll for a transform
+/// \internal
+class TransformWaiter
+{
+public:
+
+  TransformWaiter(
+    rclcpp::node_interfaces::NodeTimersInterface::SharedPtr node_timers,
+    rclcpp::Clock::SharedPtr clock,
+    std::shared_ptr<tf2_ros::BufferInterface> buffer,
+    std::string target_frame,
+    std::string source_frame,
+    rclcpp::Time transform_time,
+    rclcpp::Duration timeout,
+    TransformCallback callback,
+    rclcpp::Duration period,
+    rclcpp::callback_group::CallbackGroup::SharedPtr group,
+    rclcpp::Context::SharedPtr context)
+    :
+    promise_(),
+    future_(promise_.get_future()),
+    buffer_(buffer),
+    clock_(clock),
+    target_frame_(target_frame),
+    source_frame_(source_frame),
+    tf_time_(tf2::timeFromSec(transform_time.seconds())),
+    callback_(callback)
+  {
+    end_time_ = clock_->now() + timeout;
+    // create a timer and add it to the node
+    timer_ = rclcpp::GenericTimer<std::function<void ()>>::make_shared(
+      clock,
+      period.to_chrono<std::chrono::nanoseconds>(),
+      std::bind(&TransformWaiter::on_timer, this),
+      context);
+
+    node_timers->add_timer(timer_, group);
+  }
+
+private:
+  // must put this before future_ so it is constructed first
+  std::promise<geometry_msgs::msg::TransformStamped> promise_;
+
+public:
+  std::shared_future<geometry_msgs::msg::TransformStamped> future_;
+
+private:
+  void on_timer()
+  {
+    try {
+      // Get the transform
+      geometry_msgs::msg::TransformStamped transform = buffer_->lookupTransform(
+        target_frame_, source_frame_, tf_time_, std::chrono::nanoseconds(0));
+
+      promise_.set_value(transform);
+      timer_->cancel();
+
+      if (callback_) {
+        callback_(transform);
+      }
+    } catch (const tf2::TransformException &) {
+      // transform not available
+      if (clock_->now() >= end_time_) {
+        // Timeout reached
+        timer_->cancel();
+        promise_.set_exception(std::current_exception());
+      }
+    }
+  }
+
+  std::shared_ptr<tf2_ros::BufferInterface> buffer_;
+  rclcpp::Clock::SharedPtr clock_;
+  std::string target_frame_;
+  std::string source_frame_;
+  tf2::TimePoint tf_time_;
+  TransformCallback callback_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  rclcpp::Time end_time_;
+};
+
+std::shared_ptr<std::shared_future<geometry_msgs::msg::TransformStamped>>
+async_wait_for_transform(
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr base_interface,
+  rclcpp::node_interfaces::NodeTimersInterface::SharedPtr timer_interface,
+  rclcpp::Clock::SharedPtr clock,
+  std::shared_ptr<tf2_ros::BufferInterface> buffer,
+  std::string target_frame,
+  std::string source_frame,
+  rclcpp::Time transform_time,
+  rclcpp::Duration timeout,
+  TransformCallback callback,
+  rclcpp::Duration period,
+  rclcpp::callback_group::CallbackGroup::SharedPtr group)
+{
+  auto waiter = std::make_shared<TransformWaiter>(
+    timer_interface,
+    clock,
+    buffer,
+    target_frame,
+    source_frame,
+    transform_time,
+    timeout,
+    callback,
+    period,
+    group,
+    base_interface->get_context());
+
+  // return shared_ptr to waiter aliased to the future
+  return std::shared_ptr<std::shared_future<geometry_msgs::msg::TransformStamped>>(
+    waiter, &(waiter->future_));
+}
+}  // namespace tf2_ros

--- a/tf2_ros/src/gated_callback_caller.cpp
+++ b/tf2_ros/src/gated_callback_caller.cpp
@@ -1,0 +1,46 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <tf2_ros/gated_callback_caller.hpp>
+
+#include <stdexcept>
+
+namespace tf2_ros
+{
+GatedCallbackCaller::GatedCallbackCaller(size_t expected_transforms, GatedCallback callback)
+  : expected_transforms_(expected_transforms), callback_(callback)
+{
+  transforms_.resize(expected_transforms);
+}
+
+TransformCallback
+GatedCallbackCaller::callback_at(size_t idx)
+{
+  if (idx >= transforms_.size()) {
+    throw std::out_of_range("Asked for more callbacks than instance expected.");
+  }
+  return std::bind(&GatedCallbackCaller::operator(), this, idx, std::placeholders::_1);
+}
+
+void
+GatedCallbackCaller::operator()(size_t idx, const geometry_msgs::msg::TransformStamped & transform)
+{
+  std::unique_lock<std::mutex> lock(mtx_);
+  ++callbacks_rx_;
+  transforms_.at(idx) = transform;
+  if (callbacks_rx_ == expected_transforms_) {
+    callback_(transforms_);
+  }
+}
+}  // namespace tf2_ros

--- a/tf2_ros/test/test_async_wait_for_transform.cpp
+++ b/tf2_ros/test/test_async_wait_for_transform.cpp
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2019, Open Source Robotics Foundation, Inc.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gtest/gtest.h>
+
+#include <tf2_ros/async_wait_for_transform.hpp>
+#include <tf2_ros/gated_callback_caller.hpp>
+
+#include <rclcpp/executors.hpp>
+#include <rclcpp/utilities.hpp>
+
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/transform_listener.h>
+
+#include <atomic>
+
+class AsyncWaitForTransformTest : public ::testing::Test {
+ protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+    rclcpp::NodeOptions opts;
+    node_ = std::make_shared<rclcpp::Node>("test_async_wait_for_transform", opts);
+
+    // Create buffer/listener using existing node and rclcpp executor
+    buffer_ = std::make_shared<tf2_ros::Buffer>(node_->get_clock());
+    const bool use_tf_background_thread = false;
+    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(
+      *buffer_,
+      node_,
+      use_tf_background_thread);
+    buffer_->setUsingDedicatedThread(true);
+
+    broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(node_);
+  }
+
+  void TearDown() override
+  {
+    rclcpp::shutdown();
+  }
+
+  rclcpp::Node::SharedPtr node_;
+  std::shared_ptr<tf2_ros::Buffer> buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+  std::shared_ptr<tf2_ros::TransformBroadcaster> broadcaster_;
+};
+
+
+TEST_F(AsyncWaitForTransformTest, get_transform_async)
+{
+  std::atomic<bool> got_transform{false};
+  std::shared_ptr<std::shared_future<geometry_msgs::msg::TransformStamped>> future_ptr;
+
+  // asynchronously get the transform using the executor
+  future_ptr = async_wait_for_transform(
+    node_,
+    buffer_,
+    "foo",
+    "bar",
+    rclcpp::Time(123, 456),
+    rclcpp::Duration(std::chrono::milliseconds(500)),
+    [&got_transform] (const geometry_msgs::msg::TransformStamped &) {
+      got_transform = true;
+    });
+
+  // Send the transform being waited for
+  geometry_msgs::msg::TransformStamped transform;
+  transform.header.frame_id = "foo";
+  transform.header.stamp.sec = 123;
+  transform.header.stamp.nanosec = 456;
+  transform.child_frame_id = "bar";
+  transform.transform.rotation.w = 1.0;
+  broadcaster_->sendTransform(transform);
+
+  rclcpp::spin_until_future_complete(node_, *future_ptr);
+  EXPECT_TRUE(got_transform.load());
+}
+
+TEST_F(AsyncWaitForTransformTest, get_transform_async_gated)
+{
+  std::atomic<bool> got_transform{false};
+  std::shared_ptr<std::shared_future<geometry_msgs::msg::TransformStamped>> first_future_ptr;
+  std::shared_ptr<std::shared_future<geometry_msgs::msg::TransformStamped>> second_future_ptr;
+
+  const size_t num_transforms = 2;
+  tf2_ros::GatedCallbackCaller gcbc(
+    num_transforms,
+    [&got_transform](const std::vector<geometry_msgs::msg::TransformStamped> &) {
+      got_transform = true;
+    });
+
+  // asynchronously get the transform using the executor
+  first_future_ptr = async_wait_for_transform(
+    node_,
+    buffer_,
+    "ping",
+    "pong",
+    rclcpp::Time(123, 456),
+    rclcpp::Duration(std::chrono::milliseconds(500)),
+    gcbc.callback_at(0));
+
+  second_future_ptr = async_wait_for_transform(
+    node_,
+    buffer_,
+    "marco",
+    "polo",
+    rclcpp::Time(123, 456),
+    rclcpp::Duration(std::chrono::milliseconds(500)),
+    gcbc.callback_at(1));
+
+  // Send the transform being waited for
+  geometry_msgs::msg::TransformStamped transform;
+  transform.header.frame_id = "ping";
+  transform.header.stamp.sec = 123;
+  transform.header.stamp.nanosec = 456;
+  transform.child_frame_id = "pong";
+  transform.transform.rotation.w = 1.0;
+  broadcaster_->sendTransform(transform);
+
+  rclcpp::spin_until_future_complete(node_, *first_future_ptr);
+  EXPECT_FALSE(got_transform.load());
+
+  transform.header.frame_id = "marco";
+  transform.child_frame_id = "polo";
+  broadcaster_->sendTransform(transform);
+
+  rclcpp::spin_until_future_complete(node_, *second_future_ptr);
+  EXPECT_TRUE(got_transform.load());
+}


### PR DESCRIPTION
This PR adds `tf2_ros::async_wait_for_transform()`. It calls a callback when a transform is ready. This avoids creating a dedicated node and thread for each transform listener, and it works even if the executor is single threaded.

Internally it creates a timer with a callback that polls for the transform. If it becomes available before the timeout then the user's callback is called with the transform. If a timeout occurs then the tf2 exception is set on the returned future.

This PR also adds a class `tf2_ros::GatedCallbackCaller`. It waits for a bunch of transforms in parallel, and calls one callback once all of them are ready.