### PR TITLE
message filter fix

### DIFF
--- a/tf2_ros/include/tf2_ros/message_filter.h
+++ b/tf2_ros/include/tf2_ros/message_filter.h
@@ -448,12 +448,9 @@ public:
   void add(const MConstPtr & message)
   {
     using builtin_interfaces::msg::Time;
-    std::shared_ptr<std::map<std::string, std::string>> header(new std::map<std::string,
-      std::string>);
 
-    (*header)["callerid"] = "unknown";
     Time t = node_clock_->get_clock()->now();
-    add(MEvent(message, header, t));
+    add(MEvent(message, t));
   }
 
   /**

--- a/tf2_ros/include/tf2_ros/message_filter.h
+++ b/tf2_ros/include/tf2_ros/message_filter.h
@@ -447,9 +447,7 @@ public:
    */
   void add(const MConstPtr & message)
   {
-    using builtin_interfaces::msg::Time;
-
-    Time t = node_clock_->get_clock()->now();
+    builtin_interfaces::msg::Time t = node_clock_->get_clock()->now();
     add(MEvent(message, t));
   }
 


### PR DESCRIPTION
The following constructor doesn't exists:

```
add(MEvent(message, header, t));
```

