### PR TITLE
Added missing header (for tf2::fromMsg)

### DIFF
--- a/tf2_sensor_msgs/include/tf2_sensor_msgs/tf2_sensor_msgs.h
+++ b/tf2_sensor_msgs/include/tf2_sensor_msgs/tf2_sensor_msgs.h
@@ -36,6 +36,7 @@
 #include <sensor_msgs/point_cloud2_iterator.hpp>
 #include <Eigen/Eigen>
 #include <Eigen/Geometry>
+#include <tf2_ros/buffer_interface.h>
 
 namespace tf2
 {


### PR DESCRIPTION
This PR adds `tf2_ros/buffer_interface.h` to the list of headers so `tf2::fromMsg` is declared before use.