### PR TITLE
Make BufferClient destructor virtual

### DIFF
--- a/tf2_ros/include/tf2_ros/buffer_client.h
+++ b/tf2_ros/include/tf2_ros/buffer_client.h
@@ -126,6 +126,7 @@ namespace tf2_ros
       {
         client_ = rclcpp_action::create_client<LookupTransformAction>(node, ns);
       }
+      virtual ~BufferClient() = default;
 
       /** \brief Get the transform between two frames by frame ID.
        *


### PR DESCRIPTION
Reported by clang:
```
delete called on non-final 'tf2_ros::BufferClient' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]
```

https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/175/warnings23Result/