### PR TITLE
avoid delete-non-virtual-dtor warning

### DIFF
--- a/tf2_ros/include/tf2_ros/create_timer_ros.h
+++ b/tf2_ros/include/tf2_ros/create_timer_ros.h
@@ -54,6 +54,8 @@ public:
     rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
     rclcpp::node_interfaces::NodeTimersInterface::SharedPtr node_timers);
 
+  virtual ~CreateTimerROS() = default;
+
   /**
    * \brief Create a new timer.
    *

--- a/tf2_ros/test/test_buffer.cpp
+++ b/tf2_ros/test/test_buffer.cpp
@@ -38,7 +38,7 @@
 
 using namespace tf2;
 
-class MockCreateTimer : public tf2_ros::CreateTimerInterface
+class MockCreateTimer final : public tf2_ros::CreateTimerInterface
 {
 public:
   MockCreateTimer()


### PR DESCRIPTION
The latest master brings up two warnings about virtual destructors:

```
[ 96%] Building CXX object CMakeFiles/test_buffer.dir/test/test_buffer.cpp.o
In file included from /Users/karsten/workspace/osrf/ros2_full/src/ros2/geometry2/tf2_ros/test/test_buffer.cpp:32:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/future:366:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/system_error:150:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/string:500:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/string_view:176:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__string:56:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/algorithm:644:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/memory:3706:5: error: destructor called on non-final 'MockCreateTimer' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-virtual-dtor]
    __data_.second().~_Tp();
    ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/memory:3662:5: note: in instantiation of member function 'std::__1::__shared_ptr_emplace<MockCreateTimer, std::__1::allocator<MockCreateTimer> >::__on_zero_shared' requested here
    __shared_ptr_emplace(_Alloc __a)
    ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/memory:4327:26: note: in instantiation of member function 'std::__1::__shared_ptr_emplace<MockCreateTimer, std::__1::allocator<MockCreateTimer> >::__shared_ptr_emplace' requested here
    ::new(__hold2.get()) _CntrlBlk(__a2, _VSTD::forward<_Args>(__args)...);
                         ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/memory:4706:29: note: in instantiation of function template specialization 'std::__1::shared_ptr<MockCreateTimer>::make_shared<>' requested here
    return shared_ptr<_Tp>::make_shared(_VSTD::forward<_Args>(__args)...);
                            ^
/Users/karsten/workspace/osrf/ros2_full/src/ros2/geometry2/tf2_ros/test/test_buffer.cpp:133:33: note: in instantiation of function template specialization 'std::__1::make_shared<MockCreateTimer>' requested here
  auto mock_create_timer = std::make_shared<MockCreateTimer>();
                                ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/memory:3706:23: note: qualify call to silence this warning
    __data_.second().~_Tp();
                      ^
1 error generated.
```

This PR is fixing it. Running CI on it:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7648)](http://ci.ros2.org/job/ci_linux/7648/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=3759)](http://ci.ros2.org/job/ci_linux-aarch64/3759/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6254)](http://ci.ros2.org/job/ci_osx/6254/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7492)](http://ci.ros2.org/job/ci_windows/7492/)

Signed-off-by: Karsten Knese <karsten@openrobotics.org>