### PR TITLE
Make /tf_static use transient_local durability

### DIFF
--- a/tf2_ros/include/tf2_ros/qos.hpp
+++ b/tf2_ros/include/tf2_ros/qos.hpp
@@ -35,16 +35,31 @@
 namespace tf2_ros
 {
 
-class RCLCPP_PUBLIC DynamicQoS : public rclcpp::QoS
+class RCLCPP_PUBLIC DynamicListenerQoS: public rclcpp::QoS
 {
 public:
-  DynamicQoS() : rclcpp::QoS(100) {}
+  DynamicListenerQoS() : rclcpp::QoS(100) {}
 };
 
-class RCLCPP_PUBLIC StaticQoS : public rclcpp::QoS
+class RCLCPP_PUBLIC DynamicBroadcasterQoS : public rclcpp::QoS
 {
 public:
-  StaticQoS() : rclcpp::QoS(100)
+  DynamicBroadcasterQoS() : rclcpp::QoS(100) {}
+};
+
+class RCLCPP_PUBLIC StaticListenerQoS : public rclcpp::QoS
+{
+public:
+  StaticListenerQoS() : rclcpp::QoS(100)
+  {
+    transient_local();
+  }
+};
+
+class RCLCPP_PUBLIC StaticBroadcasterQoS : public rclcpp::QoS
+{
+public:
+  StaticBroadcasterQoS() : rclcpp::QoS(1)
   {
     transient_local();
   }

--- a/tf2_ros/include/tf2_ros/qos.hpp
+++ b/tf2_ros/include/tf2_ros/qos.hpp
@@ -38,14 +38,12 @@ namespace tf2_ros
 class RCLCPP_PUBLIC DynamicQoS : public rclcpp::QoS
 {
 public:
-  explicit
   DynamicQoS() : rclcpp::QoS(100) {}
 };
 
 class RCLCPP_PUBLIC StaticQoS : public rclcpp::QoS
 {
 public:
-  explicit
   StaticQoS() : rclcpp::QoS(100)
   {
     transient_local();

--- a/tf2_ros/include/tf2_ros/qos.hpp
+++ b/tf2_ros/include/tf2_ros/qos.hpp
@@ -38,19 +38,19 @@ namespace tf2_ros
 class RCLCPP_PUBLIC DynamicListenerQoS: public rclcpp::QoS
 {
 public:
-  DynamicListenerQoS() : rclcpp::QoS(100) {}
+  explicit DynamicListenerQoS(size_t depth = 100) : rclcpp::QoS(depth) {}
 };
 
 class RCLCPP_PUBLIC DynamicBroadcasterQoS : public rclcpp::QoS
 {
 public:
-  DynamicBroadcasterQoS() : rclcpp::QoS(100) {}
+  explicit DynamicBroadcasterQoS(size_t depth = 100) : rclcpp::QoS(depth) {}
 };
 
 class RCLCPP_PUBLIC StaticListenerQoS : public rclcpp::QoS
 {
 public:
-  StaticListenerQoS() : rclcpp::QoS(100)
+  explicit StaticListenerQoS(size_t depth = 100) : rclcpp::QoS(depth)
   {
     transient_local();
   }
@@ -59,7 +59,7 @@ public:
 class RCLCPP_PUBLIC StaticBroadcasterQoS : public rclcpp::QoS
 {
 public:
-  StaticBroadcasterQoS() : rclcpp::QoS(1)
+  explicit StaticBroadcasterQoS(size_t depth = 1) : rclcpp::QoS(depth)
   {
     transient_local();
   }

--- a/tf2_ros/include/tf2_ros/qos.hpp
+++ b/tf2_ros/include/tf2_ros/qos.hpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2019, Open Source Robotics Foundation, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef TF2_ROS__QOS_HPP_
+#define TF2_ROS__QOS_HPP_
+
+#include <rclcpp/qos.hpp>
+
+namespace tf2_ros
+{
+
+class RCLCPP_PUBLIC DynamicQoS : public rclcpp::QoS
+{
+public:
+  explicit
+  DynamicQoS() : rclcpp::QoS(100) {}
+};
+
+class RCLCPP_PUBLIC StaticQoS : public rclcpp::QoS
+{
+public:
+  explicit
+  StaticQoS() : rclcpp::QoS(100)
+  {
+    transient_local();
+  }
+};
+}  // namespace tf2_ros
+#endif  // TF2_ROS__QOS_HPP_

--- a/tf2_ros/include/tf2_ros/static_transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/static_transform_broadcaster.h
@@ -38,6 +38,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "tf2_msgs/msg/tf_message.hpp"
+#include "tf2_ros/qos.hpp"
 #include "tf2_ros/visibility_control.h"
 
 namespace tf2_ros
@@ -53,7 +54,7 @@ public:
   template<class NodeT, class AllocatorT = std::allocator<void>>
   StaticTransformBroadcaster(
     NodeT && node,
-    const rclcpp::QoS & qos = rclcpp::QoS(100),
+    const rclcpp::QoS & qos = StaticQoS(),
     const rclcpp::PublisherOptionsWithAllocator<AllocatorT> & options =
       rclcpp::PublisherOptionsWithAllocator<AllocatorT>())
   {

--- a/tf2_ros/include/tf2_ros/static_transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/static_transform_broadcaster.h
@@ -54,7 +54,7 @@ public:
   template<class NodeT, class AllocatorT = std::allocator<void>>
   StaticTransformBroadcaster(
     NodeT && node,
-    const rclcpp::QoS & qos = StaticQoS(),
+    const rclcpp::QoS & qos = StaticBroadcasterQoS(),
     const rclcpp::PublisherOptionsWithAllocator<AllocatorT> & options =
       rclcpp::PublisherOptionsWithAllocator<AllocatorT>())
   {

--- a/tf2_ros/include/tf2_ros/transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/transform_broadcaster.h
@@ -36,6 +36,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "tf2_msgs/msg/tf_message.hpp"
+#include "tf2_ros/qos.hpp"
 #include "tf2_ros/visibility_control.h"
 
 namespace tf2_ros
@@ -51,7 +52,7 @@ public:
   template<class NodeT, class AllocatorT = std::allocator<void>>
   TransformBroadcaster(
     NodeT && node,
-    const rclcpp::QoS & qos = rclcpp::QoS(100),
+    const rclcpp::QoS & qos = DynamicQoS(),
     const rclcpp::PublisherOptionsWithAllocator<AllocatorT> & options =
       rclcpp::PublisherOptionsWithAllocator<AllocatorT>())
   {

--- a/tf2_ros/include/tf2_ros/transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/transform_broadcaster.h
@@ -52,7 +52,7 @@ public:
   template<class NodeT, class AllocatorT = std::allocator<void>>
   TransformBroadcaster(
     NodeT && node,
-    const rclcpp::QoS & qos = DynamicQoS(),
+    const rclcpp::QoS & qos = DynamicBroadcasterQoS(),
     const rclcpp::PublisherOptionsWithAllocator<AllocatorT> & options =
       rclcpp::PublisherOptionsWithAllocator<AllocatorT>())
   {

--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -59,8 +59,8 @@ public:
     tf2::BufferCore & buffer,
     NodeT && node,
     bool spin_thread = true,
-    const rclcpp::QoS & qos = DynamicQoS(),
-    const rclcpp::QoS & static_qos = StaticQoS(),
+    const rclcpp::QoS & qos = DynamicListenerQoS(),
+    const rclcpp::QoS & static_qos = StaticListenerQoS(),
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options =
       rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>())
   : buffer_(buffer)

--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -39,6 +39,7 @@
 #include "rclcpp/rclcpp.hpp"
 
 #include "tf2_ros/buffer.h"
+#include "tf2_ros/qos.hpp"
 #include "tf2_ros/visibility_control.h"
 
 namespace tf2_ros
@@ -58,12 +59,13 @@ public:
     tf2::BufferCore & buffer,
     NodeT && node,
     bool spin_thread = true,
-    const rclcpp::QoS & qos = rclcpp::QoS(100),
+    const rclcpp::QoS & qos = DynamicQoS(),
+    const rclcpp::QoS & static_qos = StaticQoS(),
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options =
       rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>())
   : buffer_(buffer)
   {
-    init(node, spin_thread, qos, options);
+    init(node, spin_thread, qos, static_qos, options);
   }
 
   TF2_ROS_PUBLIC
@@ -74,7 +76,8 @@ private:
   void init(
     NodeT && node,
     bool spin_thread,
-    const rclcpp::QoS & qos = rclcpp::QoS(100),
+    const rclcpp::QoS & qos,
+    const rclcpp::QoS & static_qos,
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options =
       rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>())
   {
@@ -91,7 +94,7 @@ private:
     message_subscription_tf_static_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
       node,
       "/tf_static",
-      qos,
+      static_qos,
       std::move(static_cb),
       options);
 

--- a/tf2_ros/src/static_transform_broadcaster_program.cpp
+++ b/tf2_ros/src/static_transform_broadcaster_program.cpp
@@ -156,17 +156,8 @@ int main(int argc, char ** argv)
     return 1;
   }
 
-  rclcpp::WallRate loop_rate(0.2);
-  while (rclcpp::ok())
-  {
-    RCUTILS_LOG_INFO_THROTTLE(RCUTILS_STEADY_TIME, 30000 /* ms */, "LOOPING due to no latching at the moment");
-    broadcaster.sendTransform(msg);
-    rclcpp::spin_some(node);
-    loop_rate.sleep();
-  }
-
-  // broadcaster.sendTransform(msg);
-  // ROS_INFO("Spinning until killed publishing %s to %s", msg.header.frame_id.c_str(), msg.child_frame_id.c_str());
-  // rclcpp::spin(node);
+  broadcaster.sendTransform(msg);
+  RCLCPP_INFO(node->get_logger(), "Spinning until killed publishing %s to %s", msg.header.frame_id.c_str(), msg.child_frame_id.c_str());
+  rclcpp::spin(node);
   return 0;
 }

--- a/tf2_ros/src/transform_listener.cpp
+++ b/tf2_ros/src/transform_listener.cpp
@@ -57,7 +57,7 @@ TransformListener::TransformListener(tf2::BufferCore & buffer, bool spin_thread)
   options.start_parameter_event_publisher(false);
   options.start_parameter_services(false);
   optional_default_node_ = rclcpp::Node::make_shared("_", options);
-  init(optional_default_node_, spin_thread, DynamicQoS(), StaticQoS());
+  init(optional_default_node_, spin_thread, DynamicListenerQoS(), StaticListenerQoS());
 }
 
 TransformListener::~TransformListener()

--- a/tf2_ros/src/transform_listener.cpp
+++ b/tf2_ros/src/transform_listener.cpp
@@ -57,7 +57,7 @@ TransformListener::TransformListener(tf2::BufferCore & buffer, bool spin_thread)
   options.start_parameter_event_publisher(false);
   options.start_parameter_services(false);
   optional_default_node_ = rclcpp::Node::make_shared("_", options);
-  init(optional_default_node_, spin_thread);
+  init(optional_default_node_, spin_thread, DynamicQoS(), StaticQoS());
 }
 
 TransformListener::~TransformListener()


### PR DESCRIPTION
This makes `/tf_static` use transient_local durability to get behavior like ROS 1 latching.

The static broadcaster has a queue depth of 1 so only the latest message from a broadcaster is given to late joining listeners. This matches latching in ROS 1.