### PR TITLE
Guard against invalid iterator

### DIFF
--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -1433,6 +1433,11 @@ void BufferCore::testTransformableRequests()
       }
 
       transformable_requests_.erase(transformable_requests_.end() - 1);
+
+      // If we've removed the last element, then the iterator is invalid
+      if (0u == transformable_requests_.size()) {
+        it = transformable_requests_.end();
+      }
     }
     else
     {


### PR DESCRIPTION
I came across this bug while working on https://github.com/ros2/geometry2/pull/121.

If there is exactly one transform request in the list, after it is removed the list
iterator is invalidated. This results in undefined behavior and visible test
failures on Windows.
I've added a regession test that fails without the patch.