### PR TITLE
Remove ready_fn from launch_testing tests

### DIFF
--- a/test_tf2/test/buffer_client_tester.launch.py
+++ b/test_tf2/test/buffer_client_tester.launch.py
@@ -6,10 +6,12 @@ import unittest
 from launch import LaunchDescription
 import launch
 from launch_ros.actions import Node
-import launch_testing
 from launch.substitutions import LaunchConfiguration
+import launch_testing
+import launch_testing.actions
 
-def generate_test_description(ready_fn):
+
+def generate_test_description():
     node_under_test = Node(
         package='test_tf2',
         node_executable='test_buffer_client',
@@ -35,7 +37,7 @@ def generate_test_description(ready_fn):
         node_buffer_server,
         node_under_test,
         launch_testing.util.KeepAliveProc(),
-        launch.actions.OpaqueFunction(function=lambda context: ready_fn()),
+        launch_testing.actions.ReadyToTest(),
         ]), locals()
 
 

--- a/test_tf2/test/static_publisher.launch.py
+++ b/test_tf2/test/static_publisher.launch.py
@@ -6,10 +6,11 @@ import unittest
 from launch import LaunchDescription
 import launch
 from launch_ros.actions import Node
-import launch_testing
 from launch.substitutions import LaunchConfiguration
+import launch_testing
+import launch_testing.actions
 
-def generate_test_description(ready_fn):
+def generate_test_description():
     node_under_test = Node(
         package='test_tf2',
         node_executable='test_static_publisher',
@@ -34,7 +35,7 @@ def generate_test_description(ready_fn):
         node_static_transform_publisher_2,
         node_under_test,
         launch_testing.util.KeepAliveProc(),
-        launch.actions.OpaqueFunction(function=lambda context: ready_fn()),
+        launch_testing.actions.ReadyToTest(),
         ]), locals()
 
 

--- a/test_tf2/test/test_buffer_client.launch.py
+++ b/test_tf2/test/test_buffer_client.launch.py
@@ -6,10 +6,12 @@ import unittest
 from launch import LaunchDescription
 import launch
 from launch_ros.actions import Node
-import launch_testing
 from launch.substitutions import LaunchConfiguration
+import launch_testing
+import launch_testing.actions
 
-def generate_test_description(ready_fn):
+
+def generate_test_description():
     node_under_test = Node(
         package='test_tf2',
         node_executable='test_buffer_client.py',
@@ -34,7 +36,7 @@ def generate_test_description(ready_fn):
         node_buffer_server,
         node_under_test,
         launch_testing.util.KeepAliveProc(),
-        launch.actions.OpaqueFunction(function=lambda context: ready_fn()),
+        launch_testing.actions.ReadyToTest(),
         ]), locals()
 
 


### PR DESCRIPTION
This is part of the effort [here](https://github.com/ros2/launch/pull/346) to replace the OpaqueFunction and ready_fn with a launch_testing action.

Signed-off-by: Pete Baughman <peter.c.baughman@gmail.com>