### PR TITLE
Fix `-Wrange-loop-construct`

### DIFF
--- a/tf2_ros/test/test_buffer.cpp
+++ b/tf2_ros/test/test_buffer.cpp
@@ -81,7 +81,7 @@ public:
   void
   execute_timers()
   {
-    for (const auto elem : timer_to_callback_map_) {
+    for (const auto & elem : timer_to_callback_map_) {
       elem.second(elem.first);
     }
   }


### PR DESCRIPTION
```
--- stderr: tf2_ros
/opt/ros/master/src/ros2/geometry2/tf2_ros/test/test_buffer.cpp:84:21: warning: loop variable 'elem' creates a copy from type 'const std::pair<const unsigned long, std::function<void (const unsigned long &)> >' [-Wrange-loop-construct]
    for (const auto elem : timer_to_callback_map_) {
                    ^
/opt/ros/master/src/ros2/geometry2/tf2_ros/test/test_buffer.cpp:84:10: note: use reference type 'const std::pair<const unsigned long, std::function<void (const unsigned long &)> > &' to prevent copying
    for (const auto elem : timer_to_callback_map_) {
         ^~~~~~~~~~~~~~~~~
                    &
1 warning generated.
---
```
