### PR TITLE
Add tf2::BufferCoreInterface and tf2_ros::AsyncBufferInterface to use in tf2_ros::MessageFilter

### DIFF
--- a/tf2/include/tf2/buffer_core.h
+++ b/tf2/include/tf2/buffer_core.h
@@ -49,6 +49,7 @@
 #include <memory>
 
 #include <tf2/exceptions.h>
+#include <tf2/buffer_core_interface.h>
 #include <tf2/visibility_control.h>
 
 namespace tf2
@@ -88,7 +89,7 @@ static constexpr Duration BUFFER_CORE_DEFAULT_CACHE_TIME = std::chrono::seconds(
  *
  * All function calls which pass frame ids can potentially throw the exception tf::LookupException
  */
-class BufferCore
+class BufferCore : public BufferCoreInterface
 {
 public:
   /************* Constants ***********************/
@@ -108,7 +109,7 @@ public:
 
   /** \brief Clear all data */
   TF2_PUBLIC
-  void clear();
+  void clear() override;
 
   /** \brief Add transform information to the tf data structure
    * \param transform The transform to store
@@ -133,7 +134,7 @@ public:
   TF2_PUBLIC
   geometry_msgs::msg::TransformStamped 
     lookupTransform(const std::string& target_frame, const std::string& source_frame,
-		    const TimePoint& time) const;
+		    const TimePoint& time) const override;
 
   /** \brief Get the transform between two frames by frame ID assuming fixed frame.
    * \param target_frame The frame to which data should be transformed
@@ -151,7 +152,7 @@ public:
   geometry_msgs::msg::TransformStamped
     lookupTransform(const std::string& target_frame, const TimePoint& target_time,
 		    const std::string& source_frame, const TimePoint& source_time,
-		    const std::string& fixed_frame) const;
+		    const std::string& fixed_frame) const override;
 
   /** \brief Lookup the twist of the tracking_frame with respect to the observation frame in the reference_frame using the reference point
    * \param tracking_frame The frame to track
@@ -205,7 +206,7 @@ public:
    */
   TF2_PUBLIC
   bool canTransform(const std::string& target_frame, const std::string& source_frame,
-                    const TimePoint& time, std::string* error_msg = NULL) const;
+                    const TimePoint& time, std::string* error_msg = NULL) const override;
   
   /** \brief Test if a transform is possible
    * \param target_frame The frame into which to transform
@@ -219,7 +220,12 @@ public:
   TF2_PUBLIC
   bool canTransform(const std::string& target_frame, const TimePoint& target_time,
                     const std::string& source_frame, const TimePoint& source_time,
-                    const std::string& fixed_frame, std::string* error_msg = NULL) const;
+                    const std::string& fixed_frame, std::string* error_msg = NULL) const override;
+
+  /** \brief Get all frames that exist in the system.
+   */
+  TF2_PUBLIC
+  std::vector<std::string> getAllFrameNames() const override;
 
   /** \brief A way to see what frames have been cached in yaml format
    * Useful for debugging tools
@@ -237,7 +243,7 @@ public:
    */
   TF2_PUBLIC
   std::string allFramesAsString() const;
-  
+
   using TransformableCallback = std::function<void(TransformableRequestHandle request_handle, const std::string& target_frame, const std::string& source_frame,
                                                    TimePoint time, TransformableResult result)>;
 

--- a/tf2/include/tf2/buffer_core_interface.h
+++ b/tf2/include/tf2/buffer_core_interface.h
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2019, Open Source Robotics Foundation, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef TF2__BUFFER_CORE_INTERFACE_H_
+#define TF2__BUFFER_CORE_INTERFACE_H_
+
+#include <string>
+#include <vector>
+
+#include <geometry_msgs/msg/transform_stamped.hpp>
+
+#include <tf2/time.h>
+#include <tf2/visibility_control.h>
+
+namespace tf2
+{
+
+/**
+ * \brief Interface for providing coordinate transforms between any two frames in a system.
+ *
+ * This class provides a simple abstract interface for looking up relationships between arbitrary
+ * frames of a system.
+ */
+class BufferCoreInterface
+{
+public:
+  /**
+   * \brief Clear internal state data.
+   */
+  TF2_PUBLIC
+  virtual void
+  clear() = 0;
+
+  /**
+   * \brief Get the transform between two frames by frame ID.
+   * \param target_frame The frame to which data should be transformed.
+   * \param source_frame The frame where the data originated.
+   * \param time The time at which the value of the transform is desired (0 will get the latest).
+   * \return The transform between the frames.
+   */
+  TF2_PUBLIC
+  virtual geometry_msgs::msg::TransformStamped
+  lookupTransform(
+    const std::string& target_frame,
+    const std::string& source_frame,
+    const tf2::TimePoint& time) const = 0;
+
+  /**
+   * \brief Get the transform between two frames by frame ID assuming fixed frame.
+   * \param target_frame The frame to which data should be transformed.
+   * \param target_time The time to which the data should be transformed (0 will get the latest).
+   * \param source_frame The frame where the data originated.
+   * \param source_time The time at which the source_frame should be evaluated
+   *   (0 will get the latest).
+   * \param fixed_frame The frame in which to assume the transform is constant in time.
+   * \return The transform between the frames.
+   */
+  TF2_PUBLIC
+  virtual geometry_msgs::msg::TransformStamped
+  lookupTransform(
+    const std::string& target_frame,
+    const tf2::TimePoint& target_time,
+    const std::string& source_frame,
+    const tf2::TimePoint& source_time,
+    const std::string& fixed_frame) const = 0;
+
+  /**
+   * \brief Test if a transform is possible.
+   * \param target_frame The frame into which to transform.
+   * \param source_frame The frame from which to transform.
+   * \param time The time at which to transform.
+   * \param error_msg A pointer to a string which will be filled with why the transform failed.
+   *   Ignored if NULL.
+   * \return true if the transform is possible, false otherwise.
+   */
+  TF2_PUBLIC
+  virtual bool
+  canTransform(
+    const std::string& target_frame,
+    const std::string& source_frame,
+    const tf2::TimePoint& time,
+    std::string* error_msg) const = 0;
+
+  /**
+   * \brief Test if a transform is possible.
+   * \param target_frame The frame into which to transform.
+   * \param target_time The time into which to transform.
+   * \param source_frame The frame from which to transform.
+   * \param source_time The time from which to transform.
+   * \param fixed_frame The frame in which to treat the transform as constant in time.
+   * \param error_msg A pointer to a string which will be filled with why the transform failed.
+   *   Ignored if NULL.
+   * \return true if the transform is possible, false otherwise.
+   */
+  TF2_PUBLIC
+  virtual bool
+  canTransform(
+    const std::string& target_frame,
+    const tf2::TimePoint& target_time,
+    const std::string& source_frame,
+    const tf2::TimePoint& source_time,
+    const std::string& fixed_frame,
+    std::string* error_msg) const = 0;
+
+  /**
+   * \brief Get all frames that exist in the system.
+   */
+  TF2_PUBLIC
+  virtual std::vector<std::string>
+  getAllFrameNames() const = 0;
+};  // class BufferCoreInterface
+
+}  // namespace tf2
+
+#endif // TF2__BUFFER_CORE_INTERFACE_H_

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -592,7 +592,6 @@ struct TransformAccum
   tf2::Vector3 result_vec;
 };
 
-
 geometry_msgs::msg::TransformStamped 
   BufferCore::lookupTransform(const std::string& target_frame, const std::string& source_frame,
       const TimePoint& time) const
@@ -927,6 +926,13 @@ void BufferCore::createConnectivityErrorString(CompactFrameID source_frame, Comp
   *out = std::string("Could not find a connection between '"+lookupFrameString(target_frame)+"' and '"+
                      lookupFrameString(source_frame)+"' because they are not part of the same tree."+
                      "Tf has two or more unconnected trees.");
+}
+
+std::vector<std::string> BufferCore::getAllFrameNames() const
+{
+  std::vector<std::string> frames;
+  _getFrameStrings(frames);
+  return frames;
 }
 
 std::string BufferCore::allFramesAsString() const

--- a/tf2_ros/CMakeLists.txt
+++ b/tf2_ros/CMakeLists.txt
@@ -34,6 +34,7 @@ include_directories(include
 # tf2_ros library
 add_library(${PROJECT_NAME} SHARED
   src/buffer.cpp
+  src/create_timer_ros.cpp
   src/transform_listener.cpp
   # src/buffer_client.cpp
   # src/buffer_server.cpp

--- a/tf2_ros/include/tf2_ros/async_buffer_interface.h
+++ b/tf2_ros/include/tf2_ros/async_buffer_interface.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2019, Open Source Robotics Foundation, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef TF2_ROS__ASYNC_BUFFER_INTERFACE_H
+#define TF2_ROS__ASYNC_BUFFER_INTERFACE_H
+
+#include <functional>
+#include <future>
+
+#include <geometry_msgs/msg/transform_stamped.hpp>
+
+#include <tf2_ros/visibility_control.h>
+#include <tf2/transform_datatypes.h>
+
+namespace tf2_ros
+{
+
+using TransformStampedFuture = std::shared_future<geometry_msgs::msg::TransformStamped>;
+using TransformReadyCallback = std::function<void(const TransformStampedFuture&)>;
+
+/**
+ * \brief Abstract interface for asynchronous operations on a `tf2::BufferCoreInterface`.
+ * Implementations include tf2_ros::Buffer.
+ */
+class AsyncBufferInterface
+{
+public:
+  /**
+   * \brief Wait for a transform between two frames to become available.
+   * \param target_frame The frame into which to transform.
+   * \param source_frame The frame from which to tranform.
+   * \param time The time at which to transform.
+   * \param timeout Duration after which waiting will be stopped.
+   * \param callback The function to be called when the transform becomes available or a timeout
+   *   occurs. In the case of timeout, an exception will be set on the future.
+   * \return A future to the requested transform. If a timeout occurs a `tf2::LookupException`
+   *    will be set on the future.
+   */
+  TF2_ROS_PUBLIC
+  virtual TransformStampedFuture
+  waitForTransform(
+    const std::string& target_frame,
+    const std::string& source_frame,
+    const tf2::TimePoint& time,
+    const tf2::Duration& timeout,
+    TransformReadyCallback callback) = 0;
+};  // class AsyncBufferInterface
+
+}  // namespace tf2_ros
+
+#endif // TF2_ROS__ASYNC_BUFFER_INTERFACE_H

--- a/tf2_ros/include/tf2_ros/buffer_interface.h
+++ b/tf2_ros/include/tf2_ros/buffer_interface.h
@@ -34,7 +34,6 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <tf2_ros/visibility_control.h>
-#include <tf2/buffer_core.h>
 #include <tf2/transform_datatypes.h>
 #include <tf2/exceptions.h>
 #include <geometry_msgs/msg/transform_stamped.hpp>
@@ -43,6 +42,9 @@
 
 namespace tf2_ros
 {
+  using TransformStampedFuture = std::shared_future<geometry_msgs::msg::TransformStamped>;
+  using TransformReadyCallback = std::function<void(const TransformStampedFuture&)>;
+
   inline builtin_interfaces::msg::Time toMsg(const tf2::TimePoint & t)
   {
     std::chrono::nanoseconds ns = \
@@ -69,13 +71,12 @@ namespace tf2_ros
     return (s + std::chrono::duration_cast<std::chrono::duration<double>>(ns)).count();
   }
 
-/** \brief Abstract interface for wrapping tf2::BufferCore in a ROS-based API.
+/** \brief Abstract interface for wrapping tf2::BufferCoreInterface in a ROS-based API.
  * Implementations include tf2_ros::Buffer and tf2_ros::BufferClient.
  */
 class BufferInterface
 {
 public:
-
   /** \brief Get the transform between two frames by frame ID.
    * \param target_frame The frame to which data should be transformed
    * \param source_frame The frame where the data originated

--- a/tf2_ros/include/tf2_ros/create_timer_interface.h
+++ b/tf2_ros/include/tf2_ros/create_timer_interface.h
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2019, Open Source Robotics Foundation, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef TF2_ROS__CREATE_TIMER_INTERFACE_H
+#define TF2_ROS__CREATE_TIMER_INTERFACE_H
+
+#include <functional>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <tf2/time.h>
+
+#include <tf2_ros/visibility_control.h>
+
+namespace tf2_ros
+{
+
+using TimerHandle = uint64_t;
+using TimerCallbackType = std::function<void(const TimerHandle &)>;
+
+class CreateTimerInterfaceException: public std::runtime_error
+{
+public:
+  TF2_ROS_PUBLIC
+  CreateTimerInterfaceException(const std::string errorDescription)
+  : std::runtime_error(errorDescription)
+  {
+  }
+};
+
+class InvalidTimerHandleException: public std::runtime_error
+{
+public:
+  TF2_ROS_PUBLIC
+  InvalidTimerHandleException(const std::string description)
+  : std::runtime_error(description)
+  {
+  }
+};
+
+/**
+ * \brief Abstract interface for creating timers.
+ */
+class CreateTimerInterface
+{
+public:
+  using SharedPtr = std::shared_ptr<CreateTimerInterface>;
+  using ConstSharedPtr = std::shared_ptr<const CreateTimerInterface>;
+  using UniquePtr = std::unique_ptr<CreateTimerInterface>;
+
+  /**
+   * \brief Create a new timer.
+   *
+   * After creation, the timer will periodically execute the user-provided callback.
+   *
+   * \param clock The clock providing the current time
+   * \param period The interval at which the timer fires
+   * \param callback The callback function to execute every interval
+   */
+  TF2_ROS_PUBLIC
+  virtual TimerHandle
+  createTimer(
+    rclcpp::Clock::SharedPtr clock,
+    const tf2::Duration & period,
+    TimerCallbackType callback) = 0;
+
+  /**
+   * \brief Cancel a timer.
+   *
+   * The timer will stop executing user callbacks.
+   *
+   * \param timer_handle Handle to the timer to cancel
+   * \raises tf2_ros::InvalidTimerHandleException if the timer does not exist
+   */
+  TF2_ROS_PUBLIC
+  virtual void
+  cancel(const TimerHandle & timer_handle) = 0;
+
+  /**
+   * \brief Reset the timer.
+   *
+   * The timer will reset and continue to execute user callbacks periodically.
+   *
+   * \param timer_handle Handle to the timer to reset
+   * \raises tf2_ros::InvalidTimerHandleException if the timer does not exist
+   */
+  TF2_ROS_PUBLIC
+  virtual void
+  reset(const TimerHandle & timer_handle) = 0;
+
+  /**
+   * \brief Remove a timer.
+   *
+   * The timer will be canceled and removed from internal storage.
+   *
+   * \param timer_handle Handle to the timer to reset
+   * \raises tf2_ros::InvalidTimerHandleException if the timer does not exist
+   */
+  TF2_ROS_PUBLIC
+  virtual void
+  remove(const TimerHandle & timer_handle) = 0;
+};  // class CreateTimerInterface
+
+}  // namespace tf2_ros
+
+#endif // TF2_ROS__CREATE_TIMER_INTERFACE_H

--- a/tf2_ros/include/tf2_ros/create_timer_ros.h
+++ b/tf2_ros/include/tf2_ros/create_timer_ros.h
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2019, Open Source Robotics Foundation, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef TF2_ROS__CREATE_TIMER_ROS_H
+#define TF2_ROS__CREATE_TIMER_ROS_H
+
+#include <mutex>
+#include <unordered_map>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <tf2_ros/create_timer_interface.h>
+#include <tf2_ros/visibility_control.h>
+
+namespace tf2_ros
+{
+
+/**
+ * \brief Create and manage ROS timers.
+ *
+ * This class is thread safe.
+ */
+class CreateTimerROS : public CreateTimerInterface
+{
+public:
+  TF2_ROS_PUBLIC
+  CreateTimerROS(
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
+    rclcpp::node_interfaces::NodeTimersInterface::SharedPtr node_timers);
+
+  /**
+   * \brief Create a new timer.
+   *
+   * After creation, the timer will periodically execute the user-provided callback.
+   *
+   * \param clock The clock providing the current time
+   * \param period The interval at which the timer fires
+   * \param callback The callback function to execute every interval
+   */
+  TF2_ROS_PUBLIC
+  virtual TimerHandle
+  createTimer(
+    rclcpp::Clock::SharedPtr clock,
+    const tf2::Duration & period,
+    TimerCallbackType callback) override;
+
+  /**
+   * \brief Cancel a timer.
+   *
+   * The timer will stop executing user callbacks.
+   *
+   * \param timer_handle Handle to the timer to cancel
+   * \raises tf2_ros::InvalidTimerHandleException if the timer does not exist
+   */
+  TF2_ROS_PUBLIC
+  virtual void
+  cancel(const TimerHandle & timer_handle) override;
+
+  /**
+   * \brief Reset the timer.
+   *
+   * The timer will reset and continue to execute user callbacks periodically.
+   *
+   * \param timer_handle Handle to the timer to reset
+   * \raises tf2_ros::InvalidTimerHandleException if the timer does not exist
+   */
+  TF2_ROS_PUBLIC
+  virtual void
+  reset(const TimerHandle & timer_handle) override;
+
+  /**
+   * \brief Remove a timer.
+   *
+   * The timer will be canceled and removed from internal storage.
+   *
+   * \param timer_handle Handle to the timer to reset.
+   * \raises tf2_ros::InvalidTimerHandleException if the timer does not exist
+   */
+  TF2_ROS_PUBLIC
+  virtual void
+  remove(const TimerHandle & timer_handle) override;
+
+private:
+
+  void
+  cancelNoLock(const TimerHandle & timer_handle);
+
+  void
+  timerCallback(
+    const TimerHandle & timer_handle,
+    TimerCallbackType callback);
+
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_;
+  rclcpp::node_interfaces::NodeTimersInterface::SharedPtr node_timers_;
+  TimerHandle next_timer_handle_index_;
+  std::unordered_map<TimerHandle, rclcpp::TimerBase::SharedPtr> timers_map_;
+  std::mutex timers_map_mutex_;
+};  // class CreateTimerROS
+
+}  // namespace tf2_ros
+
+#endif // TF2_ROS__CREATE_TIMER_INTERFACE_H

--- a/tf2_ros/src/create_timer_ros.cpp
+++ b/tf2_ros/src/create_timer_ros.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2019, Open Source Robotics Foundation, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <functional>
+
+#include <rclcpp/create_timer.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <tf2/time.h>
+
+#include <tf2_ros/create_timer_ros.h>
+
+namespace tf2_ros
+{
+
+CreateTimerROS::CreateTimerROS(
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
+  rclcpp::node_interfaces::NodeTimersInterface::SharedPtr node_timers)
+: node_base_(node_base), node_timers_(node_timers), next_timer_handle_index_(0)
+{
+}
+
+TimerHandle
+CreateTimerROS::createTimer(
+  rclcpp::Clock::SharedPtr clock,
+  const tf2::Duration & period,
+  TimerCallbackType callback)
+{
+  std::lock_guard<std::mutex> lock(timers_map_mutex_);
+  auto timer_handle_index = next_timer_handle_index_++;
+  auto timer = rclcpp::create_timer<std::function<void()>>(
+    node_base_.get(),
+    node_timers_.get(),
+    clock,
+    period,
+    std::bind(&CreateTimerROS::timerCallback, this, timer_handle_index, callback));
+  timers_map_[timer_handle_index] = timer;
+  return timer_handle_index;
+}
+
+void
+CreateTimerROS::cancel(const TimerHandle & timer_handle)
+{
+  std::lock_guard<std::mutex> lock(timers_map_mutex_);
+  cancelNoLock(timer_handle);
+}
+
+void
+CreateTimerROS::reset(const TimerHandle & timer_handle)
+{
+  std::lock_guard<std::mutex> lock(timers_map_mutex_);
+  try {
+    timers_map_.at(timer_handle)->reset();
+  } catch (const std::out_of_range) {
+    throw InvalidTimerHandleException("Invalid timer handle in reset()");
+  }
+}
+
+void
+CreateTimerROS::remove(const TimerHandle & timer_handle)
+{
+  std::lock_guard<std::mutex> lock(timers_map_mutex_);
+  try {
+    cancelNoLock(timer_handle);
+  } catch (const InvalidTimerHandleException) {
+    throw InvalidTimerHandleException("Invalid timer handle in remove()");
+  }
+  timers_map_.erase(timer_handle);
+}
+
+void
+CreateTimerROS::cancelNoLock(const TimerHandle & timer_handle)
+{
+  try {
+    timers_map_.at(timer_handle)->cancel();
+  } catch (const std::out_of_range) {
+    throw InvalidTimerHandleException("Invalid timer handle in cancel()");
+  }
+}
+
+void
+CreateTimerROS::timerCallback(
+  const TimerHandle & timer_handle,
+  TimerCallbackType callback)
+{
+  callback(timer_handle);
+}
+
+}  // namespace tf2_ros

--- a/tf2_ros/test/message_filter_test.cpp
+++ b/tf2_ros/test/message_filter_test.cpp
@@ -35,6 +35,7 @@
 #include <message_filters/simple_filter.h>
 #include <message_filters/message_traits.h>
 #include <tf2_ros/buffer.h>
+#include <tf2_ros/create_timer_ros.h>
 #include <tf2_ros/message_filter.h>
 #include <tf2_ros/static_transform_broadcaster.h>
 #include <tf2_ros/transform_listener.h>
@@ -50,11 +51,16 @@ TEST(tf2_ros_message_filter, multiple_frames_and_time_tolerance)
 {
   auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
 
+  auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
+    node->get_node_base_interface(),
+    node->get_node_timers_interface());
+
   message_filters::Subscriber<geometry_msgs::msg::PointStamped> sub;
   sub.subscribe(node, "point");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
   tf2_ros::Buffer buffer(clock);
+  buffer.setCreateTimerInterface(create_timer_interface);
   tf2_ros::TransformListener tfl(buffer);
   tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "map", 10, node);
   filter.connectInput(sub);

--- a/tf2_ros/test/test_buffer.cpp
+++ b/tf2_ros/test/test_buffer.cpp
@@ -27,14 +27,68 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <exception>
 #include <chrono>
+#include <exception>
+#include <future>
 #include <gtest/gtest.h>
+#include <tf2_ros/create_timer_interface.h>
 #include <tf2_ros/transform_listener.h>
 #include <rclcpp/rclcpp.hpp>
 
 
 using namespace tf2;
+
+class MockCreateTimer : public tf2_ros::CreateTimerInterface
+{
+public:
+  MockCreateTimer()
+  : timer_handle_index_(0)
+  {
+  }
+
+  tf2_ros::TimerHandle
+  createTimer(
+    rclcpp::Clock::SharedPtr clock,
+    const tf2::Duration & period,
+    tf2_ros::TimerCallbackType callback)
+  {
+    (void) clock;
+    (void) period;
+    const auto timer_handle = timer_handle_index_++;
+    timer_to_callback_map_[timer_handle] = callback;
+    return timer_handle;
+  }
+
+  void
+  cancel(const tf2_ros::TimerHandle & timer_handle)
+  {
+    (void) timer_handle;
+  }
+
+  void
+  reset(const tf2_ros::TimerHandle & timer_handle)
+  {
+    (void) timer_handle;
+  }
+
+  void
+  remove(const tf2_ros::TimerHandle & timer_handle)
+  {
+    // Don't actually remove timer to avoid race condition
+    (void) timer_handle;
+  }
+
+  void
+  execute_timers()
+  {
+    for (const auto elem : timer_to_callback_map_) {
+      elem.second(elem.first);
+    }
+  }
+
+  tf2_ros::TimerHandle timer_handle_index_;
+  std::unordered_map<tf2_ros::TimerHandle, tf2_ros::TimerCallbackType> timer_to_callback_map_;
+};
 
 TEST(test_buffer, construct_with_null_clock)
 {
@@ -70,6 +124,103 @@ TEST(test_buffer, can_transform_valid_transform)
   EXPECT_DOUBLE_EQ(transform.transform.translation.x, output.transform.translation.x);
   EXPECT_DOUBLE_EQ(transform.transform.translation.y, output.transform.translation.y);
   EXPECT_DOUBLE_EQ(transform.transform.translation.z, output.transform.translation.z);
+}
+
+TEST(test_buffer, wait_for_transform_valid)
+{
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+  tf2_ros::Buffer buffer(clock);
+  auto mock_create_timer = std::make_shared<MockCreateTimer>();
+  buffer.setCreateTimerInterface(mock_create_timer);
+
+  rclcpp::Time rclcpp_time = clock->now();
+  tf2::TimePoint tf2_time(std::chrono::nanoseconds(rclcpp_time.nanoseconds()));
+
+  geometry_msgs::msg::TransformStamped transform_callback_result;
+  auto future = buffer.waitForTransform(
+    "foo",
+    "bar",
+    tf2_time, tf2::durationFromSec(1.0),
+    [&transform_callback_result](const tf2_ros::TransformStampedFuture & future)
+    {
+      transform_callback_result = future.get();
+    });
+
+  geometry_msgs::msg::TransformStamped transform;
+  transform.header.frame_id = "foo";
+  transform.header.stamp = builtin_interfaces::msg::Time(rclcpp_time);
+  transform.child_frame_id = "bar";
+  transform.transform.translation.x = 1.0;
+  transform.transform.translation.y = 2.0;
+  transform.transform.translation.z = 3.0;
+  transform.transform.rotation.w = 1.0;
+  transform.transform.rotation.x = 0.0;
+  transform.transform.rotation.y = 0.0;
+  transform.transform.rotation.z = 0.0;
+
+  EXPECT_TRUE(buffer.setTransform(transform, "unittest"));
+
+  EXPECT_TRUE(buffer.canTransform("bar", "foo", tf2_time));
+  const auto status = future.wait_for(std::chrono::seconds(1));
+  EXPECT_EQ(status, std::future_status::ready);
+
+  auto transform_result = future.get();
+  EXPECT_STREQ(transform.child_frame_id.c_str(), transform_result.child_frame_id.c_str());
+  EXPECT_STREQ(transform.child_frame_id.c_str(), transform_callback_result.child_frame_id.c_str());
+  EXPECT_DOUBLE_EQ(transform.transform.translation.x, transform_result.transform.translation.x);
+  EXPECT_DOUBLE_EQ(transform.transform.translation.y, transform_result.transform.translation.y);
+  EXPECT_DOUBLE_EQ(transform.transform.translation.z, transform_result.transform.translation.z);
+  EXPECT_DOUBLE_EQ(transform.transform.translation.x, transform_callback_result.transform.translation.x);
+  EXPECT_DOUBLE_EQ(transform.transform.translation.y, transform_callback_result.transform.translation.y);
+  EXPECT_DOUBLE_EQ(transform.transform.translation.z, transform_callback_result.transform.translation.z);
+
+  // Expect there to be exactly one timer
+  EXPECT_EQ(mock_create_timer->timer_to_callback_map_.size(), 1u);
+}
+
+TEST(test_buffer, wait_for_transform_timeout)
+{
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+  tf2_ros::Buffer buffer(clock);
+  auto mock_create_timer = std::make_shared<MockCreateTimer>();
+  buffer.setCreateTimerInterface(mock_create_timer);
+
+  rclcpp::Time time_start = clock->now();
+  tf2::TimePoint tf2_time(std::chrono::nanoseconds(time_start.nanoseconds()));
+
+  bool callback_timeout = false;
+  auto future = buffer.waitForTransform(
+    "foo",
+    "bar",
+    tf2_time, tf2::durationFromSec(1.0),
+    [&callback_timeout](const tf2_ros::TransformStampedFuture & future)
+    {
+      try {
+        // Expect this to throw an exception due to timeout
+        future.get();
+      } catch (...) {
+        callback_timeout = true;
+      }
+    });
+
+  // Set an irrelevant transform
+  geometry_msgs::msg::TransformStamped transform;
+  transform.header.frame_id = "test";
+  transform.header.stamp = builtin_interfaces::msg::Time(clock->now());
+  transform.child_frame_id = "baz";
+  transform.transform.rotation.w = 1.0;
+  EXPECT_TRUE(buffer.setTransform(transform, "unittest"));
+
+  auto status = future.wait_for(std::chrono::milliseconds(1));
+  EXPECT_EQ(status, std::future_status::timeout);
+
+  // Fake a time out
+  mock_create_timer->execute_timers();
+
+  EXPECT_FALSE(buffer.canTransform("bar", "foo", tf2_time));
+  status = future.wait_for(std::chrono::milliseconds(1));
+  EXPECT_EQ(status, std::future_status::ready);
+  EXPECT_TRUE(callback_timeout);
 }
 
 int main(int argc, char **argv){


### PR DESCRIPTION
This work is towards enabling the use of MessageFilter in RViz (see https://github.com/ros2/rviz/pull/375#issuecomment-504124116).
The idea is to make RViz transformer plugins extend the new `tf2::FrameTransformerInterface` so that we can take advantage of `tf2::MessageFilter` with different transformer plugins (not just `tf2::BufferCore`).

This PR does three things:

1. Propose the new interface `tf2::FrameTransformerInterface` (533ccd6)
1. Make `tf2::BufferCore` implement the interface (f4c2c98)
1. Make `tf2::MessageFilter` use the interface (9550875)