### PR TITLE
Improve tf2_echo and tf2_monitor messages while waiting for data

### DIFF
--- a/tf2_ros/src/tf2_echo.cpp
+++ b/tf2_ros/src/tf2_echo.cpp
@@ -103,8 +103,15 @@ int main(int argc, char ** argv)
   std::string source_frameid = std::string(argv[1]);
   std::string target_frameid = std::string(argv[2]);
 
-  // Wait for up to one second for the first transforms to become avaiable. 
-  echoListener.buffer_.canTransform(source_frameid, target_frameid, tf2::TimePoint(), tf2::durationFromSec(1.0));
+  // Wait for up to one second for the first transforms to become avaiable.
+  std::string warning_msg;
+  while (rclcpp::ok() && !echoListener.buffer_.canTransform(
+    source_frameid, target_frameid, tf2::TimePoint(), &warning_msg))
+  {
+    RCLCPP_INFO_THROTTLE(nh->get_logger(), *clock, 1000, "Waiting for transfrom %s ->  %s: %s",
+      source_frameid.c_str(), target_frameid.c_str(), warning_msg.c_str());
+    rate.sleep();
+  }
 
   //Nothing needs to be done except wait for a quit
   //The callbacks withing the listener class

--- a/tf2_ros/src/tf2_echo.cpp
+++ b/tf2_ros/src/tf2_echo.cpp
@@ -108,7 +108,7 @@ int main(int argc, char ** argv)
   while (rclcpp::ok() && !echoListener.buffer_.canTransform(
     source_frameid, target_frameid, tf2::TimePoint(), &warning_msg))
   {
-    RCLCPP_INFO_THROTTLE(nh->get_logger(), *clock, 1000, "Waiting for transfrom %s ->  %s: %s",
+    RCLCPP_INFO_THROTTLE(nh->get_logger(), *clock, 1000, "Waiting for transform %s ->  %s: %s",
       source_frameid.c_str(), target_frameid.c_str(), warning_msg.c_str());
     rate.sleep();
   }

--- a/tf2_ros/src/tf2_monitor.cpp
+++ b/tf2_ros/src/tf2_monitor.cpp
@@ -139,7 +139,7 @@ public:
         framea_, frameb_, tf2::TimePoint(), &warning_msg))
       {
         RCLCPP_INFO_THROTTLE(node_->get_logger(), *clock_, 1000,
-          "Waiting for transfrom %s ->  %s: %s", framea_.c_str(), frameb_.c_str(),
+          "Waiting for transform %s ->  %s: %s", framea_.c_str(), frameb_.c_str(),
           warning_msg.c_str());
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
       }

--- a/tf2_ros/src/tf2_monitor.cpp
+++ b/tf2_ros/src/tf2_monitor.cpp
@@ -196,9 +196,9 @@ public:
     unsigned int counter = 0;
 
     if (using_specific_chain_) {
-      std::cout << "Gathering data on " << framea_ << " -> " << frameb_ << "...\n";
+      std::cout << "Gathering data on " << framea_ << " -> " << frameb_ << " for 10 seconds...\n";
     } else {
-      std::cout << "Gathering data on all frames...\n";
+      std::cout << "Gathering data on all frames for 10 seconds...\n";
     }
 
 

--- a/tf2_ros/src/tf2_monitor.cpp
+++ b/tf2_ros/src/tf2_monitor.cpp
@@ -131,14 +131,19 @@ public:
         buffer_(clock_)
   {
     tf_ = std::make_shared<tf2_ros::TransformListener>(buffer_);
-    
+
     if (using_specific_chain_)
     {
-      std::cout << "Waiting for transform chain to become available between "<< framea_ << " and " << frameb_<< " " << std::flush;
-      while (rclcpp::ok() && !buffer_.canTransform(framea_, frameb_, tf2::TimePointZero, tf2::durationFromSec(1.0)))
-        std::cout << "." << std::flush;
-      std::cout << std::endl;
-     
+      std::string warning_msg;
+      while (rclcpp::ok() && !buffer_.canTransform(
+        framea_, frameb_, tf2::TimePoint(), &warning_msg))
+      {
+        RCLCPP_INFO_THROTTLE(node_->get_logger(), *clock_, 1000,
+          "Waiting for transfrom %s ->  %s: %s", framea_.c_str(), frameb_.c_str(),
+          warning_msg.c_str());
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+      }
+
       try{
         buffer_._chainAsVector(frameb_, tf2::TimePointZero, framea_, tf2::TimePointZero, frameb_, chain_);
       }
@@ -190,6 +195,11 @@ public:
     double lowpass = 0.01;
     unsigned int counter = 0;
 
+    if (using_specific_chain_) {
+      std::cout << "Gathering data on " << framea_ << " -> " << frameb_ << "...\n";
+    } else {
+      std::cout << "Gathering data on all frames...\n";
+    }
 
 
   while (rclcpp::ok()){


### PR DESCRIPTION
Fixes https://github.com/ros2/geometry2/issues/240

This improves the logged messages while waiting for transform data.

Currently `tf2_echo` quickly outputs alot of warning messages before outputting the data. This isn't actually anything to worry about, so this PR uses a different signature for `canTransform()` that does not internally console log a warning message, and `INFO`'s a message instead.

Currently `tf2_monitor` outputs a warning message about being unable to get a transform, and then it waits 10 seconds before outputting any more data. This gives the mistaken impression that the transform data was delayed (#240). This PR again changes to a different `canTransform()` signature that doesn't internally console log, and outputs a message before the initial 10 second wait indicating that `tf2_monitor` is gathering data to give statistics on it.

## tf_echo

before:
```
$ ./install/tf2_ros/lib/tf2_ros/tf2_echo foo bar
[WARN] [1587425227.666861760] [tf2_echo]: This rmw implementation does not support ON_OFFERED_INCOMPATIBLE_QOS events, you will not be notified when Publishers offer an incompatible QoS profile to Subscriptions on the same topic.
[WARN] [1587425227.667188847] [tf2_echo]: This rmw implementation does not support ON_REQUESTED_INCOMPATIBLE_QOS events, you will not be notified when Subscriptions request an incompatible QoS profile from Publishers on the same topic.
Warning: Invalid frame ID "foo" passed to canTransform argument target_frame - frame does not exist
         at line 133 in /home/sloretz/ws/ros2/src/ros2/geometry2/tf2/src/buffer_core.cpp
Warning: Invalid frame ID "foo" passed to canTransform argument target_frame - frame does not exist
         at line 133 in /home/sloretz/ws/ros2/src/ros2/geometry2/tf2/src/buffer_core.cpp
Warning: Invalid frame ID "foo" passed to canTransform argument target_frame - frame does not exist
         at line 133 in /home/sloretz/ws/ros2/src/ros2/geometry2/tf2/src/buffer_core.cpp
Warning: Invalid frame ID "foo" passed to canTransform argument target_frame - frame does not exist
         at line 133 in /home/sloretz/ws/ros2/src/ros2/geometry2/tf2/src/buffer_core.cpp
Warning: Invalid frame ID "foo" passed to canTransform argument target_frame - frame does not exist
         at line 133 in /home/sloretz/ws/ros2/src/ros2/geometry2/tf2/src/buffer_core.cpp
Warning: Invalid frame ID "foo" passed to canTransform argument target_frame - frame does not exist
         at line 133 in /home/sloretz/ws/ros2/src/ros2/geometry2/tf2/src/buffer_core.cpp
Warning: Invalid frame ID "foo" passed to canTransform argument target_frame - frame does not exist
         at line 133 in /home/sloretz/ws/ros2/src/ros2/geometry2/tf2/src/buffer_core.cpp
Warning: Invalid frame ID "foo" passed to canTransform argument target_frame - frame does not exist
         at line 133 in /home/sloretz/ws/ros2/src/ros2/geometry2/tf2/src/buffer_core.cpp
Warning: Invalid frame ID "foo" passed to canTransform argument target_frame - frame does not exist
         at line 133 in /home/sloretz/ws/ros2/src/ros2/geometry2/tf2/src/buffer_core.cpp
Warning: Invalid frame ID "foo" passed to canTransform argument target_frame - frame does not exist
         at line 133 in /home/sloretz/ws/ros2/src/ros2/geometry2/tf2/src/buffer_core.cpp
Warning: Invalid frame ID "foo" passed to canTransform argument target_frame - frame does not exist
         at line 133 in /home/sloretz/ws/ros2/src/ros2/geometry2/tf2/src/buffer_core.cpp
Warning: Invalid frame ID "foo" passed to canTransform argument target_frame - frame does not exist
         at line 133 in /home/sloretz/ws/ros2/src/ros2/geometry2/tf2/src/buffer_core.cpp
Warning: Invalid frame ID "foo" passed to canTransform argument target_frame - frame does not exist
         at line 133 in /home/sloretz/ws/ros2/src/ros2/geometry2/tf2/src/buffer_core.cpp
Warning: Invalid frame ID "foo" passed to canTransform argument target_frame - frame does not exist
         at line 133 in /home/sloretz/ws/ros2/src/ros2/geometry2/tf2/src/buffer_core.cpp
Warning: Invalid frame ID "foo" passed to canTransform argument target_frame - frame does not exist
         at line 133 in /home/sloretz/ws/ros2/src/ros2/geometry2/tf2/src/buffer_core.cpp
At time 0.0
- Translation: [0.000, 0.000, 1.000]
- Rotation: in Quaternion [0.000, 0.000, 0.000, 1.000]
At time 0.0
```


after:

```
$ ./install/tf2_ros/lib/tf2_ros/tf2_echo foo bar
[WARN] [1587425288.140909647] [tf2_echo]: This rmw implementation does not support ON_OFFERED_INCOMPATIBLE_QOS events, you will not be notified when Publishers offer an incompatible QoS profile to Subscriptions on the same topic.
[WARN] [1587425288.141386844] [tf2_echo]: This rmw implementation does not support ON_REQUESTED_INCOMPATIBLE_QOS events, you will not be notified when Subscriptions request an incompatible QoS profile from Publishers on the same topic.
[INFO] [1587425288.142785113] [tf2_echo]: Waiting for transfrom foo ->  bar: Invalid frame ID "foo" passed to canTransform argument target_frame - frame does not exist
At time 0.0
- Translation: [0.000, 0.000, 1.000]
- Rotation: in Quaternion [0.000, 0.000, 0.000, 1.000]
```



## tf2_monitor

before

```
$ ./install/tf2_ros/lib/tf2_ros/tf2_monitor foo bar
[WARN] [1587427596.765386291] [tf2_monitor_main]: This rmw implementation does not support ON_OFFERED_INCOMPATIBLE_QOS events, you will not be notified when Publishers offer an incompatible QoS profile to Subscriptions on the same topic.
[WARN] [1587427596.765740516] [tf2_monitor_main]: This rmw implementation does not support ON_REQUESTED_INCOMPATIBLE_QOS events, you will not be notified when Subscriptions request an incompatible QoS profile from Publishers on the same topic.
Waiting for transform chain to become available between foo and bar Warning: Invalid frame ID "foo" passed to canTransform argument target_frame - frame does not exist
         at line 133 in /home/sloretz/ws/ros2/src/ros2/geometry2/tf2/src/buffer_core.cpp
Warning: Invalid frame ID "foo" passed to canTransform argument target_frame - frame does not exist
         at line 133 in /home/sloretz/ws/ros2/src/ros2/geometry2/tf2/src/buffer_core.cpp




RESULTS: for foo to bar
Chain is: foo -> bar
Net delay     avg = 3.02043e+08: max = 1.58743e+09

Frames:
Frame: bar, published by <no authority available>, Average Delay: 3762.37, Max Delay: 3762.37

All Broadcasters:
Node: <no authority available> 1e+08 Hz, Average Delay: 3762.37 Max Delay: 3762.37
```


after

```
$ ./install/tf2_ros/lib/tf2_ros/tf2_monitor foo bar
[WARN] [1587427442.787598164] [tf2_monitor_main]: This rmw implementation does not support ON_OFFERED_INCOMPATIBLE_QOS events, you will not be notified when Publishers offer an incompatible QoS profile to Subscriptions on the same topic.
[WARN] [1587427442.788069130] [tf2_monitor_main]: This rmw implementation does not support ON_REQUESTED_INCOMPATIBLE_QOS events, you will not be notified when Subscriptions request an incompatible QoS profile from Publishers on the same topic.
[INFO] [1587427442.789677489] [tf2_monitor_main]: Waiting for transfrom foo ->  bar: Invalid frame ID "foo" passed to canTransform argument target_frame - frame does not exist
Gathering data on foo -> bar...



RESULTS: for foo to bar
Chain is: foo -> bar
Net delay     avg = 3.02043e+08: max = 1.58743e+09

Frames:
Frame: bar, published by <no authority available>, Average Delay: 3608.94, Max Delay: 3608.94

All Broadcasters:
Node: <no authority available> 1e+08 Hz, Average Delay: 3608.94 Max Delay: 3608.94
```
