### PR TITLE
Fix displayTimePoint truncation error

### DIFF
--- a/tf2/CMakeLists.txt
+++ b/tf2/CMakeLists.txt
@@ -72,6 +72,11 @@ if(BUILD_TESTING)
     )
   endif()
 
+  ament_add_gtest(test_time test/test_time.cpp)
+  if (TARGET test_time)
+    target_link_libraries(test_time tf2)
+  endif()
+
 # TODO(tfoote) reimplement speed test without dependency on message datatypes.
 # add_executable(speed_test EXCLUDE_FROM_ALL test/speed_test.cpp)
 # target_link_libraries(speed_test tf2  ${geometry_msgs_LIBRARIES} ${console_bridge_LIBRARIES})

--- a/tf2/src/time.cpp
+++ b/tf2/src/time.cpp
@@ -40,14 +40,21 @@ std::string tf2::displayTimePoint(const tf2::TimePoint& stamp)
 {
   const char * format_str = "%.6f";
   double current_time = tf2::timeToSec(stamp);
-  int buff_size = snprintf(NULL, 0, format_str, current_time);
+
+  // Determine how many bytes to allocate for the string. If successful, buff_size does not count
+  // null terminating character. http://www.cplusplus.com/reference/cstdio/snprintf/
+  int buff_size = rcutils_snprintf(NULL, 0, format_str, current_time);
   if (buff_size < 0) {
     char errmsg[200];
     rcutils_strerror(errmsg, sizeof(errmsg));
     throw std::runtime_error(errmsg);
   }
 
+  // Increase by one for null-terminating character
+  ++buff_size;
   char * buffer = new char[buff_size];
+
+  // Write to the string. buffer size must accommodate the null-terminating character
   int bytes_written = rcutils_snprintf(buffer, buff_size, format_str, current_time);
   if (bytes_written < 0) {
     delete[] buffer;

--- a/tf2/test/test_time.cpp
+++ b/tf2/test/test_time.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2020, Open Source Robotics Foundation, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <chrono>
+#include <gtest/gtest.h>
+#include "tf2/time.h"
+
+using namespace std::literals::chrono_literals;
+
+TEST(TestTime, durationFromSec) {
+  EXPECT_EQ(tf2::durationFromSec(0.0), 0ns);
+  EXPECT_EQ(tf2::durationFromSec(-0.0), 0ns);
+  EXPECT_EQ(tf2::durationFromSec(1.0), 1e9ns);
+  EXPECT_EQ(tf2::durationFromSec(-1.0), -1e9ns);
+  EXPECT_EQ(tf2::durationFromSec(1.000000001), 1s + 1ns);
+  EXPECT_EQ(tf2::durationFromSec(1.0000000012345), 1s + 1ns);
+  EXPECT_EQ(tf2::durationFromSec(0.5), 5e8ns);
+  EXPECT_EQ(tf2::durationFromSec(1.5), 1s + 5e8ns);
+  EXPECT_EQ(tf2::durationFromSec(2.5), 2s + 5e8ns);
+  EXPECT_EQ(tf2::durationFromSec(-0.5), -5e8ns);
+  EXPECT_EQ(tf2::durationFromSec(-1.5), -1s - 5e8ns);
+  EXPECT_EQ(tf2::durationFromSec(-2.5), -2s - 5e8ns);
+  EXPECT_EQ(tf2::durationFromSec(1e-40), 0s);
+  EXPECT_EQ(tf2::durationFromSec(-1e-40), 0s);
+}
+
+TEST(TestTime, timeFromSec) {
+  auto time_point = tf2::TimePoint();
+  EXPECT_EQ(tf2::timeFromSec(0.0), time_point);
+  EXPECT_EQ(tf2::timeFromSec(1.0), time_point + 1s);
+  EXPECT_EQ(tf2::timeFromSec(-1.0), time_point - 1s);
+  EXPECT_EQ(tf2::timeFromSec(0.0), time_point);
+  EXPECT_EQ(tf2::timeFromSec(1e-9), time_point + 1ns);
+  EXPECT_EQ(tf2::timeFromSec(-1e-9), time_point - 1ns);
+}
+
+TEST(TestTime, durationToSec) {
+  EXPECT_EQ(tf2::durationToSec(0s), 0.0);
+  EXPECT_EQ(tf2::durationToSec(1s), 1.0);
+  EXPECT_EQ(tf2::durationToSec(-1s), -1.0);
+  EXPECT_EQ(tf2::durationToSec(1ns), 1e-9);
+  EXPECT_EQ(tf2::durationToSec(-1ns), -1e-9);
+  EXPECT_EQ(tf2::durationToSec(1s + 1ns), 1.000000001);
+  EXPECT_EQ(tf2::durationToSec(1s - 1ns), 0.999999999);
+
+  // Check rounding of seconds component
+  EXPECT_EQ(tf2::durationToSec(500ms), 0.5);
+  EXPECT_EQ(tf2::durationToSec(1s + 500ms), 1.5);
+  EXPECT_EQ(tf2::durationToSec(2s + 500ms), 2.5);
+  EXPECT_EQ(tf2::durationToSec(-500ms), -0.5);
+  EXPECT_EQ(tf2::durationToSec(-1s - 500ms), -1.5);
+  EXPECT_EQ(tf2::durationToSec(-2s - 500ms), -2.5);
+}
+
+TEST(TestTime, timeToSec) {
+  auto time_point = tf2::TimePoint();
+  EXPECT_EQ(tf2::timeToSec(time_point), 0.0);
+  EXPECT_EQ(tf2::timeToSec(time_point + 1s), 1.0);
+  EXPECT_EQ(tf2::timeToSec(time_point - 1s), -1.0);
+  EXPECT_EQ(tf2::timeToSec(time_point + 1ns), 0.000000001);
+}
+
+TEST(TestTime, displayTimePoint) {
+  EXPECT_EQ(tf2::displayTimePoint(tf2::TimePoint(0s)), "0.000000");
+  EXPECT_EQ(tf2::displayTimePoint(tf2::TimePoint(-0s)), "0.000000");
+  EXPECT_EQ(tf2::displayTimePoint(tf2::TimePoint(1s)), "1.000000");
+  EXPECT_EQ(tf2::displayTimePoint(tf2::TimePoint(10s)), "10.000000");
+  EXPECT_EQ(tf2::displayTimePoint(tf2::TimePoint(-1s)), "-1.000000");
+  EXPECT_EQ(tf2::displayTimePoint(tf2::TimePoint(-10s)), "-10.000000");
+  EXPECT_EQ(tf2::displayTimePoint(tf2::TimePoint(1ns)), "0.000000");
+  EXPECT_EQ(tf2::displayTimePoint(tf2::TimePoint(-1ns)), "-0.000000");
+  EXPECT_EQ(tf2::displayTimePoint(tf2::TimePoint(1000ns)), "0.000001");
+  EXPECT_EQ(tf2::displayTimePoint(tf2::TimePoint(-1000ns)), "-0.000001");
+}


### PR DESCRIPTION
`tf2::displayTimePoint()` incorrectly calculated the buffer size for creating a new string. This fixes it and now it will print out 6 decimal places of precision. Tests have been added for the tf2 time functionality.

Build --packages-up-to tf2 test_tf2
Test --packages-select tf2 test_tf2
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10294)](http://ci.ros2.org/job/ci_linux/10294/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=5828)](http://ci.ros2.org/job/ci_linux-aarch64/5828/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8374)](http://ci.ros2.org/job/ci_osx/8374/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10191)](http://ci.ros2.org/job/ci_windows/10191/)