### PR TITLE
Put some parens on that print.

### DIFF
--- a/tf2_ros/src/tf2_ros/buffer_interface.py
+++ b/tf2_ros/src/tf2_ros/buffer_interface.py
@@ -192,7 +192,7 @@ class TransformRegistration():
     __type_map = {}
     
     def print_me(self):
-        print TransformRegistration.__type_map
+        print(TransformRegistration.__type_map)
 
     def add(self, key, callback):
         TransformRegistration.__type_map[key] = callback


### PR DESCRIPTION
Found when doing syntax checks for Python 3.5 on Stretch.