### PR TITLE
Fix deprecated copy in tf2::Stamped<T>

### DIFF
--- a/tf2/include/tf2/transform_datatypes.h
+++ b/tf2/include/tf2/transform_datatypes.h
@@ -62,6 +62,14 @@ class Stamped : public T{
   
   /** Set the data element */
   void setData(const T& input){*static_cast<T*>(this) = input;};
+
+  Stamped& operator=(const Stamped<T>& s)
+  {
+    T::operator=(s);
+    this->stamp_ = s.stamp_;
+    this->frame_id_ = s.frame_id_;
+    return *this;
+  }
 };
 
 /** \brief Comparison Operator for Stamped datatypes */


### PR DESCRIPTION
Fix a deprecated copy warning by implementing the assignment operator

Signed-off-by: Hunter L. Allen <hunterlallen@protonmail.com>

---

Example warning (with GCC 9.2.1).

```
/home/allenh1/ros2_ws/src/allenh1/slam_gmapping/gmapping/src/slam_gmapping.cpp:                                                                                                                                                              In member function ‘bool SlamGMapping::initMapper(std::shared_ptr<sensor_msgs::m                                                                                                                                                             sg::LaserScan_<std::allocator<void> > >)’:
/home/allenh1/ros2_ws/src/allenh1/slam_gmapping/gmapping/src/slam_gmapping.cpp:4                                                                                                                                                             34:73: warning: implicitly-declared ‘tf2::Stamped<tf2::Transform>& tf2::Stamped<                                                                                                                                                             tf2::Transform>::operator=(const tf2::Stamped<tf2::Transform>&)’ is deprecated                                                                                                                                                               -Wdeprecated-copy]
  434 |       tf2::Transform(q, tf2::Vector3(0, 0, 0)), time_stamp, laser_frame                                                                                                                                                              );
      |                                                                                                                                                                                                                                      ^
In file included from /home/allenh1/ros2_ws/install/tf2_ros/include/tf2_ros/asyn                                                                                                                                                             c_buffer_interface.h:39,
                 from /home/allenh1/ros2_ws/install/tf2_ros/include/tf2_ros/buff                                                                                                                                                             er.h:39,
                 from /home/allenh1/ros2_ws/install/tf2_ros/include/tf2_ros/tran                                                                                                                                                             sform_listener.h:41,
                 from /home/allenh1/ros2_ws/src/allenh1/slam_gmapping/gmapping/s                                                                                                                                                             rc/slam_gmapping.hpp:40,
                 from /home/allenh1/ros2_ws/src/allenh1/slam_gmapping/gmapping/s                                                                                                                                                             rc/slam_gmapping.cpp:107:
/home/allenh1/ros2_ws/install/tf2/include/tf2/transform_datatypes.h:58:3: note:                                                                                                                                                              because ‘tf2::Stamped<tf2::Transform>’ has user-provided ‘tf2::Stamped<T>::Stamp                                                                                                                                                             ed(const tf2::Stamped<T>&) [with T = tf2::Transform]’
   58 |   Stamped(const Stamped<T>& s):
      |   ^~~~~~~
/home/allenh1/ros2_ws/src/allenh1/slam_gmapping/gmapping/src/slam_gmapping.cpp:4                                                                                                                                                             42:73: warning: implicitly-declared ‘tf2::Stamped<tf2::Transform>& tf2::Stamped<                                                                                                                                                             tf2::Transform>::operator=(const tf2::Stamped<tf2::Transform>&)’ is deprecated                                                                                                                                                               -Wdeprecated-copy]
  442 |       tf2::Transform(q, tf2::Vector3(0, 0, 0)), time_stamp, laser_frame                                                                                                                                                              );
      |                                                                                                                                                                                                                                      ^
In file included from /home/allenh1/ros2_ws/install/tf2_ros/include/tf2_ros/asyn                                                                                                                                                             c_buffer_interface.h:39,
                 from /home/allenh1/ros2_ws/install/tf2_ros/include/tf2_ros/buff                                                                                                                                                             er.h:39,
                 from /home/allenh1/ros2_ws/install/tf2_ros/include/tf2_ros/tran                                                                                                                                                             sform_listener.h:41,
                 from /home/allenh1/ros2_ws/src/allenh1/slam_gmapping/gmapping/s                                                                                                                                                             rc/slam_gmapping.hpp:40,
                 from /home/allenh1/ros2_ws/src/allenh1/slam_gmapping/gmapping/s                                                                                                                                                             rc/slam_gmapping.cpp:107:
/home/allenh1/ros2_ws/install/tf2/include/tf2/transform_datatypes.h:58:3: note:                                                                                                                                                              because ‘tf2::Stamped<tf2::Transform>’ has user-provided ‘tf2::Stamped<T>::Stamp                                                                                                                                                             ed(const tf2::Stamped<T>&) [with T = tf2::Transform]’
   58 |   Stamped(const Stamped<T>& s):
      |   ^~~~~~~
```