### PR TITLE
Fix compiler warning

### DIFF
--- a/tf2_ros/src/buffer.cpp
+++ b/tf2_ros/src/buffer.cpp
@@ -266,7 +266,7 @@ Buffer::timerCallback(const TimerHandle & timer_handle,
                       TransformReadyCallback callback)
 {
   bool timer_is_valid = false;
-  tf2::TransformableRequestHandle request_handle;
+  tf2::TransformableRequestHandle request_handle = 0u;
   {
     std::lock_guard<std::mutex> lock(timer_to_request_map_mutex_);
     auto timer_and_request_it = timer_to_request_map_.find(timer_handle);


### PR DESCRIPTION
This fixes a 'maybe uninitialized' warning in RelWithDebInfo builds.

Addresses https://github.com/ros2/geometry2/pull/143#discussion_r311691499

CI (RelWithDebInfo):
* Linux [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7835)](https://ci.ros2.org/job/ci_linux/7835/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=3903)](http://ci.ros2.org/job/ci_linux-aarch64/3903/)
* macOS [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6392)](https://ci.ros2.org/job/ci_osx/6392/)
* Windows [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7672)](https://ci.ros2.org/job/ci_windows/7672/)