### PR TITLE
Migrate buffer action client to ROS 2

### DIFF
--- a/tf2_ros/CMakeLists.txt
+++ b/tf2_ros/CMakeLists.txt
@@ -28,7 +28,7 @@ add_library(${PROJECT_NAME} SHARED
   src/buffer.cpp
   src/create_timer_ros.cpp
   src/transform_listener.cpp
-  # src/buffer_client.cpp
+  src/buffer_client.cpp
   src/buffer_server.cpp
   src/transform_broadcaster.cpp
   src/static_transform_broadcaster.cpp
@@ -122,6 +122,9 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_buffer_server test/test_buffer_server.cpp)
   target_link_libraries(test_buffer_server ${PROJECT_NAME})
+
+  ament_add_gtest(test_buffer_client test/test_buffer_client.cpp)
+  target_link_libraries(test_buffer_client ${PROJECT_NAME})
 
   # Adds a tf2_ros message_filter unittest that uses
   # multiple target frames and a non-zero time tolerance

--- a/tf2_ros/src/buffer_client.cpp
+++ b/tf2_ros/src/buffer_client.cpp
@@ -38,127 +38,171 @@
 
 namespace tf2_ros
 {
-  BufferClient::BufferClient(std::string ns, double check_frequency, tf2::Duration timeout_padding): 
-    client_(ns), 
-    check_frequency_(check_frequency),
-    timeout_padding_(timeout_padding)
+  geometry_msgs::msg::TransformStamped BufferClient::lookupTransform(
+    const std::string& target_frame,
+    const std::string& source_frame,
+    const tf2::TimePoint& time,
+    const tf2::Duration timeout) const
   {
-  }
-
-  geometry_msgs::TransformStamped BufferClient::lookupTransform(const std::string& target_frame, const std::string& source_frame,
-      const tf2::TimePoint& time, const tf2::Duration timeout) const
-  {
-    //populate the goal message
-    tf2_msgs::LookupTransformGoal goal;
+    // populate the goal message
+    LookupTransformAction::Goal goal;
     goal.target_frame = target_frame;
     goal.source_frame = source_frame;
-    goal.source_time = time;
-    goal.timeout = timeout;
+    goal.source_time = tf2_ros::toMsg(time);
+    goal.timeout = tf2_ros::toMsg(timeout);
     goal.advanced = false;
 
     return processGoal(goal);
   }
 
-  geometry_msgs::TransformStamped BufferClient::lookupTransform(const std::string& target_frame, const tf2::TimePoint& target_time,
-      const std::string& source_frame, const tf2::TimePoint& source_time,
-      const std::string& fixed_frame, const tf2::Duration timeout) const
+  geometry_msgs::msg::TransformStamped BufferClient::lookupTransform(
+    const std::string& target_frame,
+    const tf2::TimePoint& target_time,
+    const std::string& source_frame,
+    const tf2::TimePoint& source_time,
+    const std::string& fixed_frame,
+    const tf2::Duration timeout) const
   {
-    //populate the goal message
-    tf2_msgs::LookupTransformGoal goal;
+    // populate the goal message
+    LookupTransformAction::Goal goal;
     goal.target_frame = target_frame;
     goal.source_frame = source_frame;
-    goal.source_time = source_time;
-    goal.timeout = timeout;
-    goal.target_time = target_time;
+    goal.source_time = tf2_ros::toMsg(source_time);
+    goal.timeout = tf2_ros::toMsg(timeout);
+    goal.target_time = tf2_ros::toMsg(target_time);
     goal.fixed_frame = fixed_frame;
     goal.advanced = true;
 
     return processGoal(goal);
   }
 
-  geometry_msgs::TransformStamped BufferClient::processGoal(const tf2_msgs::LookupTransformGoal& goal) const
+  geometry_msgs::msg::TransformStamped BufferClient::processGoal(
+    const LookupTransformAction::Goal& goal) const
   {
-    client_.sendGoal(goal);
-    ros::Rate r(check_frequency_);
+    if (!client_->wait_for_action_server(tf2_ros::fromMsg(goal.timeout))) {
+      throw tf2::ConnectivityException("Failed find available action server");
+    }
+
+    auto goal_handle_future = client_->async_send_goal(goal);
+
+    const std::chrono::milliseconds period(static_cast<int>((1.0 / check_frequency_) * 1000));
+    bool ready = false;
     bool timed_out = false;
     tf2::TimePoint start_time = tf2::get_now();
-    while(ros::ok() && !client_.getState().isDone() && !timed_out)
-    {
-      timed_out = tf2::get_now() > start_time + goal.timeout + timeout_padding_;
-      r.sleep();
+    while (rclcpp::ok() && !ready && !timed_out) {
+      ready = (std::future_status::ready == goal_handle_future.wait_for(period));
+      timed_out = tf2::get_now() > start_time + tf2_ros::fromMsg(goal.timeout) + timeout_padding_;
     }
 
-    //this shouldn't happen, but could in rare cases where the server hangs
-    if(timed_out)
-    {
-      //make sure to cancel the goal the server is pursuing
-      client_.cancelGoal();
-      throw tf2::TimeoutException("The LookupTransform goal sent to the BufferServer did not come back in the specified time. Something is likely wrong with the server.");
+    if (timed_out) {
+      throw tf2::TimeoutException("Did not receive the goal response for the goal sent to "
+         "the action server. Something is likely wrong with the server.");
     }
 
-    if(client_.getState() != actionlib::SimpleClientGoalState::SUCCEEDED)
-      throw tf2::TimeoutException("The LookupTransform goal sent to the BufferServer did not come back with SUCCEEDED status. Something is likely wrong with the server.");
+    auto goal_handle = goal_handle_future.get();
+    if (!goal_handle) {
+      throw GoalRejectedException("Goal rejected by action server");
+    }
 
-    //process the result for errors and return it
-    return processResult(*client_.getResult());
+    auto result_future = client_->async_get_result(goal_handle);
+
+    ready = false;
+    while (rclcpp::ok() && !ready && !timed_out) {
+      ready = (std::future_status::ready == result_future.wait_for(period));
+      timed_out = tf2::get_now() > start_time + tf2_ros::fromMsg(goal.timeout) + timeout_padding_;
+    }
+
+    if (timed_out) {
+      throw tf2::TimeoutException("Did not receive the result for the goal sent to "
+         "the action server. Something is likely wrong with the server.");
+    }
+
+    auto wrapped_result = result_future.get();
+
+    switch (wrapped_result.code) {
+      case rclcpp_action::ResultCode::SUCCEEDED:
+        break;
+      case rclcpp_action::ResultCode::ABORTED:
+        throw GoalAbortedException("LookupTransform action was aborted");
+      case rclcpp_action::ResultCode::CANCELED:
+        throw GoalCanceledException("LookupTransform action was canceled");
+      default:
+        throw UnexpectedResultCodeException("Unexpected result code returned from server");
+    }
+
+    // process the result for errors and return it
+    return processResult(wrapped_result.result);
   }
 
-  geometry_msgs::TransformStamped BufferClient::processResult(const tf2_msgs::LookupTransformResult& result) const
+  geometry_msgs::msg::TransformStamped BufferClient::processResult(
+    const LookupTransformAction::Result::SharedPtr& result) const
   {
-    //if there's no error, then we'll just return the transform
-    if(result.error.error != result.error.NO_ERROR){
-      //otherwise, we'll have to throw the appropriate exception
-      if(result.error.error == result.error.LOOKUP_ERROR)
-        throw tf2::LookupException(result.error.error_string);
+    // if there's no error, then we'll just return the transform
+    if (result->error.error != result->error.NO_ERROR) {
+      // otherwise, we'll have to throw the appropriate exception
+      if (result->error.error == result->error.LOOKUP_ERROR)
+        throw tf2::LookupException(result->error.error_string);
 
-      if(result.error.error == result.error.CONNECTIVITY_ERROR)
-        throw tf2::ConnectivityException(result.error.error_string);
+      if (result->error.error == result->error.CONNECTIVITY_ERROR)
+        throw tf2::ConnectivityException(result->error.error_string);
 
-      if(result.error.error == result.error.EXTRAPOLATION_ERROR)
-        throw tf2::ExtrapolationException(result.error.error_string);
+      if (result->error.error == result->error.EXTRAPOLATION_ERROR)
+        throw tf2::ExtrapolationException(result->error.error_string);
 
-      if(result.error.error == result.error.INVALID_ARGUMENT_ERROR)
-        throw tf2::InvalidArgumentException(result.error.error_string);
+      if (result->error.error == result->error.INVALID_ARGUMENT_ERROR)
+        throw tf2::InvalidArgumentException(result->error.error_string);
 
-      if(result.error.error == result.error.TIMEOUT_ERROR)
-        throw tf2::TimeoutException(result.error.error_string);
+      if (result->error.error == result->error.TIMEOUT_ERROR)
+        throw tf2::TimeoutException(result->error.error_string);
 
-      throw tf2::TransformException(result.error.error_string);
+      throw tf2::TransformException(result->error.error_string);
     }
 
-    return result.transform;
+    return result->transform;
   }
 
-  bool BufferClient::canTransform(const std::string& target_frame, const std::string& source_frame, 
-        const tf2::TimePoint& time, const tf2::Duration timeout, std::string* errstr) const
+  bool BufferClient::canTransform(
+    const std::string& target_frame,
+    const std::string& source_frame,
+    const tf2::TimePoint& time,
+    const tf2::Duration timeout,
+    std::string* errstr) const
   {
-    try
-    {
+    try {
       lookupTransform(target_frame, source_frame, time, timeout);
       return true;
-    }
-    catch(tf2::TransformException& ex)
-    {
-      if(errstr)
+    } catch (tf2::TransformException& ex) {
+      if (errstr)
+        *errstr = ex.what();
+      return false;
+    } catch (LookupTransformGoalException& ex) {
+      if (errstr)
         *errstr = ex.what();
       return false;
     }
+
   }
 
-  bool BufferClient::canTransform(const std::string& target_frame, const tf2::TimePoint& target_time,
-        const std::string& source_frame, const tf2::TimePoint& source_time,
-        const std::string& fixed_frame, const tf2::Duration timeout, std::string* errstr) const
+  bool BufferClient::canTransform(
+    const std::string& target_frame,
+    const tf2::TimePoint& target_time,
+    const std::string& source_frame,
+    const tf2::TimePoint& source_time,
+    const std::string& fixed_frame,
+    const tf2::Duration timeout,
+    std::string* errstr) const
   {
-    try
-    {
+    try {
       lookupTransform(target_frame, target_time, source_frame, source_time, fixed_frame, timeout);
       return true;
-    }
-    catch(tf2::TransformException& ex)
-    {
+    } catch (tf2::TransformException& ex) {
       if(errstr)
+        *errstr = ex.what();
+      return false;
+    } catch (LookupTransformGoalException& ex) {
+      if (errstr)
         *errstr = ex.what();
       return false;
     }
   }
-};
+}  // namespace tf2_ros

--- a/tf2_ros/test/test_buffer_client.cpp
+++ b/tf2_ros/test/test_buffer_client.cpp
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2019, Open Source Robotics Foundation, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <chrono>
+#include <future>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include <tf2_msgs/action/lookup_transform.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_action/rclcpp_action.hpp>
+
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/buffer_client.h>
+
+static const std::string ACTION_NAME = "test_tf2_buffer_action";
+
+class MockBufferServer : public rclcpp::Node
+{
+  using LookupTransformAction = tf2_msgs::action::LookupTransform;
+  using GoalHandle = rclcpp_action::ServerGoalHandle<LookupTransformAction>;
+
+public:
+  MockBufferServer()
+    : rclcpp::Node("mock_buffer_server"),
+      transform_available_(false)
+  {
+    action_server_ = rclcpp_action::create_server<LookupTransformAction>(
+      get_node_base_interface(),
+      get_node_clock_interface(),
+      get_node_logging_interface(),
+      get_node_waitables_interface(),
+      ACTION_NAME,
+      [](const rclcpp_action::GoalUUID &, std::shared_ptr<const LookupTransformAction::Goal>)
+        {return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;},
+      [](const std::shared_ptr<GoalHandle>){return rclcpp_action::CancelResponse::ACCEPT;},
+      std::bind(&MockBufferServer::acceptedCallback, this, std::placeholders::_1));
+  }
+
+  void acceptedCallback(const std::shared_ptr<GoalHandle> goal_handle)
+  {
+    auto result = std::make_shared<LookupTransformAction::Result>();
+    if (transform_available_) {
+      result->transform.transform = transform_;
+      goal_handle->succeed(result);
+    } else {
+      goal_handle->abort(result);
+    }
+  }
+
+  void setTransform(const geometry_msgs::msg::Transform & transform)
+  {
+    transform_ = transform;
+    transform_available_ = true;
+  }
+
+private:
+  geometry_msgs::msg::Transform transform_;
+  bool transform_available_;
+
+  rclcpp_action::Server<LookupTransformAction>::SharedPtr action_server_;
+};
+
+class TestBufferClient : public ::testing::Test
+{
+protected:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestCase()
+  {
+    rclcpp::shutdown();
+  }
+
+  void SetUp()
+  {
+    node_ = std::make_shared<rclcpp::Node>("tf_buffer");
+    client_ = std::make_unique<tf2_ros::BufferClient>(node_, ACTION_NAME);
+    mock_server_ = std::make_shared<MockBufferServer>();
+
+    executor_.add_node(node_);
+    executor_.add_node(mock_server_);
+
+    // Start spinning in a thread
+    spin_thread_ = std::thread(
+      std::bind(&rclcpp::executors::SingleThreadedExecutor::spin, &executor_));
+
+    // Wait for discovery
+    ASSERT_TRUE(client_->waitForServer(std::chrono::seconds(10)));
+    // This hack ensure the action server can see the client
+    // TODO(jacobperron): Replace with discovery rclcpp API when it exists
+    while (mock_server_->count_subscribers("/" + ACTION_NAME + "/_action/feedback") < 1u) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+  }
+
+  void TearDown()
+  {
+    executor_.cancel();
+    spin_thread_.join();
+    mock_server_.reset();
+    client_.reset();
+    node_.reset();
+  }
+
+  rclcpp::Node::SharedPtr node_;
+  std::unique_ptr<tf2_ros::BufferClient> client_;
+  std::shared_ptr<MockBufferServer> mock_server_;
+  rclcpp::executors::SingleThreadedExecutor executor_;
+  std::thread spin_thread_;
+};
+
+TEST_F(TestBufferClient, lookup_transform_available)
+{
+  // Set a transform to be available
+  geometry_msgs::msg::Transform transform_in;
+  transform_in.rotation.w = 0.5;
+  transform_in.translation.x = 42.0;
+  mock_server_->setTransform(transform_in);
+
+  auto transform_out = client_->lookupTransform(
+    "test_target_frame", "test_source_frame", tf2::get_now());
+
+  EXPECT_EQ(transform_out.transform.rotation.w, transform_in.rotation.w);
+  EXPECT_EQ(transform_out.transform.translation.x, transform_in.translation.x);
+}
+
+TEST_F(TestBufferClient, lookup_transform_unavailable)
+{
+  EXPECT_THROW(
+    client_->lookupTransform("test_target_frame", "test_source_frame", tf2::get_now()),
+    tf2_ros::GoalAbortedException);
+}
+
+TEST_F(TestBufferClient, can_transform_available)
+{
+  // Set a transform to be available
+  geometry_msgs::msg::Transform transform_in;
+  transform_in.rotation.w = 0.5;
+  transform_in.translation.x = 42.0;
+  mock_server_->setTransform(transform_in);
+
+  EXPECT_TRUE(client_->canTransform("test_target_frame", "test_source_frame", tf2::get_now()));
+}
+
+TEST_F(TestBufferClient, can_transform_unavailable)
+{
+  EXPECT_FALSE(client_->canTransform("test_target_frame", "test_source_frame", tf2::get_now()));
+}
+
+int main(int argc, char **argv){
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+


### PR DESCRIPTION
Closes #158 

Introduce new custom exceptions with base class tf2_ros::LookupTransformGoalException
for communicating different failure modes.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8116)](http://ci.ros2.org/job/ci_linux/8116/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=4109)](http://ci.ros2.org/job/ci_linux-aarch64/4109/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6610)](http://ci.ros2.org/job/ci_osx/6610/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7998)](http://ci.ros2.org/job/ci_windows/7998/)