### PR TITLE
Additional KDL and Eigen conversion overloads from ROS1

### DIFF
--- a/tf2_eigen/include/tf2_eigen/tf2_eigen.h
+++ b/tf2_eigen/include/tf2_eigen/tf2_eigen.h
@@ -149,6 +149,33 @@ void fromMsg(const geometry_msgs::msg::Point& msg, Eigen::Vector3d& out)
   out.z() = msg.z;
 }
 
+/** \brief Convert an Eigen Vector3d type to a Vector3 message.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param in The Eigen Vector3d to convert.
+ * \return The vector converted to a Vector3 message.
+ */
+inline
+geometry_msgs::msg::Vector3& toMsg(const Eigen::Vector3d& in, geometry_msgs::msg::Vector3& out)
+{
+  out.x = in.x();
+  out.y = in.y();
+  out.z = in.z();
+  return out;
+}
+
+/** \brief Convert a Vector3 message type to a Eigen-specific Vector3d type.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.h
+ * \param msg The Vector3 message to convert.
+ * \param out The vector converted to a Eigen Vector3d.
+ */
+inline
+void fromMsg(const geometry_msgs::msg::Vector3& msg, Eigen::Vector3d& out)
+{
+  out.x() = msg.x;
+  out.y() = msg.y;
+  out.z() = msg.z;
+}
+
 /** \brief Apply a geometry_msgs TransformStamped to an Eigen-specific Vector3d type.
  * This function is a specialization of the doTransform template defined in tf2/convert.h.
  * \param t_in The vector to transform, as a timestamped Eigen Vector3d data type.
@@ -547,12 +574,12 @@ geometry_msgs::msg::Quaternion toMsg(const Eigen::Quaterniond& in) {
 }
 
 inline
-geometry_msgs::Twist toMsg(const Eigen::Matrix<double,6,1>& in) {
+geometry_msgs::msg::Twist toMsg(const Eigen::Matrix<double,6,1>& in) {
   return tf2::toMsg(in);
 }
 
 inline
-void fromMsg(const geometry_msgs::Twist &msg, Eigen::Matrix<double,6,1>& out) {
+void fromMsg(const geometry_msgs::msg::Twist &msg, Eigen::Matrix<double,6,1>& out) {
   tf2::fromMsg(msg, out);
 }
 

--- a/tf2_eigen/include/tf2_eigen/tf2_eigen.h
+++ b/tf2_eigen/include/tf2_eigen/tf2_eigen.h
@@ -546,6 +546,16 @@ geometry_msgs::msg::Quaternion toMsg(const Eigen::Quaterniond& in) {
   return tf2::toMsg(in);
 }
 
+inline
+geometry_msgs::Twist toMsg(const Eigen::Matrix<double,6,1>& in) {
+  return tf2::toMsg(in);
+}
+
+inline
+void fromMsg(const geometry_msgs::Twist &msg, Eigen::Matrix<double,6,1>& out) {
+  tf2::fromMsg(msg, out);
+}
+
 } // namespace
 
 #endif // TF2_EIGEN_H

--- a/tf2_kdl/include/tf2_kdl/tf2_kdl.h
+++ b/tf2_kdl/include/tf2_kdl/tf2_kdl.h
@@ -38,6 +38,7 @@
 #include <geometry_msgs/msg/point_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <geometry_msgs/msg/wrench_stamped.hpp>
+#include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <builtin_interfaces/msg/time.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
@@ -250,6 +251,36 @@ inline
 /** \brief Convert a stamped KDL Frame type to a Pose message.
  * This function is a specialization of the toMsg template defined in tf2/convert.h.
  * \param in The timestamped KDL Frame to convert.
+ * \return The frame converted to a Pose message.
+ */
+inline
+geometry_msgs::msg::Pose toMsg(const KDL::Frame& in)
+{
+  geometry_msgs::msg::Pose msg;
+  msg.position.x = in.p[0];
+  msg.position.y = in.p[1];
+  msg.position.z = in.p[2];
+  in.M.GetQuaternion(msg.orientation.x, msg.orientation.y, msg.orientation.z, msg.orientation.w);
+  return msg;
+}
+
+/** \brief Convert a Pose message type to a KDL Frame.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.h.
+ * \param msg The Pose message to convert.
+ * \param out The pose converted to a KDL Frame.
+ */
+inline
+void fromMsg(const geometry_msgs::msg::Pose& msg, KDL::Frame& out)
+{
+  out.p[0] = msg.position.x;
+  out.p[1] = msg.position.y;
+  out.p[2] = msg.position.z;
+  out.M = KDL::Rotation::Quaternion(msg.orientation.x, msg.orientation.y, msg.orientation.z, msg.orientation.w);
+}
+
+/** \brief Convert a stamped KDL Frame type to a Pose message.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param in The timestamped KDL Frame to convert.
  * \return The frame converted to a PoseStamped message.
  */
 inline
@@ -258,15 +289,12 @@ geometry_msgs::msg::PoseStamped toMsg(const tf2::Stamped<KDL::Frame>& in)
   geometry_msgs::msg::PoseStamped msg;
   msg.header.stamp = tf2_ros::toMsg(in.stamp_);
   msg.header.frame_id = in.frame_id_;
-  msg.pose.position.x = in.p[0];
-  msg.pose.position.y = in.p[1];
-  msg.pose.position.z = in.p[2];
-  in.M.GetQuaternion(msg.pose.orientation.x, msg.pose.orientation.y, msg.pose.orientation.z, msg.pose.orientation.w);
+  msg.pose = toMsg(static_cast<const KDL::Frame&>(in));
   return msg;
 }
 
 /** \brief Convert a Pose message transform type to a stamped KDL Frame.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.h.
  * \param msg The PoseStamped message to convert.
  * \param out The pose converted to a timestamped KDL Frame.
  */
@@ -275,12 +303,8 @@ void fromMsg(const geometry_msgs::msg::PoseStamped& msg, tf2::Stamped<KDL::Frame
 {
   out.stamp_ = tf2_ros::fromMsg(msg.header.stamp);
   out.frame_id_ = msg.header.frame_id;
-  out.p[0] = msg.pose.position.x;
-  out.p[1] = msg.pose.position.y;
-  out.p[2] = msg.pose.position.z;
-  out.M = KDL::Rotation::Quaternion(msg.pose.orientation.x, msg.pose.orientation.y, msg.pose.orientation.z, msg.pose.orientation.w);
+  fromMsg(msg.pose, static_cast<KDL::Frame&>(out));
 }
-
 
 } // namespace
 


### PR DESCRIPTION
This is a "backport" of PRs #292 and #294 added to the ROS1 version of geometry2 last year, originally authored by @IanTheEngineer. All I did was cherry pick the commits and make the (superficial) syntax changes required for ROS2 messages.

I've found these additional conversions to be useful and I imagine they'll eventually be needed by moveit2 since it was originally motivated by migrating moveit to tf2.