### PR TITLE
Migrate buffer action server to ROS 2 

### DIFF
--- a/tf2_ros/CMakeLists.txt
+++ b/tf2_ros/CMakeLists.txt
@@ -14,12 +14,10 @@ if(NOT ANDROID)
 endif()
 
 find_package(ament_cmake REQUIRED)
-# TODO(tfoote) uncomment when reenabling server client interfaces
-# find_package(actionlib REQUIRED)
-# find_package(actionlib_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(message_filters REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rclcpp_action REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_msgs REQUIRED)
 
@@ -31,7 +29,7 @@ add_library(${PROJECT_NAME} SHARED
   src/create_timer_ros.cpp
   src/transform_listener.cpp
   # src/buffer_client.cpp
-  # src/buffer_server.cpp
+  src/buffer_server.cpp
   src/transform_broadcaster.cpp
   src/static_transform_broadcaster.cpp
 )
@@ -40,22 +38,25 @@ ament_target_dependencies(${PROJECT_NAME}
   "geometry_msgs"
   "message_filters"
   "rclcpp"
+  "rclcpp_action"
   "tf2"
   "tf2_msgs"
 )
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE "TF2_ROS_BUILDING_DLL")
 
-# TODO(tfoote) port server client interfaces
-# # buffer_server executable
-# add_executable(buffer_server src/buffer_server_main.cpp)
-# add_dependencies(${PROJECT_NAME}_buffer_server tf2_msgs_gencpp)
-# target_link_libraries(${PROJECT_NAME}_buffer_server
-#   ${PROJECT_NAME}
-#   ${catkin_LIBRARIES}
-#   ${Boost_LIBRARIES}
-# )
-
+# buffer_server executable
+add_executable(buffer_server src/buffer_server_main.cpp)
+target_link_libraries(buffer_server
+  ${PROJECT_NAME}
+)
+ament_target_dependencies(buffer_server
+  "geometry_msgs"
+  "rclcpp"
+  "rclcpp_action"
+  "tf2"
+  "tf2_msgs"
+)
 
 # static_transform_publisher
 add_executable(static_transform_publisher
@@ -101,7 +102,7 @@ install(TARGETS
 
 # install executables
 install(TARGETS
-  # buffer_server
+  buffer_server
   static_transform_publisher
   tf2_echo
   tf2_monitor
@@ -118,6 +119,9 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   ament_add_gtest(test_buffer test/test_buffer.cpp)
   target_link_libraries(test_buffer ${PROJECT_NAME})
+
+  ament_add_gtest(test_buffer_server test/test_buffer_server.cpp)
+  target_link_libraries(test_buffer_server ${PROJECT_NAME})
 
   # Adds a tf2_ros message_filter unittest that uses
   # multiple target frames and a non-zero time tolerance

--- a/tf2_ros/include/tf2_ros/buffer_interface.h
+++ b/tf2_ros/include/tf2_ros/buffer_interface.h
@@ -64,6 +64,25 @@ namespace tf2_ros
     return tf2::TimePoint(std::chrono::duration_cast<tf2::Duration>(ns));
   }
 
+  inline builtin_interfaces::msg::Duration toMsg(const tf2::Duration & t)
+  {
+    std::chrono::nanoseconds ns = \
+      std::chrono::duration_cast<std::chrono::nanoseconds>(t);
+    std::chrono::seconds s = \
+      std::chrono::duration_cast<std::chrono::seconds>(t);
+    builtin_interfaces::msg::Duration duration_msg;
+    duration_msg.sec = (int32_t)s.count();
+    duration_msg.nanosec = (uint32_t)(ns.count() % 1000000000ull);
+    return duration_msg;
+  }
+
+  inline tf2::Duration fromMsg(const builtin_interfaces::msg::Duration & duration_msg)
+  {
+    int64_t d = duration_msg.sec * 1000000000ull + duration_msg.nanosec;
+    std::chrono::nanoseconds ns(d);
+    return tf2::Duration(std::chrono::duration_cast<tf2::Duration>(ns));
+  }
+
   inline double timeToSec(const builtin_interfaces::msg::Time & time_msg)
   {
     auto ns = std::chrono::duration<double, std::nano>(time_msg.nanosec);

--- a/tf2_ros/include/tf2_ros/buffer_server.h
+++ b/tf2_ros/include/tf2_ros/buffer_server.h
@@ -36,24 +36,29 @@
 *********************************************************************/
 #ifndef TF2_ROS_BUFFER_SERVER_H_
 #define TF2_ROS_BUFFER_SERVER_H_
+#include <memory>
+#include <string>
 
-#include <actionlib/server/action_server.h>
-#include <tf2_msgs/LookupTransformAction.h>
-#include <geometry_msgs/msg/transform_stamped.h>
-#include <tf2_ros/buffer.h>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <rclcpp/create_timer.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_action/rclcpp_action.hpp>
+#include <tf2_msgs/action/lookup_transform.hpp>
+
+#include <tf2/buffer_core_interface.h>
 
 namespace tf2_ros
 {
-  /** \brief Action server for the actionlib-based implementation of tf2_ros::BufferInterface.
-   * 
+  /** \brief Action server for the action-based implementation of tf2::BufferCoreInterface.
+   *
    * Use this class with a tf2_ros::TransformListener in the same process.
    * You can use this class with a tf2_ros::BufferClient in a different process.
    */
   class BufferServer
   {
     private:
-      typedef actionlib::ActionServer<tf2_msgs::LookupTransformAction> LookupTransformServer;
-      typedef LookupTransformServer::GoalHandle GoalHandle;
+      using LookupTransformAction = tf2_msgs::action::LookupTransform;
+      using GoalHandle = std::shared_ptr<rclcpp_action::ServerGoalHandle<LookupTransformAction>>;
 
       struct GoalInfo
       {
@@ -64,29 +69,59 @@ namespace tf2_ros
     public:
       /** \brief Constructor
        * \param buffer The Buffer that this BufferServer will wrap.
+       * \param node The node to add the buffer server to.
        * \param ns The namespace in which to look for action clients.
-       * \param auto_start Pass argument to the constructor of the ActionServer.
        * \param check_period How often to check for changes to known transforms (via a timer event).
        */
-      BufferServer(const Buffer& buffer, const std::string& ns,
-          bool auto_start = true, tf2::Duration check_period = tf2::durationFromSec(0.01));
+      template<typename NodePtr>
+      BufferServer(
+        const tf2::BufferCoreInterface& buffer,
+        NodePtr node,
+        const std::string& ns,
+        tf2::Duration check_period = tf2::durationFromSec(0.01))
+      : buffer_(buffer),
+        logger_(node->get_logger())
+      {
+        using namespace std::placeholders;
 
-      /** \brief Start the action server.
-       */
-      void start();
+        server_ = rclcpp_action::create_server<LookupTransformAction>(
+          node,
+          ns,
+          std::bind(&BufferServer::goalCB, this, _1, _2),
+          std::bind(&BufferServer::cancelCB, this, _1),
+          std::bind(&BufferServer::acceptedCB, this, _1));
+
+        check_timer_ = rclcpp::create_timer(
+          node, node->get_clock(), check_period, std::bind(&BufferServer::checkTransforms, this));
+        RCLCPP_DEBUG(logger_, "Buffer server started");
+      }
 
     private:
-      void goalCB(GoalHandle gh);
-      void cancelCB(GoalHandle gh);
-      void checkTransforms(const tf2::TimePointrEvent& e);
-      bool canTransform(GoalHandle gh);
-      geometry_msgs::TransformStamped lookupTransform(GoalHandle gh);
+      TF2_ROS_PUBLIC
+      rclcpp_action::GoalResponse goalCB(
+        const rclcpp_action::GoalUUID & uuid, std::shared_ptr<const LookupTransformAction::Goal> goal);
 
-      const Buffer& buffer_;
-      LookupTransformServer server_;
+      TF2_ROS_PUBLIC
+      void acceptedCB(GoalHandle gh);
+
+      TF2_ROS_PUBLIC
+      rclcpp_action::CancelResponse cancelCB(GoalHandle gh);
+
+      TF2_ROS_PUBLIC
+      void checkTransforms();
+
+      TF2_ROS_PUBLIC
+      bool canTransform(GoalHandle gh);
+
+      TF2_ROS_PUBLIC
+      geometry_msgs::msg::TransformStamped lookupTransform(GoalHandle gh);
+
+      const tf2::BufferCoreInterface& buffer_;
+      rclcpp::Logger logger_;
+      rclcpp_action::Server<LookupTransformAction>::SharedPtr server_;
       std::list<GoalInfo> active_goals_;
       std::mutex mutex_;
-      tf2::TimePointr check_timer_;
+      rclcpp::TimerBase::SharedPtr check_timer_;
   };
 }
 #endif

--- a/tf2_ros/package.xml
+++ b/tf2_ros/package.xml
@@ -21,12 +21,11 @@
 
   <depend>message_filters</depend>
   <depend>rclcpp</depend>
+  <depend>rclcpp_action</depend>
   <depend>tf2</depend>
   <depend>tf2_msgs</depend>
 
   <!-- TODO(tfoote) dependencies from unported sections restore when ported
-  <depend>actionlib</depend>
-  <depend>actionlib_msgs</depend>
   <depend>xmlrpcpp</depend> -->
   <!-- <build_depend version_gte="1.11.1">message_filters</build_depend> -->
   <!-- <build_depend>rosgraph</build_depend> -->

--- a/tf2_ros/src/buffer_server.cpp
+++ b/tf2_ros/src/buffer_server.cpp
@@ -34,23 +34,16 @@
 *
 * Author: Eitan Marder-Eppstein
 *********************************************************************/
+#include <string>
+
+#include <tf2/exceptions.h>
+
+#include <tf2_ros/buffer.h>  // Only needed for toMsg() and fromMsg()
 #include <tf2_ros/buffer_server.h>
 
 namespace tf2_ros
 {
-  BufferServer::BufferServer(const Buffer& buffer, const std::string& ns, bool auto_start, tf2::Duration check_period): 
-    buffer_(buffer),
-    server_(ros::NodeHandle(),
-            ns,
-            boost::bind(&BufferServer::goalCB, this, _1),
-            boost::bind(&BufferServer::cancelCB, this, _1),
-            auto_start)
-  {
-    ros::NodeHandle n;
-    check_timer_ = n.createTimer(check_period, boost::bind(&BufferServer::checkTransforms, this, _1));
-  }
-
-  void BufferServer::checkTransforms(const builtin_interfaces::msg::TimerEvent& e)
+  void BufferServer::checkTransforms()
   {
     std::unique_lock<std::mutex> lock(mutex_);
     for(std::list<GoalInfo>::iterator it = active_goals_.begin(); it != active_goals_.end();)
@@ -59,59 +52,81 @@ namespace tf2_ros
 
       //we want to lookup a transform if the time on the goal
       //has expired, or a transform is available
-      if(canTransform(info.handle) || info.end_time < tf2::get_now())
+      if(canTransform(info.handle))
       {
-        tf2_msgs::LookupTransformResult result;
+        auto result = std::make_shared<LookupTransformAction::Result>();
 
         //try to populate the result, catching exceptions if they occur
         try
         {
-          result.transform = lookupTransform(info.handle);
+          result->transform = lookupTransform(info.handle);
+
+          RCLCPP_DEBUG(
+            logger_,
+            "Can transform for goal %s",
+            rclcpp_action::to_string(info.handle->get_goal_id()).c_str());
+
+          info.handle->succeed(result);
         }
         catch (tf2::ConnectivityException &ex)
         {
-          result.error.error = result.error.CONNECTIVITY_ERROR;
-          result.error.error_string = ex.what();
+          result->error.error = result->error.CONNECTIVITY_ERROR;
+          result->error.error_string = ex.what();
+          info.handle->abort(result);
         }
         catch (tf2::LookupException &ex)
         {
-          result.error.error = result.error.LOOKUP_ERROR;
-          result.error.error_string = ex.what();
+          result->error.error = result->error.LOOKUP_ERROR;
+          result->error.error_string = ex.what();
+          info.handle->abort(result);
         }
         catch (tf2::ExtrapolationException &ex)
         {
-          result.error.error = result.error.EXTRAPOLATION_ERROR;
-          result.error.error_string = ex.what();
+          result->error.error = result->error.EXTRAPOLATION_ERROR;
+          result->error.error_string = ex.what();
+          info.handle->abort(result);
         }
         catch (tf2::InvalidArgumentException &ex)
         {
-          result.error.error = result.error.INVALID_ARGUMENT_ERROR;
-          result.error.error_string = ex.what();
+          result->error.error = result->error.INVALID_ARGUMENT_ERROR;
+          result->error.error_string = ex.what();
+          info.handle->abort(result);
         }
         catch (tf2::TimeoutException &ex)
         {
-          result.error.error = result.error.TIMEOUT_ERROR;
-          result.error.error_string = ex.what();
+          result->error.error = result->error.TIMEOUT_ERROR;
+          result->error.error_string = ex.what();
+          info.handle->abort(result);
         }
         catch (tf2::TransformException &ex)
         {
-          result.error.error = result.error.TRANSFORM_ERROR;
-          result.error.error_string = ex.what();
+          result->error.error = result->error.TRANSFORM_ERROR;
+          result->error.error_string = ex.what();
+          info.handle->abort(result);
         }
 
-        //make sure to pass the result to the client
-        //even failed transforms are considered a success
-        //since the request was successfully processed
-        it = active_goals_.erase(it);
-        info.handle.setSucceeded(result);
-      }
-      else
+      } else if (info.end_time < tf2::get_now()) {
+        // Timeout
+        auto result = std::make_shared<LookupTransformAction::Result>();
+        info.handle->abort(result);
+      } else {
         ++it;
+      }
+
+      // Remove goal if it has terminated
+      if (!info.handle->is_active()) {
+        it = active_goals_.erase(it);
+      }
     }
   }
 
-  void BufferServer::cancelCB(GoalHandle gh)
+  rclcpp_action::CancelResponse BufferServer::cancelCB(GoalHandle gh)
   {
+    RCLCPP_DEBUG(
+      logger_,
+      "Cancel request for goal %s",
+      rclcpp_action::to_string(gh->get_goal_id()).c_str());
+
     std::unique_lock<std::mutex> lock(mutex_);
     //we need to find the goal in the list and remove it... also setting it as canceled
     //if its not in the list, we won't do anything since it will have already been set
@@ -121,67 +136,90 @@ namespace tf2_ros
       GoalInfo& info = *it;
       if(info.handle == gh)
       {
+        RCLCPP_DEBUG(
+          logger_,
+          "Accept cancel request for goal %s",
+          rclcpp_action::to_string(gh->get_goal_id()).c_str());
         it = active_goals_.erase(it);
-        info.handle.setCanceled();
-        return;
+        auto result = std::make_shared<LookupTransformAction::Result>();
+        info.handle->canceled(result);
+        return rclcpp_action::CancelResponse::ACCEPT;
       }
       else
         ++it;
     }
+
+    RCLCPP_DEBUG(
+      logger_,
+      "Reject cancel request for goal %s",
+      rclcpp_action::to_string(gh->get_goal_id()).c_str());
+
+    return rclcpp_action::CancelResponse::REJECT;
   }
 
-  void BufferServer::goalCB(GoalHandle gh)
+  rclcpp_action::GoalResponse BufferServer::goalCB(
+    const rclcpp_action::GoalUUID & uuid, std::shared_ptr<const LookupTransformAction::Goal> goal)
   {
-    //we'll accept all goals we get
-    gh.setAccepted();
+    (void)uuid;
+    (void)goal;
+    // accept all goals we get
+    return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
+  }
 
+  void BufferServer::acceptedCB(GoalHandle gh)
+  {
+    RCLCPP_DEBUG(
+      logger_,
+      "New goal accepted with ID %s",
+      rclcpp_action::to_string(gh->get_goal_id()).c_str());
     //if the transform isn't immediately available, we'll push it onto our list to check
     //along with the time that the goal will end
     GoalInfo goal_info;
     goal_info.handle = gh;
-    goal_info.end_time = tf2::get_now() + gh.getGoal()->timeout;
+    goal_info.end_time = tf2::get_now() + tf2_ros::fromMsg(gh->get_goal()->timeout);
 
     //we can do a quick check here to see if the transform is valid
-    //we'll also do this if the end time has been reached 
+    //we'll also do this if the end time has been reached
     if(canTransform(gh) || goal_info.end_time <= tf2::get_now())
     {
-      tf2_msgs::LookupTransformResult result;
+      auto result = std::make_shared<LookupTransformAction::Result>();
       try
       {
-        result.transform = lookupTransform(gh);
+        result->transform = lookupTransform(gh);
       }
       catch (tf2::ConnectivityException &ex)
       {
-        result.error.error = result.error.CONNECTIVITY_ERROR;
-        result.error.error_string = ex.what();
+        result->error.error = result->error.CONNECTIVITY_ERROR;
+        result->error.error_string = ex.what();
       }
       catch (tf2::LookupException &ex)
       {
-        result.error.error = result.error.LOOKUP_ERROR;
-        result.error.error_string = ex.what();
+        result->error.error = result->error.LOOKUP_ERROR;
+        result->error.error_string = ex.what();
       }
       catch (tf2::ExtrapolationException &ex)
       {
-        result.error.error = result.error.EXTRAPOLATION_ERROR;
-        result.error.error_string = ex.what();
+        result->error.error = result->error.EXTRAPOLATION_ERROR;
+        result->error.error_string = ex.what();
       }
       catch (tf2::InvalidArgumentException &ex)
       {
-        result.error.error = result.error.INVALID_ARGUMENT_ERROR;
-        result.error.error_string = ex.what();
+        result->error.error = result->error.INVALID_ARGUMENT_ERROR;
+        result->error.error_string = ex.what();
       }
       catch (tf2::TimeoutException &ex)
       {
-        result.error.error = result.error.TIMEOUT_ERROR;
-        result.error.error_string = ex.what();
+        result->error.error = result->error.TIMEOUT_ERROR;
+        result->error.error_string = ex.what();
       }
       catch (tf2::TransformException &ex)
       {
-        result.error.error = result.error.TRANSFORM_ERROR;
-        result.error.error_string = ex.what();
+        result->error.error = result->error.TRANSFORM_ERROR;
+        result->error.error_string = ex.what();
       }
 
-      gh.setSucceeded(result);
+      RCLCPP_DEBUG(logger_, "Transform available immediately for new goal");
+      gh->succeed(result);
       return;
     }
 
@@ -191,31 +229,28 @@ namespace tf2_ros
 
   bool BufferServer::canTransform(GoalHandle gh)
   {
-    const tf2_msgs::LookupTransformGoal::ConstPtr& goal = gh.getGoal();
+    const auto goal = gh->get_goal();
+
+    tf2::TimePoint source_time_point = tf2_ros::fromMsg(goal->source_time);
+
+    // check whether we need to used the advanced or simple api
+    if(!goal->advanced)
+      return buffer_.canTransform(goal->target_frame, goal->source_frame, source_time_point, nullptr);
+
+    tf2::TimePoint target_time_point = tf2_ros::fromMsg(goal->target_time);
+    return buffer_.canTransform(goal->target_frame, target_time_point,
+        goal->source_frame, source_time_point, goal->fixed_frame, nullptr);
+  }
+
+  geometry_msgs::msg::TransformStamped BufferServer::lookupTransform(GoalHandle gh)
+  {
+    const auto goal = gh->get_goal();
 
     //check whether we need to used the advanced or simple api
     if(!goal->advanced)
-      return buffer_.canTransform(goal->target_frame, goal->source_frame, goal->source_time);
+      return buffer_.lookupTransform(goal->target_frame, goal->source_frame, tf2_ros::fromMsg(goal->source_time));
 
-    return buffer_.canTransform(goal->target_frame, goal->target_time, 
-        goal->source_frame, goal->source_time, goal->fixed_frame);
+    return buffer_.lookupTransform(goal->target_frame, tf2_ros::fromMsg(goal->target_time),
+        goal->source_frame, tf2_ros::fromMsg(goal->source_time), goal->fixed_frame);
   }
-
-  geometry_msgs::TransformStamped BufferServer::lookupTransform(GoalHandle gh)
-  {
-    const tf2_msgs::LookupTransformGoal::ConstPtr& goal = gh.getGoal();
-
-    //check whether we need to used the advanced or simple api
-    if(!goal->advanced)
-      return buffer_.lookupTransform(goal->target_frame, goal->source_frame, goal->source_time);
-
-    return buffer_.lookupTransform(goal->target_frame, goal->target_time, 
-        goal->source_frame, goal->source_time, goal->fixed_frame);
-  }
-
-  void BufferServer::start()
-  {
-    server_.start();
-  }
-
-};
+}  // namespace tf2_ros

--- a/tf2_ros/src/buffer_server_main.cpp
+++ b/tf2_ros/src/buffer_server_main.cpp
@@ -34,39 +34,25 @@
 *
 * Author: Wim Meeussen
 *********************************************************************/
+#include <tf2_ros/buffer.h>
 #include <tf2_ros/buffer_server.h>
 #include <tf2_ros/transform_listener.h>
-#include <ros/ros.h>
-
-
-class MyClass
-{
-public:
-  MyClass() {}
-  MyClass(double d) {}
-};
-
-class BlankClass
-{
-public:
-  BlankClass() {}
-};
+#include <rclcpp/rclcpp.hpp>
 
 int main(int argc, char** argv)
 {
-  ros::init(argc, argv, "tf_buffer");
-  ros::NodeHandle nh;  
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<rclcpp::Node>("tf_buffer");
+  double buffer_size = node->declare_parameter("buffer_size", 120.0);
 
-  double buffer_size;
-  nh.param("buffer_size", buffer_size, 120.0);
+  tf2_ros::Buffer buffer(node->get_clock(), tf2::durationFromSec(buffer_size));
+  tf2_ros::TransformListener listener(buffer);
+  tf2_ros::BufferServer buffer_server(buffer, node, "tf2_buffer_server");
 
-  // WIM: this works fine:
-  tf2_ros::Buffer buffer_core(tf2::durationFromSec(buffer_size+0)); // WTF??
-  tf2_ros::TransformListener listener(buffer_core);
-  tf2_ros::BufferServer buffer_server(buffer_core, "tf2_buffer_server", false);
-  buffer_server.start();
-  // But you should probably read this instead:
-  // http://www.informit.com/guides/content.aspx?g=cplusplus&seqNum=439
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+  executor.spin();
 
-  ros::spin();
+  rclcpp::shutdown();
+  return 0;
 }

--- a/tf2_ros/test/test_buffer_server.cpp
+++ b/tf2_ros/test/test_buffer_server.cpp
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2019, Open Source Robotics Foundation, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <chrono>
+#include <future>
+
+#include <gtest/gtest.h>
+
+#include <tf2_msgs/action/lookup_transform.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_action/rclcpp_action.hpp>
+
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/buffer_server.h>
+
+static const std::string ACTION_NAME = "test_tf2_buffer_action";
+
+class MockBufferClient : public rclcpp::Node
+{
+  using LookupTransformAction = tf2_msgs::action::LookupTransform;
+  using GoalHandle = rclcpp_action::ClientGoalHandle<LookupTransformAction>;
+
+public:
+  MockBufferClient()
+    : rclcpp::Node("mock_buffer_client"),
+      accepted_(false)
+  {
+    action_client_ = rclcpp_action::create_client<LookupTransformAction>(
+      get_node_base_interface(),
+      get_node_graph_interface(),
+      get_node_logging_interface(),
+      get_node_waitables_interface(),
+      ACTION_NAME);
+  }
+
+  std::shared_future<bool> send_goal(
+    const std::string target_frame,
+    const std::string source_frame,
+    const std::chrono::seconds timeout,
+    const std::string fixed_frame = "",
+    const bool advanced = false)
+  {
+    // Promise is set to true when the result is received
+    auto promise = std::make_shared<std::promise<bool>>();
+
+    auto goal = LookupTransformAction::Goal();
+    goal.target_frame = target_frame;
+    goal.source_frame = source_frame;
+    goal.source_time.sec = 0;
+    goal.source_time.nanosec = 0u;
+    goal.timeout.sec = static_cast<int32_t>(timeout.count());
+    goal.target_time.sec = 0;
+    goal.target_time.nanosec = 0u;
+    goal.fixed_frame = fixed_frame;
+    goal.advanced = advanced;
+
+    auto send_goal_options = rclcpp_action::Client<LookupTransformAction>::SendGoalOptions();
+    send_goal_options.goal_response_callback =
+      [this](std::shared_future<GoalHandle::SharedPtr> future) {
+        auto goal_handle = future.get();
+        if (!goal_handle) {
+          this->accepted_ = false;
+        } else {
+          this->accepted_ = true;
+        }
+      };
+
+    send_goal_options.result_callback = [this, promise](const GoalHandle::WrappedResult & result) {
+      this->result_ = result;
+      promise->set_value(true);
+    };
+    action_client_->async_send_goal(goal, send_goal_options);
+    return std::shared_future<bool>(promise->get_future());
+  }
+
+  bool accepted_;
+  GoalHandle::WrappedResult result_;
+  rclcpp_action::Client<LookupTransformAction>::SharedPtr action_client_;
+};
+
+class TestBufferServer : public ::testing::Test
+{
+protected:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestCase()
+  {
+    rclcpp::shutdown();
+  }
+
+  void SetUp()
+  {
+    node_ = std::make_shared<rclcpp::Node>("tf_buffer");
+    buffer_ = std::make_shared<tf2_ros::Buffer>(node_->get_clock());
+    server_ = std::make_unique<tf2_ros::BufferServer>(*buffer_, node_, ACTION_NAME);
+    mock_client_ = std::make_shared<MockBufferClient>();
+
+    executor_.add_node(node_);
+    executor_.add_node(mock_client_);
+
+    // Wait for discovery
+    ASSERT_TRUE(mock_client_->action_client_->wait_for_action_server(std::chrono::seconds(10)));
+  }
+
+  void TearDown()
+  {
+    mock_client_.reset();
+    server_.reset();
+    buffer_.reset();
+    node_.reset();
+  }
+
+  void setTransform(
+    const std::string target_frame,
+    const std::string source_frame,
+    geometry_msgs::msg::Transform transform)
+  {
+    geometry_msgs::msg::TransformStamped transform_stamped;
+    transform_stamped.header.frame_id = target_frame;
+    transform_stamped.child_frame_id = source_frame;
+    transform_stamped.transform = transform;
+    buffer_->setTransform(transform_stamped, "mock_tf_authority");
+  }
+
+  rclcpp::Node::SharedPtr node_;
+  std::shared_ptr<tf2_ros::Buffer> buffer_;
+  std::unique_ptr<tf2_ros::BufferServer> server_;
+  std::shared_ptr<MockBufferClient> mock_client_;
+  rclcpp::executors::SingleThreadedExecutor executor_;
+};
+
+TEST_F(TestBufferServer, lookup_transform_available)
+{
+  EXPECT_FALSE(mock_client_->accepted_);
+
+  // Send goal with 1 second timeout
+  auto result_ready_future = mock_client_->send_goal(
+    "test_target_link", "test_source_link", std::chrono::seconds(1));
+
+  // Make transform available
+  geometry_msgs::msg::Transform transform;
+  transform.translation.x = 1.0;
+  transform.translation.y = -2.0;
+  transform.translation.z = 3.0;
+  transform.rotation.w = 1.0;
+  setTransform("test_target_link", "test_source_link", transform);
+
+  auto spin_result = executor_.spin_until_future_complete(
+    result_ready_future, std::chrono::seconds(3));
+  ASSERT_EQ(spin_result, rclcpp::executor::FutureReturnCode::SUCCESS);
+
+  EXPECT_TRUE(mock_client_->accepted_);
+  EXPECT_EQ(mock_client_->result_.code, rclcpp_action::ResultCode::SUCCEEDED);
+}
+
+TEST_F(TestBufferServer, lookup_transform_timeout)
+{
+  EXPECT_FALSE(mock_client_->accepted_);
+
+  // Send goal with 1 second timeout
+  auto result_ready_future = mock_client_->send_goal(
+    "test_target_link", "test_source_link", std::chrono::seconds(1));
+
+  auto start_time = std::chrono::system_clock::now();
+  auto spin_result = executor_.spin_until_future_complete(
+    result_ready_future, std::chrono::seconds(3));
+  ASSERT_EQ(spin_result, rclcpp::executor::FutureReturnCode::SUCCESS);
+  auto end_time = std::chrono::system_clock::now();
+
+  auto time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
+  EXPECT_NEAR(static_cast<double>(time_ms.count()), 1000.0, 100.0);
+
+  EXPECT_TRUE(mock_client_->accepted_);
+  EXPECT_EQ(mock_client_->result_.code, rclcpp_action::ResultCode::ABORTED);
+}
+
+TEST_F(TestBufferServer, lookup_transform_delayed)
+{
+  EXPECT_FALSE(mock_client_->accepted_);
+
+  // Send goal with 5 second timeout
+  auto result_ready_future = mock_client_->send_goal(
+    "test_target_link", "test_source_link", std::chrono::seconds(5));
+
+  // Expect executor to timeout since transform is not available yet
+  auto spin_result = executor_.spin_until_future_complete(
+    result_ready_future, std::chrono::seconds(1));
+  EXPECT_EQ(spin_result, rclcpp::executor::FutureReturnCode::TIMEOUT);
+
+  EXPECT_TRUE(mock_client_->accepted_);
+
+  // Make transform available
+  geometry_msgs::msg::Transform transform;
+  transform.translation.x = 1.0;
+  transform.translation.y = -2.0;
+  transform.translation.z = 3.0;
+  transform.rotation.w = 1.0;
+  setTransform("test_target_link", "test_source_link", transform);
+
+  // Wait some more
+  spin_result = executor_.spin_until_future_complete(
+    result_ready_future, std::chrono::seconds(3));
+  ASSERT_EQ(spin_result, rclcpp::executor::FutureReturnCode::SUCCESS);
+
+  EXPECT_EQ(mock_client_->result_.code, rclcpp_action::ResultCode::SUCCEEDED);
+}
+
+int main(int argc, char **argv){
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+


### PR DESCRIPTION
PR contains two commits, the first is in support of the second:
* Add conversion functions for durations 8f95e9b
* Migrate buffer action server to ROS 2 4923ed3

Connects to #158 

This is the first half of #158. I'll follow-up with another PR for the action client.