### PR TITLE
Replace deprecated launch_ros usage

### DIFF
--- a/test_tf2/test/buffer_client_tester.launch.py
+++ b/test_tf2/test/buffer_client_tester.launch.py
@@ -14,20 +14,20 @@ import launch_testing.actions
 def generate_test_description():
     node_under_test = Node(
         package='test_tf2',
-        node_executable='test_buffer_client',
+        executable='test_buffer_client',
         output='screen',
         arguments=[],
     )
     node_static_transform_publisher = Node(
         package='tf2_ros',
-        node_executable='static_transform_publisher',
+        executable='static_transform_publisher',
         output='screen',
         arguments=["5", "6", "7", "0", "0", "0", "1", "a", "b"]
     )
 
     node_buffer_server = Node(
         package='test_tf2',
-        node_executable='test_buffer_server',
+        executable='test_buffer_server',
         output='screen',
         arguments=[],
         sigterm_timeout=LaunchConfiguration('sigterm_timeout', default=2)

--- a/test_tf2/test/static_publisher.launch.py
+++ b/test_tf2/test/static_publisher.launch.py
@@ -13,19 +13,19 @@ import launch_testing.actions
 def generate_test_description():
     node_under_test = Node(
         package='test_tf2',
-        node_executable='test_static_publisher',
+        executable='test_static_publisher',
         output='screen',
         arguments=[],
     )
     node_static_transform_publisher_1 = Node(
         package='tf2_ros',
-        node_executable='static_transform_publisher',
+        executable='static_transform_publisher',
         output='screen',
         arguments=["1", "0", "0", "0", "0", "0", "1", "a", "b"]
     )
     node_static_transform_publisher_2 = Node(
         package='tf2_ros',
-        node_executable='static_transform_publisher',
+        executable='static_transform_publisher',
         output='screen',
         arguments=["0", "1", "0", "0", "0", "0", "1", "b", "c"]
     )

--- a/test_tf2/test/test_buffer_client.launch.py
+++ b/test_tf2/test/test_buffer_client.launch.py
@@ -14,19 +14,19 @@ import launch_testing.actions
 def generate_test_description():
     node_under_test = Node(
         package='test_tf2',
-        node_executable='test_buffer_client.py',
+        executable='test_buffer_client.py',
         output='screen',
     )
     node_static_transform_publisher = Node(
         package='tf2_ros',
-        node_executable='static_transform_publisher',
+        executable='static_transform_publisher',
         output='screen',
         arguments=["5", "6", "7", "0", "0", "0", "1", "a", "b"]
     )
 
     node_buffer_server = Node(
         package='test_tf2',
-        node_executable='test_buffer_server',
+        executable='test_buffer_server',
         output='screen',
         arguments=[],
         sigterm_timeout=LaunchConfiguration('sigterm_timeout', default=2)


### PR DESCRIPTION
The Node parameter 'node_executable' has been deprecated and replaced by
the parameter 'executable'.

Depends on https://github.com/ros2/launch_ros/pull/140