### PR TITLE
Add missing visibility header include

### DIFF
--- a/tf2_ros/include/tf2_ros/buffer_server.h
+++ b/tf2_ros/include/tf2_ros/buffer_server.h
@@ -46,6 +46,7 @@
 #include <tf2_msgs/action/lookup_transform.hpp>
 
 #include <tf2/buffer_core_interface.h>
+#include <tf2_ros/visibility_control.h>
 
 namespace tf2_ros
 {


### PR DESCRIPTION
Noticed this was missing when trying to compile an external project including this header.