### PR TITLE
clear tf2 buffers when clock reset

### DIFF
--- a/tf2_ros/src/transform_listener.cpp
+++ b/tf2_ros/src/transform_listener.cpp
@@ -94,6 +94,13 @@ void TransformListener::initThread(
 
 void TransformListener::subscription_callback(const tf2_msgs::msg::TFMessage::SharedPtr msg, bool is_static)
 {
+  tf2::TimePoint now = tf2::get_now();
+  if(now < last_update_){
+    ROS_WARN("Detected jump back in time. Clearing TF buffer.");
+    buffer_.clear();
+  }
+  last_update_ = now;
+
   const tf2_msgs::msg::TFMessage & msg_in = *msg;
   // TODO(tfoote) find a way to get the authority
   std::string authority = "Authority undetectable";  // msg_evt.getPublisherName();  // lookup the authority


### PR DESCRIPTION
This PR clear tf2 buffers when clock reset, in the transform_listener.

This is present in ROS1 melodic (https://github.com/ros/geometry2/tree/melodic-devel/tf2_ros/src), introduced by https://github.com/ros/geometry2/commit/619a1329854d8e6fcc78c576a53594f2caadf383

I was trying to solve an error saying "TF old data ..." when I reset the gazebo simulation. Even though this did not solve that problem, I thought since it was in ROS1 melodic, we might want this in ROS2 as well, unless there is already something that takes care of this.