### PR TITLE
Remove template specialization for toMsg functions

### DIFF
--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
@@ -354,7 +354,6 @@ void fromMsg(const geometry_msgs::msg::QuaternionStamped& msg, geometry_msgs::ms
  * \param in A instance of the tf2::Quaternion specialization of the tf2::Stamped template.
  * \return The QuaternionStamped converted to a geometry_msgs QuaternionStamped message type.
  */
-template <>
 inline
 geometry_msgs::msg::QuaternionStamped toMsg(const tf2::Stamped<tf2::Quaternion>& in)
 {

--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
@@ -372,7 +372,6 @@ geometry_msgs::msg::QuaternionStamped toMsg(const tf2::Stamped<tf2::Quaternion>&
  * \param in A QuaternionStamped message type.
  * \param out The QuaternionStamped converted to the equivalent tf2 type.
  */
-template <>
 inline
 void fromMsg(const geometry_msgs::msg::QuaternionStamped& in, tf2::Stamped<tf2::Quaternion>& out)
 {

--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
@@ -508,7 +508,6 @@ void fromMsg(const geometry_msgs::msg::TransformStamped& in, tf2::Stamped <tf2::
  * \param in An instance of the tf2::Transform specialization of the tf2::Stamped template.
  * \return The TransformStamped converted to a geometry_msgs TransformStamped message type.
  */
-template <>
 inline
 geometry_msgs::msg::TransformStamped toMsg(const tf2::Stamped<tf2::Transform>& in)
 {

--- a/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
+++ b/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
@@ -40,6 +40,21 @@ static const double EPS = 1e-3;
 
 TEST(TfGeometry, Conversions)
 {
+  // QuaternionStamped
+  {
+    auto rotation = tf2::Quaternion(1.0, 2.0, 3.0, 4.0).normalized();
+    auto stamp = tf2::timeFromSec(2);
+    std::string frame_id = "test_frame_id";
+    tf2::Stamped<tf2::Quaternion> quat_stamped(rotation, stamp, frame_id);
+    geometry_msgs::msg::QuaternionStamped quat_stamped_msg;
+    quat_stamped_msg = tf2::toMsg(quat_stamped);
+
+    EXPECT_NEAR(rotation.getX(), quat_stamped_msg.quaternion.x, EPS);
+    EXPECT_NEAR(rotation.getY(), quat_stamped_msg.quaternion.y, EPS);
+    EXPECT_NEAR(rotation.getZ(), quat_stamped_msg.quaternion.z, EPS);
+    EXPECT_NEAR(rotation.getW(), quat_stamped_msg.quaternion.w, EPS);
+  }
+
   // TransformStamped
   {
     auto rotation = tf2::Quaternion(1.0, 2.0, 3.0, 4.0).normalized();

--- a/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
+++ b/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
@@ -47,7 +47,7 @@ TEST(TfGeometry, Conversions)
     std::string frame_id = "test_frame_id";
     tf2::Stamped<tf2::Quaternion> quat_stamped(rotation, stamp, frame_id);
     geometry_msgs::msg::QuaternionStamped quat_stamped_msg;
-    quat_stamped_msg = tf2::toMsg(quat_stamped);
+    tf2::convert(quat_stamped, quat_stamped_msg);
 
     EXPECT_NEAR(rotation.getX(), quat_stamped_msg.quaternion.x, EPS);
     EXPECT_NEAR(rotation.getY(), quat_stamped_msg.quaternion.y, EPS);
@@ -56,7 +56,7 @@ TEST(TfGeometry, Conversions)
     EXPECT_EQ(frame_id, quat_stamped_msg.header.frame_id);
 
     tf2::Stamped<tf2::Quaternion> quat_from_msg;
-    tf2::fromMsg(quat_stamped_msg, quat_from_msg);
+    tf2::convert(quat_stamped_msg, quat_from_msg);
 
     EXPECT_NEAR(quat_from_msg.getX(), quat_stamped_msg.quaternion.x, EPS);
     EXPECT_NEAR(quat_from_msg.getY(), quat_stamped_msg.quaternion.y, EPS);
@@ -73,7 +73,7 @@ TEST(TfGeometry, Conversions)
     std::string frame_id = "test_frame_id";
     tf2::Stamped<tf2::Transform> tf_stamped(tf2::Transform(rotation, translation), stamp, frame_id);
     geometry_msgs::msg::TransformStamped tf_stamped_msg;
-    tf_stamped_msg = tf2::toMsg(tf_stamped);
+    tf2::convert(tf_stamped, tf_stamped_msg);
 
     EXPECT_NEAR(rotation.getX(), tf_stamped_msg.transform.rotation.x, EPS);
     EXPECT_NEAR(rotation.getY(), tf_stamped_msg.transform.rotation.y, EPS);
@@ -85,7 +85,7 @@ TEST(TfGeometry, Conversions)
     EXPECT_EQ(frame_id, tf_stamped_msg.header.frame_id);
 
     tf2::Stamped<tf2::Transform> tf_from_msg;
-    tf2::fromMsg(tf_stamped_msg, tf_from_msg);
+    tf2::convert(tf_stamped_msg, tf_from_msg);
 
     EXPECT_NEAR(tf_from_msg.getRotation().getX(), tf_stamped_msg.transform.rotation.x, EPS);
     EXPECT_NEAR(tf_from_msg.getRotation().getY(), tf_stamped_msg.transform.rotation.y, EPS);

--- a/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
+++ b/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
@@ -42,7 +42,7 @@ TEST(TfGeometry, Conversions)
 {
   // TransformStamped
   {
-    tf2::Quaternion rotation(1.0, 2.0, 3.0, 4.0);
+    auto rotation = tf2::Quaternion(1.0, 2.0, 3.0, 4.0).normalized();
     tf2::Vector3 translation(1.0, 2.0, 3.0);
     auto stamp = tf2::timeFromSec(2);
     std::string frame_id = "test_frame_id";
@@ -50,13 +50,13 @@ TEST(TfGeometry, Conversions)
     geometry_msgs::msg::TransformStamped tf_stamped_msg;
     tf_stamped_msg = tf2::toMsg(tf_stamped);
 
-    EXPECT_NEAR(rotation.x(), tf_stamped_msg.transform.rotation.x, EPS);
-    EXPECT_NEAR(rotation.y(), tf_stamped_msg.transform.rotation.y, EPS);
-    EXPECT_NEAR(rotation.z(), tf_stamped_msg.transform.rotation.z, EPS);
-    EXPECT_NEAR(rotation.w(), tf_stamped_msg.transform.rotation.w, EPS);
-    EXPECT_NEAR(translation.x(), tf_stamped_msg.transform.translation.z, EPS);
-    EXPECT_NEAR(translation.y(), tf_stamped_msg.transform.translation.y, EPS);
-    EXPECT_NEAR(translation.z(), tf_stamped_msg.transform.translation.z, EPS);
+    EXPECT_NEAR(rotation.getX(), tf_stamped_msg.transform.rotation.x, EPS);
+    EXPECT_NEAR(rotation.getY(), tf_stamped_msg.transform.rotation.y, EPS);
+    EXPECT_NEAR(rotation.getZ(), tf_stamped_msg.transform.rotation.z, EPS);
+    EXPECT_NEAR(rotation.getW(), tf_stamped_msg.transform.rotation.w, EPS);
+    EXPECT_NEAR(translation.getX(), tf_stamped_msg.transform.translation.x, EPS);
+    EXPECT_NEAR(translation.getY(), tf_stamped_msg.transform.translation.y, EPS);
+    EXPECT_NEAR(translation.getZ(), tf_stamped_msg.transform.translation.z, EPS);
   }
 }
 

--- a/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
+++ b/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
@@ -38,6 +38,27 @@
 std::unique_ptr<tf2_ros::Buffer> tf_buffer = nullptr;
 static const double EPS = 1e-3;
 
+TEST(TfGeometry, Conversions)
+{
+  // TransformStamped
+  {
+    tf2::Quaternion rotation(1.0, 2.0, 3.0, 4.0);
+    tf2::Vector3 translation(1.0, 2.0, 3.0);
+    auto stamp = tf2::timeFromSec(2);
+    std::string frame_id = "test_frame_id";
+    tf2::Stamped<tf2::Transform> tf_stamped(tf2::Transform(rotation, translation), stamp, frame_id);
+    geometry_msgs::msg::TransformStamped tf_stamped_msg;
+    tf_stamped_msg = tf2::toMsg(tf_stamped);
+
+    EXPECT_NEAR(rotation.x(), tf_stamped_msg.transform.rotation.x, EPS);
+    EXPECT_NEAR(rotation.y(), tf_stamped_msg.transform.rotation.y, EPS);
+    EXPECT_NEAR(rotation.z(), tf_stamped_msg.transform.rotation.z, EPS);
+    EXPECT_NEAR(rotation.w(), tf_stamped_msg.transform.rotation.w, EPS);
+    EXPECT_NEAR(translation.x(), tf_stamped_msg.transform.translation.z, EPS);
+    EXPECT_NEAR(translation.y(), tf_stamped_msg.transform.translation.y, EPS);
+    EXPECT_NEAR(translation.z(), tf_stamped_msg.transform.translation.z, EPS);
+  }
+}
 
 TEST(TfGeometry, Frame)
 {

--- a/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
+++ b/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
@@ -53,6 +53,16 @@ TEST(TfGeometry, Conversions)
     EXPECT_NEAR(rotation.getY(), quat_stamped_msg.quaternion.y, EPS);
     EXPECT_NEAR(rotation.getZ(), quat_stamped_msg.quaternion.z, EPS);
     EXPECT_NEAR(rotation.getW(), quat_stamped_msg.quaternion.w, EPS);
+    EXPECT_EQ(frame_id, quat_stamped_msg.header.frame_id);
+
+    tf2::Stamped<tf2::Quaternion> quat_from_msg;
+    tf2::fromMsg(quat_stamped_msg, quat_from_msg);
+
+    EXPECT_NEAR(quat_from_msg.getX(), quat_stamped_msg.quaternion.x, EPS);
+    EXPECT_NEAR(quat_from_msg.getY(), quat_stamped_msg.quaternion.y, EPS);
+    EXPECT_NEAR(quat_from_msg.getZ(), quat_stamped_msg.quaternion.z, EPS);
+    EXPECT_NEAR(quat_from_msg.getW(), quat_stamped_msg.quaternion.w, EPS);
+    EXPECT_EQ(quat_from_msg.frame_id_, quat_stamped_msg.header.frame_id);
   }
 
   // TransformStamped
@@ -72,6 +82,19 @@ TEST(TfGeometry, Conversions)
     EXPECT_NEAR(translation.getX(), tf_stamped_msg.transform.translation.x, EPS);
     EXPECT_NEAR(translation.getY(), tf_stamped_msg.transform.translation.y, EPS);
     EXPECT_NEAR(translation.getZ(), tf_stamped_msg.transform.translation.z, EPS);
+    EXPECT_EQ(frame_id, tf_stamped_msg.header.frame_id);
+
+    tf2::Stamped<tf2::Transform> tf_from_msg;
+    tf2::fromMsg(tf_stamped_msg, tf_from_msg);
+
+    EXPECT_NEAR(tf_from_msg.getRotation().getX(), tf_stamped_msg.transform.rotation.x, EPS);
+    EXPECT_NEAR(tf_from_msg.getRotation().getY(), tf_stamped_msg.transform.rotation.y, EPS);
+    EXPECT_NEAR(tf_from_msg.getRotation().getZ(), tf_stamped_msg.transform.rotation.z, EPS);
+    EXPECT_NEAR(tf_from_msg.getRotation().getW(), tf_stamped_msg.transform.rotation.w, EPS);
+    EXPECT_NEAR(tf_from_msg.getOrigin().getX(), tf_stamped_msg.transform.translation.x, EPS);
+    EXPECT_NEAR(tf_from_msg.getOrigin().getY(), tf_stamped_msg.transform.translation.y, EPS);
+    EXPECT_NEAR(tf_from_msg.getOrigin().getZ(), tf_stamped_msg.transform.translation.z, EPS);
+    EXPECT_EQ(tf_from_msg.frame_id_, tf_stamped_msg.header.frame_id);
   }
 }
 


### PR DESCRIPTION
Resolves #176 

Before, the compiler was preferring the overloaded function:

https://github.com/ros2/geometry2/blob/71b054249cda9f1bbdbdc2f61bd518b998ce0378/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h#L397-L398

instead of the template specialization. I tried to change the overload into a template specialization, but then we run into the error that the compile can't deduce the second template parameter (ie. the return type).

I'm not sure if this is an ideal fix, or if instead we should go with template specialization (I'm not sure how we were/are benefiting from this), which requires the user to be explicit:

```c++
auto msg = tf2::toMsg<tf2::Stamped<tf2::Transform>, geometry_msgs::msg::TransformStamped>(tf_stamped);
```

I've also went ahead and made the change for stamped quaternions, which have the same bug.