### PR TITLE
Print out the name of the signalFailure reason instead of just its enum value

### DIFF
--- a/tf2_ros/include/tf2_ros/message_filter.h
+++ b/tf2_ros/include/tf2_ros/message_filter.h
@@ -64,6 +64,8 @@ namespace filter_failure_reasons
 {
 enum FilterFailureReason
 {
+  // NOTE when adding new values, do not explicitly assign a number. See FilterFailureReasonCount
+
   /// The message buffer overflowed, and this message was pushed off the back of the queue, but the reason it was unable to be transformed is unknown.
   Unknown,
   /// The timestamp on the message is more than the cache length earlier than the newest data in the transform cache
@@ -76,7 +78,7 @@ enum FilterFailureReason
 
 }
 
-std::string get_filter_failure_reason_string(filter_failure_reasons::FilterFailureReason reason) {
+static std::string get_filter_failure_reason_string(filter_failure_reasons::FilterFailureReason reason) {
   switch (reason) {
     case filter_failure_reasons::Unknown:
       return "Unknown";
@@ -369,7 +371,7 @@ public:
             info.handles.push_back(next_handle_index_++);
           }
         }
-        catch (std::exception & e)  {
+        catch (const std::exception & e)  {
           TF2_ROS_MESSAGEFILTER_WARN("Message dropped because: %s", e.what());
           messageDropped(evt, filter_failure_reasons::OutTheBack);
           return;
@@ -393,7 +395,7 @@ public:
               info.handles.push_back(next_handle_index_++);
             }
           }
-          catch (std::exception & e)  {
+          catch (const std::exception & e)  {
             TF2_ROS_MESSAGEFILTER_WARN("Message dropped because: %s", e.what());
             messageDropped(evt, filter_failure_reasons::OutTheBack);
             return;

--- a/tf2_ros/include/tf2_ros/message_filter.h
+++ b/tf2_ros/include/tf2_ros/message_filter.h
@@ -70,7 +70,7 @@ enum FilterFailureReason
   OutTheBack,
   /// The frame_id on the message is empty
   EmptyFrameID,
-  /// Placeholder value, keep it at the end of the enum
+  /// Max enum value for iteration, keep it at the end of the enum
   FilterFailureReasonCount,
 };
 

--- a/tf2_ros/test/message_filter_test.cpp
+++ b/tf2_ros/test/message_filter_test.cpp
@@ -195,22 +195,22 @@ TEST(tf2_ros_message_filter, multiple_frames_and_time_tolerance)
 TEST(tf2_ros_message_filter, failure_reason_string_conversion)
 {
   // Sanity test defined messages
-  ASSERT_EQ(
+  EXPECT_EQ(
     "Unknown",
     tf2_ros::get_filter_failure_reason_string(tf2_ros::filter_failure_reasons::Unknown)
   );
-  ASSERT_EQ(
+  EXPECT_EQ(
     "OutTheBack",
     tf2_ros::get_filter_failure_reason_string(tf2_ros::filter_failure_reasons::OutTheBack)
   );
-  ASSERT_EQ(
+  EXPECT_EQ(
     "EmptyFrameID",
     tf2_ros::get_filter_failure_reason_string(tf2_ros::filter_failure_reasons::EmptyFrameID)
   );
 
   // Make sure all values have been given a string
   for (size_t i=0; i < tf2_ros::filter_failure_reasons::FilterFailureReasonCount; i++) {
-    ASSERT_NE(
+    EXPECT_NE(
       "Invalid Failure Reason",
       tf2_ros::get_filter_failure_reason_string(
         tf2_ros::filter_failure_reasons::FilterFailureReason(i))
@@ -219,7 +219,7 @@ TEST(tf2_ros_message_filter, failure_reason_string_conversion)
 
   // Test that value outside the defined range has been given a string and that count was
   // maintained at the end
-  ASSERT_EQ(
+  EXPECT_EQ(
     "Invalid Failure Reason",
     tf2_ros::get_filter_failure_reason_string(
       tf2_ros::filter_failure_reasons::FilterFailureReasonCount)

--- a/tf2_ros/test/message_filter_test.cpp
+++ b/tf2_ros/test/message_filter_test.cpp
@@ -192,6 +192,40 @@ TEST(tf2_ros_message_filter, multiple_frames_and_time_tolerance)
   ASSERT_TRUE(filter_callback_fired);
 }
 
+TEST(tf2_ros_message_filter, failure_reason_string_conversion)
+{
+  // Sanity test defined messages
+  ASSERT_EQ(
+    "Unknown",
+    tf2_ros::get_filter_failure_reason_string(tf2_ros::filter_failure_reasons::Unknown)
+  );
+  ASSERT_EQ(
+    "OutTheBack",
+    tf2_ros::get_filter_failure_reason_string(tf2_ros::filter_failure_reasons::OutTheBack)
+  );
+  ASSERT_EQ(
+    "EmptyFrameID",
+    tf2_ros::get_filter_failure_reason_string(tf2_ros::filter_failure_reasons::EmptyFrameID)
+  );
+
+  // Make sure all values have been given a string
+  for (size_t i=0; i < tf2_ros::filter_failure_reasons::FilterFailureReasonCount; i++) {
+    ASSERT_NE(
+      "Invalid Failure Reason",
+      tf2_ros::get_filter_failure_reason_string(
+        tf2_ros::filter_failure_reasons::FilterFailureReason(i))
+    );
+  }
+
+  // Test that value outside the defined range has been given a string and that count was
+  // maintained at the end
+  ASSERT_EQ(
+    "Invalid Failure Reason",
+    tf2_ros::get_filter_failure_reason_string(
+      tf2_ros::filter_failure_reasons::FilterFailureReasonCount)
+  );
+}
+
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Print a slightly more informative error message from signalFailure in the tf2 MessageFilter and add a unit test for the string conversion.

First half of follow-through for https://github.com/ros2/geometry2/pull/130
Part of fix for https://github.com/ros2/geometry2/issues/118
Part of https://github.com/ros-security/aws-roadmap/issues/74

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>