### PR TITLE
Fix high CPU - Use executor to spin and stop node in tf_listener thread

### DIFF
--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -116,7 +116,6 @@ private:
   rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr message_subscription_tf_;
   rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr message_subscription_tf_static_;
   tf2::BufferCore & buffer_;
-  std::unique_ptr<rclcpp::executors::SingleThreadedExecutor> executor_;
   tf2::TimePoint last_update_;
 };
 }  // namespace tf2_ros

--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -116,7 +116,8 @@ private:
   rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr message_subscription_tf_;
   rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr message_subscription_tf_static_;
   tf2::BufferCore & buffer_;
-  std::atomic<bool> stop_thread_{false};
+  std::unique_ptr<rclcpp::executors::SingleThreadedExecutor> executor_;
+  bool spin_thread_{false};
   tf2::TimePoint last_update_;
 };
 }  // namespace tf2_ros

--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -117,7 +117,6 @@ private:
   rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr message_subscription_tf_static_;
   tf2::BufferCore & buffer_;
   std::unique_ptr<rclcpp::executors::SingleThreadedExecutor> executor_;
-  bool spin_thread_{false};
   tf2::TimePoint last_update_;
 };
 }  // namespace tf2_ros

--- a/tf2_ros/src/transform_listener.cpp
+++ b/tf2_ros/src/transform_listener.cpp
@@ -54,27 +54,27 @@ TransformListener::TransformListener(tf2::BufferCore & buffer, bool spin_thread)
 
 TransformListener::~TransformListener()
 {
-  if (executor_) {
-  executor_->cancel();
-  }
 }
 
 void TransformListener::initThread(
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface)
 {
-  executor_ = std::make_unique<rclcpp::executors::SingleThreadedExecutor>();
+  auto executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+
   // This lambda is required because `std::thread` cannot infer the correct
   // rclcpp::spin, since there are more than one versions of it (overloaded).
   // see: http://stackoverflow.com/a/27389714/671658
   // I (wjwwood) chose to use the lamda rather than the static cast solution.
-  auto run_func = [&](rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface) {
-      executor_->add_node(node_base_interface);
-      executor_->spin();
-      executor_->remove_node(node_base_interface);
+  auto run_func =
+    [executor](rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface) {
+      executor->add_node(node_base_interface);
+      executor->spin();
+      executor->remove_node(node_base_interface);
     };
   dedicated_listener_thread_ = thread_ptr(
     new std::thread(run_func, node_base_interface),
-    [](std::thread * t) {
+    [executor](std::thread * t) {
+      executor->cancel();
       t->join();
       delete t;
       // TODO(tfoote) reenable callback queue processing

--- a/tf2_ros/src/transform_listener.cpp
+++ b/tf2_ros/src/transform_listener.cpp
@@ -54,19 +54,24 @@ TransformListener::TransformListener(tf2::BufferCore & buffer, bool spin_thread)
 
 TransformListener::~TransformListener()
 {
-  stop_thread_ = true;
+  if (spin_thread_) {
+  executor_->cancel();
+  }
 }
 
 void TransformListener::initThread(
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface)
 {
-  stop_thread_ = false;
+  executor_ = std::make_unique<rclcpp::executors::SingleThreadedExecutor>();
+  spin_thread_ = true;
   // This lambda is required because `std::thread` cannot infer the correct
   // rclcpp::spin, since there are more than one versions of it (overloaded).
   // see: http://stackoverflow.com/a/27389714/671658
   // I (wjwwood) chose to use the lamda rather than the static cast solution.
   auto run_func = [&](rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface) {
-      while (!stop_thread_ && rclcpp::ok()) {rclcpp::spin_some(node_base_interface);}
+      executor_->add_node(node_base_interface);
+      executor_->spin();
+      executor_->remove_node(node_base_interface);
     };
   dedicated_listener_thread_ = thread_ptr(
     new std::thread(run_func, node_base_interface),

--- a/tf2_ros/src/transform_listener.cpp
+++ b/tf2_ros/src/transform_listener.cpp
@@ -54,7 +54,7 @@ TransformListener::TransformListener(tf2::BufferCore & buffer, bool spin_thread)
 
 TransformListener::~TransformListener()
 {
-  if (spin_thread_) {
+  if (executor_) {
   executor_->cancel();
   }
 }
@@ -63,7 +63,6 @@ void TransformListener::initThread(
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface)
 {
   executor_ = std::make_unique<rclcpp::executors::SingleThreadedExecutor>();
-  spin_thread_ = true;
   // This lambda is required because `std::thread` cannot infer the correct
   // rclcpp::spin, since there are more than one versions of it (overloaded).
   // see: http://stackoverflow.com/a/27389714/671658


### PR DESCRIPTION
Previously, #114 resolved the issue of terminating the work in the thread spinning the node which lead to hanging and unclean shutdown when destructing the node. However, the current implementation runs in a tight loop using `rclcpp::spin_some`, which leads to very high and inefficient cpu usage even when there is no work to be processed.

This problem was resolved in https://github.com/ros-planning/navigation2/pull/866, by putting the node on an executor and spinning. As opposed to `rclcpp::spin`, this change allows the executor to manage the termination of the spin thread by calling `executor->cancel` in the destructor. This pattern seems to work well when needing to cleanly join a thread spinning a node.