### PR TITLE
Fix tf2_bullet to have the same version as other packages.

### DIFF
--- a/tf2_bullet/package.xml
+++ b/tf2_bullet/package.xml
@@ -1,6 +1,6 @@
 <package format="2">
   <name>tf2_bullet</name>
-  <version>0.9.1</version>
+  <version>0.12.4</version>
   <description>
     tf2_bullet
   </description>


### PR DESCRIPTION
catkin_prepare_release requires this.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>