### PR TITLE
Uncommented tf2_bullet and tf2_tools

### DIFF
--- a/geometry2/package.xml
+++ b/geometry2/package.xml
@@ -10,13 +10,13 @@
   <license>BSD</license>
 
   <url type="website">http://www.ros.org/wiki/geometry2</url>
-    
+
   <author>Tully Foote</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <exec_depend>tf2</exec_depend>
-  <!--exec_depend>tf2_bullet</exec_depend-->
+  <exec_depend>tf2_bullet</exec_depend>
   <exec_depend>tf2_eigen</exec_depend>
   <exec_depend>tf2_geometry_msgs</exec_depend>
   <exec_depend>tf2_kdl</exec_depend>
@@ -24,7 +24,7 @@
   <exec_depend>tf2_py</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>tf2_sensor_msgs</exec_depend>
-  <!--exec_depend>tf2_tools</exec_depend-->
+  <exec_depend>tf2_tools</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
[tf2_bullet](https://ci.ros2.org/view/nightly/job/nightly_linux_release/lastBuild/consoleFull#console-section-577) and [tf2_tools](https://ci.ros2.org/view/nightly/job/nightly_linux_release/lastBuild/consoleFull#console-section-579) are building properly, for this reason I uncomment this two lines.

Signed-off-by: ahcorde <ahcorde@gmail.com>