### PR TITLE
modify error message to not match the pattern for Jenkins MSBuild errors

### DIFF
--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -256,26 +256,26 @@ bool BufferCore::setTransformImpl(const tf2::Transform& transform_in, const std:
   bool error_exists = false;
   if (stripped_child_frame_id == stripped_frame_id)
   {
-    CONSOLE_BRIDGE_logError("TF_SELF_TRANSFORM: Ignoring transform from authority \"%s\" with frame_id and child_frame_id  \"%s\" because they are the same",  authority.c_str(), stripped_child_frame_id.c_str());
+    CONSOLE_BRIDGE_logError("TF SELF_TRANSFORM: Ignoring transform from authority \"%s\" with frame_id and child_frame_id  \"%s\" because they are the same",  authority.c_str(), stripped_child_frame_id.c_str());
     error_exists = true;
   }
 
   if (stripped_child_frame_id == "")
   {
-    CONSOLE_BRIDGE_logError("TF_NO_CHILD_FRAME_ID: Ignoring transform from authority \"%s\" because child_frame_id not set ", authority.c_str());
+    CONSOLE_BRIDGE_logError("TF NO_CHILD_FRAME_ID: Ignoring transform from authority \"%s\" because child_frame_id not set ", authority.c_str());
     error_exists = true;
   }
 
   if (stripped_frame_id == "")
   {
-    CONSOLE_BRIDGE_logError("TF_NO_FRAME_ID: Ignoring transform with child_frame_id \"%s\"  from authority \"%s\" because frame_id not set", stripped_child_frame_id.c_str(), authority.c_str());
+    CONSOLE_BRIDGE_logError("TF NO_FRAME_ID: Ignoring transform with child_frame_id \"%s\"  from authority \"%s\" because frame_id not set", stripped_child_frame_id.c_str(), authority.c_str());
     error_exists = true;
   }
 
   if (std::isnan(transform_in.getOrigin().x()) || std::isnan(transform_in.getOrigin().y()) || std::isnan(transform_in.getOrigin().z())||
       std::isnan(transform_in.getRotation().x()) || std::isnan(transform_in.getRotation().y()) || std::isnan(transform_in.getRotation().z()) || std::isnan(transform_in.getRotation().w()))
   {
-    CONSOLE_BRIDGE_logError("TF_NAN_INPUT: Ignoring transform for child_frame_id \"%s\" from authority \"%s\" because of a nan value in the transform (%f %f %f) (%f %f %f %f)",
+    CONSOLE_BRIDGE_logError("TF NAN_INPUT: Ignoring transform for child_frame_id \"%s\" from authority \"%s\" because of a nan value in the transform (%f %f %f) (%f %f %f %f)",
              stripped_child_frame_id.c_str(), authority.c_str(),
              transform_in.getOrigin().x(), transform_in.getOrigin().y(), transform_in.getOrigin().z(),
              transform_in.getRotation().x(), transform_in.getRotation().y(), transform_in.getRotation().z(), transform_in.getRotation().w()
@@ -290,7 +290,7 @@ bool BufferCore::setTransformImpl(const tf2::Transform& transform_in, const std:
 
   if (!valid) 
   {
-    CONSOLE_BRIDGE_logError("TF_DENORMALIZED_QUATERNION: Ignoring transform for child_frame_id \"%s\" from authority \"%s\" because of an invalid quaternion in the transform (%f %f %f %f)",
+    CONSOLE_BRIDGE_logError("TF DENORMALIZED_QUATERNION: Ignoring transform for child_frame_id \"%s\" from authority \"%s\" because of an invalid quaternion in the transform (%f %f %f %f)",
              stripped_child_frame_id.c_str(), authority.c_str(),
              transform_in.getRotation().x(), transform_in.getRotation().y(), transform_in.getRotation().z(), transform_in.getRotation().w());
     error_exists = true;


### PR DESCRIPTION
Without this patch Jenkins considers these error messages to be MSBuild errors when they appear in launch output: https://ci.ros2.org/job/ci_windows/10668/msbuild/

The Jenkins plugin `warnings-ng` uses the following regex to match MSBuild messages: https://github.com/jenkinsci/analysis-model/blob/7aab09ca4d0b4237fdf88760e5e5d677dd8fc09d/src/main/java/edu/hm/hafner/analysis/parser/MsBuildParser.java#L22-L27

This patch slightly modifies the error messages to not match the regex anymore. Since the tokens like `TF_SELF_TRANSFORM` don't seem to be used anywhere else except in these messages I think it is fine to modify them.

Build with this patch without any extracted warnings: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10669)](https://ci.ros2.org/job/ci_windows/10669/)