### PR TITLE
Fix up -Wcast-qual warning

### DIFF
--- a/tf2/include/tf2/LinearMath/Vector3.h
+++ b/tf2/include/tf2/LinearMath/Vector3.h
@@ -625,7 +625,7 @@ public:
 TF2SIMD_FORCE_INLINE void	tf2SwapScalarEndian(const tf2Scalar& sourceVal, tf2Scalar& destVal)
 {
 	unsigned char* dest = (unsigned char*) &destVal;
-	unsigned char* src  = (unsigned char*) &sourceVal;
+	const unsigned char* src  = (const unsigned char*) &sourceVal;
 	dest[0] = src[7];
     dest[1] = src[6];
     dest[2] = src[5];

--- a/tf2/include/tf2/LinearMath/Vector3.h
+++ b/tf2/include/tf2/LinearMath/Vector3.h
@@ -625,7 +625,7 @@ public:
 TF2SIMD_FORCE_INLINE void	tf2SwapScalarEndian(const tf2Scalar& sourceVal, tf2Scalar& destVal)
 {
 	unsigned char* dest = (unsigned char*) &destVal;
-	const unsigned char* src  = (const unsigned char*) &sourceVal;
+	const unsigned char* src  = reinterpret_cast<const unsigned char*>(&sourceVal);
 	dest[0] = src[7];
     dest[1] = src[6];
     dest[2] = src[5];


### PR DESCRIPTION
Hi, this PR intends to fix the -Wcast-qual warning that happens when compiling any code including `tf2/include/tf2/LinearMath/Vector3.h `:

```shell
......
/opt/ros/dashing/include/tf2/LinearMath/Vector3.h: In function ‘void tf2::tf2SwapScalarEndian(const tf2Scalar&, tf2Scalar&)’:
/opt/ros/dashing/include/tf2/LinearMath/Vector3.h:628:42: warning: cast from type ‘const tf2Scalar* {aka const double*}’ to type ‘unsigned char*’ casts away qualifiers [-Wcast-qual]
  unsigned char* src  = (unsigned char*) &sourceVal;
                                          ^~~~~~~~~
......
```