### PR TITLE
Remove TODO

### DIFF
--- a/tf2_ros/include/tf2_ros/static_transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/static_transform_broadcaster.h
@@ -58,7 +58,6 @@ public:
     const rclcpp::PublisherOptionsWithAllocator<AllocatorT> & options =
       rclcpp::PublisherOptionsWithAllocator<AllocatorT>())
   {
-    // TODO(tfoote) latched equivalent
     publisher_ = rclcpp::create_publisher<tf2_msgs::msg::TFMessage>(
       node, "/tf_static", qos, options);
   }


### PR DESCRIPTION
The TODO is done; The publisher is using QoS durability setting 'transient local' which is the closest thing to the 'latched' concept in ROS 1.

https://github.com/ros2/geometry2/blob/ae7115f9a2e88e8520124c0171d7ebcfaccff991/tf2_ros/include/tf2_ros/qos.hpp#L65