### PR TITLE
add missing test dependency

### DIFF
--- a/tf2_geometry_msgs/CMakeLists.txt
+++ b/tf2_geometry_msgs/CMakeLists.txt
@@ -28,12 +28,14 @@ ament_python_install_package(${PROJECT_NAME}
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
+  find_package(rclcpp REQUIRED)
   ament_add_gtest(test_tf2_geometry_msgs test/test_tf2_geometry_msgs.cpp)
   if(TARGET test_tf2_geometry_msgs)
     target_include_directories(test_tf2_geometry_msgs PUBLIC include)
     ament_target_dependencies(test_tf2_geometry_msgs
       "geometry_msgs"
       "orocos_kdl"
+      "rclcpp"
       "tf2"
       "tf2_ros"
     )

--- a/tf2_geometry_msgs/package.xml
+++ b/tf2_geometry_msgs/package.xml
@@ -24,6 +24,7 @@
   -->
 
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>rclcpp</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
+++ b/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
@@ -30,6 +30,7 @@
 /** \author Wim Meeussen */
 
 
+#include <rclcpp/clock.hpp>
 #include <tf2_ros/transform_listener.h>
 #include <gtest/gtest.h>
 #include <tf2_ros/buffer.h>


### PR DESCRIPTION
Related to ros2/ros2#904.

Usage: https://github.com/ros2/geometry2/blob/ac1747415d8236a078d62d7bbbc092ab8c1fd647/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp#L190