### PR TITLE
Quaternion initialization

### DIFF
--- a/test_tf2/test/test_tf2_bullet.cpp
+++ b/test_tf2/test/test_tf2_bullet.cpp
@@ -92,7 +92,10 @@ int main(int argc, char **argv){
   t.transform.translation.x = 10;
   t.transform.translation.y = 20;
   t.transform.translation.z = 30;
+  t.transform.rotation.w = 0;
   t.transform.rotation.x = 1;
+  t.transform.rotation.y = 0;
+  t.transform.rotation.z = 0;
   t.header.stamp = builtin_interfaces::msg::Time(2.0);
   t.header.frame_id = "A";
   t.child_frame_id = "B";

--- a/test_tf2/test/test_tf2_bullet.cpp
+++ b/test_tf2/test/test_tf2_bullet.cpp
@@ -36,7 +36,7 @@
 #include <gtest/gtest.h>
 #include <tf2/convert.h>
 
-tf2_ros::Buffer* tf_buffer;
+std::unique_ptr<tf2_ros::Buffer> tf_buffer = nullptr;
 static const double EPS = 1e-3;
 
 TEST(TfBullet, Transform)
@@ -85,7 +85,7 @@ int main(int argc, char **argv){
   ros::init(argc, argv, "test");
   ros::NodeHandle n;
 
-  tf_buffer = new tf2_ros::Buffer();
+  tf_buffer = std::make_unique<tf2_ros::Buffer>();
 
   // populate buffer
   geometry_msgs::TransformStamped t;
@@ -102,6 +102,5 @@ int main(int argc, char **argv){
   tf_buffer->setTransform(t, "test");
 
   int ret = RUN_ALL_TESTS();
-  delete tf_buffer;
   return ret;
 }

--- a/tf2_geometry_msgs/scripts/test.py
+++ b/tf2_geometry_msgs/scripts/test.py
@@ -5,14 +5,14 @@ import rospy
 import PyKDL
 import tf2_ros
 import tf2_geometry_msgs
-from geometry_msgs.msg import TransformStamped, PointStamped, Vector3Stamped, PoseStamped
+from geometry_msgs.msg import TransformStamped, PointStamped, Vector3Stamped, PoseStamped, Quaternion
 
 class GeometryMsgs(unittest.TestCase):
     def test_transform(self):
         b = tf2_ros.Buffer()
         t = TransformStamped()
         t.transform.translation.x = 1
-        t.transform.rotation.x = 1
+        t.transform.rotation = Quaternion(w=0, x=1, y=0, z=0)
         t.header.stamp = rospy.Time(2.0)
         t.header.frame_id = 'a'
         t.child_frame_id = 'b'
@@ -40,7 +40,7 @@ class GeometryMsgs(unittest.TestCase):
         v.pose.position.x = 1
         v.pose.position.y = 2
         v.pose.position.z = 3
-        v.pose.orientation.x = 1
+        v.pose.orientation = Quaternion(w=0, x=1, y=0, z=0)
         out = b.transform(v, 'b')
         self.assertEqual(out.pose.position.x, 0)
         self.assertEqual(out.pose.position.y, -2)
@@ -51,7 +51,7 @@ class GeometryMsgs(unittest.TestCase):
         t.transform.translation.x = 1
         t.transform.translation.y = 2
         t.transform.translation.z = 3
-        t.transform.rotation.w = 1
+        t.transform.rotation = Quaterion(w=1, x=0, y=0, z=0)
         v = Vector3Stamped()
         v.vector.x = 1
         v.vector.y = 0
@@ -66,7 +66,7 @@ class GeometryMsgs(unittest.TestCase):
         t.transform.translation.x = 1
         t.transform.translation.y = 2
         t.transform.translation.z = 3
-        t.transform.rotation.y = 1
+        t.transform.rotation = Quaterion(w=0, x=0, y=1, z=0)
 
         v = Vector3Stamped()
         v.vector.x = 1

--- a/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
+++ b/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
@@ -45,7 +45,10 @@ TEST(TfGeometry, Frame)
   v1.pose.position.x = 1;
   v1.pose.position.y = 2;
   v1.pose.position.z = 3;
+  v1.pose.orientation.w = 0;
   v1.pose.orientation.x = 1;
+  v1.pose.orientation.y = 0;
+  v1.pose.orientation.z = 0;
   v1.header.stamp = tf2_ros::toMsg(tf2::timeFromSec(2));
   v1.header.frame_id = "A";
 
@@ -134,7 +137,10 @@ int main(int argc, char **argv){
   t.transform.translation.x = 10;
   t.transform.translation.y = 20;
   t.transform.translation.z = 30;
+  t.transform.rotation.w = 0;
   t.transform.rotation.x = 1;
+  t.transform.rotation.y = 0;
+  t.transform.rotation.z = 0;
   t.header.stamp = tf2_ros::toMsg(tf2::timeFromSec(2));
   t.header.frame_id = "A";
   t.child_frame_id = "B";

--- a/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
+++ b/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
@@ -35,7 +35,7 @@
 #include <tf2_ros/buffer.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
-tf2_ros::Buffer* tf_buffer;
+std::unique_ptr<tf2_ros::Buffer> tf_buffer = nullptr;
 static const double EPS = 1e-3;
 
 
@@ -129,7 +129,7 @@ int main(int argc, char **argv){
   testing::InitGoogleTest(&argc, argv);
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf_buffer = new tf2_ros::Buffer(clock);
+  tf_buffer = std::make_unique<tf2_ros::Buffer>(clock);
   tf_buffer->setUsingDedicatedThread(true);
 
   // populate buffer
@@ -147,6 +147,5 @@ int main(int argc, char **argv){
   tf_buffer->setTransform(t, "test");
 
   int ret = RUN_ALL_TESTS();
-  delete tf_buffer;
   return ret;
 }

--- a/tf2_kdl/scripts/test.py
+++ b/tf2_kdl/scripts/test.py
@@ -5,7 +5,7 @@ import rclpy
 import PyKDL
 import tf2_ros
 import tf2_kdl
-from geometry_msgs.msg import TransformStamped
+from geometry_msgs.msg import TransformStamped, Quaternion
 from copy import deepcopy
 import builtin_interfaces
 
@@ -14,7 +14,7 @@ class KDLConversions(unittest.TestCase):
         b = tf2_ros.Buffer()
         t = TransformStamped()
         t.transform.translation.x = 1.0
-        t.transform.rotation.x = 1.0
+        t.transform.rotation = Quaternion(w=0, x=1, y=0, z=0)
         t.header.stamp = builtin_interfaces.msg.Time(sec=2)
         t.header.frame_id = 'a'
         t.child_frame_id = 'b'

--- a/tf2_kdl/test/test_tf2_kdl.cpp
+++ b/tf2_kdl/test/test_tf2_kdl.cpp
@@ -124,7 +124,10 @@ int main(int argc, char **argv){
   t.transform.translation.x = 10;
   t.transform.translation.y = 20;
   t.transform.translation.z = 30;
+  t.transform.rotation.w = 0;
   t.transform.rotation.x = 1;
+  t.transform.rotation.y = 0;
+  t.transform.rotation.z = 0;
   t.header.stamp.sec = 2;
   t.header.stamp.nanosec = 0;
   t.header.frame_id = "A";

--- a/tf2_ros/test/time_reset_test.cpp
+++ b/tf2_ros/test/time_reset_test.cpp
@@ -57,7 +57,10 @@ TEST(tf2_ros_transform_listener, time_backwards)
   msg.header.stamp = builtin_interfaces::msg::Time(100, 0);
   msg.header.frame_id = "foo";
   msg.child_frame_id = "bar";
+  msg.transform.rotation.w = 0.0;
   msg.transform.rotation.x = 1.0;
+  msg.transform.rotation.y = 0.0;
+  msg.transform.rotation.z = 0.0;
   tfb.sendTransform(msg);
   msg.header.stamp = builtin_interfaces::msg::Time(102, 0);
   tfb.sendTransform(msg);

--- a/tf2_sensor_msgs/test/test_tf2_sensor_msgs.cpp
+++ b/tf2_sensor_msgs/test/test_tf2_sensor_msgs.cpp
@@ -35,7 +35,7 @@
 #include <gtest/gtest.h>
 #include <tf2_ros/buffer.h>
 
-tf2_ros::Buffer* tf_buffer;
+std::unique_ptr<tf2_ros::Buffer> tf_buffer = nullptr;
 static const double EPS = 1e-3;
 
 
@@ -83,7 +83,7 @@ int main(int argc, char **argv){
   ros::NodeHandle n;
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf_buffer = new tf2_ros::Buffer(clock);
+  tf_buffer = std::make_unique<tf2_ros::Buffer>(clock);
 
   // populate buffer
   geometry_msgs::msg::TransformStamped t;
@@ -100,6 +100,5 @@ int main(int argc, char **argv){
   tf_buffer->setTransform(t, "test");
 
   int ret = RUN_ALL_TESTS();
-  delete tf_buffer;
   return ret;
 }


### PR DESCRIPTION
I've recently proposed [changing the default values](https://github.com/ros2/common_interfaces/pull/74) of the `Quaternion` message to default to the identity quaternion rather than all zeros. A few tests here make the assumption that message fields (`w` in particular) are initialized to zero. This PR removes those assumptions and can be merged regardless of whether the change to the default values is accepted or not.

