### PR TITLE
Port eigen_kdl.h/cpp to ROS2

### DIFF
--- a/eigen_kdl/CMakeLists.txt
+++ b/eigen_kdl/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.5)
+project(eigen_kdl)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(orocos_kdl REQUIRED)
+find_package(eigen3_cmake_module REQUIRED)
+find_package(Eigen3 REQUIRED)
+
+include_directories(SYSTEM ${EIGEN3_INCLUDE_DIRS})
+include_directories(include)
+
+
+add_library(${PROJECT_NAME} SHARED
+  src/eigen_kdl.cpp
+)
+
+ament_target_dependencies(${PROJECT_NAME} orocos_kdl)
+
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION include/${PROJECT_NAME})
+
+install(TARGETS ${PROJECT_NAME}
+  DESTINATION lib/${PROJECT_NAME})
+
+ament_export_include_directories(include)
+ament_export_dependencies(
+  eigen3_cmake_module
+  Eigen3
+  orocos_kdl)
+ament_package()

--- a/eigen_kdl/include/eigen_kdl/eigen_kdl.h
+++ b/eigen_kdl/include/eigen_kdl/eigen_kdl.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2009, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Author: Adam Leeper, Stuart Glaser
+ */
+
+#ifndef EIGEN_KDL_CONVERSIONS_H
+#define EIGEN_KDL_CONVERSIONS_H
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+#include <kdl/frames.hpp>
+
+namespace tf2 {
+
+/// Converts a KDL rotation into an Eigen quaternion
+void quaternionKDLToEigen(const KDL::Rotation &k, Eigen::Quaterniond &e);
+
+/// Converts an Eigen quaternion into a KDL rotation
+void quaternionEigenToKDL(const Eigen::Quaterniond &e, KDL::Rotation &k);
+
+/// Converts a KDL frame into an Eigen Affine3d
+void transformKDLToEigen(const KDL::Frame &k, Eigen::Affine3d &e);
+
+/// Converts a KDL frame into an Eigen Isometry3d
+void transformKDLToEigen(const KDL::Frame &k, Eigen::Isometry3d &e);
+
+/// Converts an Eigen Affine3d into a KDL frame
+void transformEigenToKDL(const Eigen::Affine3d &e, KDL::Frame &k);
+
+/// Converts an Eigen Isometry3d into a KDL frame
+void transformEigenToKDL(const Eigen::Isometry3d &e, KDL::Frame &k);
+
+/// Converts a KDL twist into an Eigen matrix
+void twistKDLToEigen(const KDL::Twist &k, Eigen::Matrix<double, 6, 1> &e);
+
+/// Converts an Eigen matrix into a KDL Twist
+void twistEigenToKDL(const Eigen::Matrix<double, 6, 1> &e, KDL::Twist &k);
+
+/// Converts a KDL vector into an Eigen matrix
+void vectorKDLToEigen(const KDL::Vector &k, Eigen::Matrix<double, 3, 1> &e);
+
+/// Converts an Eigen matrix into a KDL vector
+void vectorEigenToKDL(const Eigen::Matrix<double, 3, 1> &e, KDL::Vector &k);
+
+/// Converts a KDL wrench into an Eigen matrix
+void wrenchKDLToEigen(const KDL::Wrench &k, Eigen::Matrix<double, 6, 1> &e);
+
+/// Converts an Eigen matrix into a KDL wrench
+void wrenchEigenToKDL(const Eigen::Matrix<double, 6, 1> &e, KDL::Wrench &k);
+
+} // namespace
+
+#endif

--- a/eigen_kdl/package.xml
+++ b/eigen_kdl/package.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>eigen_kdl</name>
+  <version>0.13.4</version>
+  <description>
+
+     Conversion functions between:
+      - Eigen and KDL
+
+  </description>
+  <author>Stuart Glaser</author>
+  <author>Adam Leeper</author>
+  <maintainer email="tfoote@osrfoundation.org">Tully Foote</maintainer>
+
+  <license>BSD</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <buildtool_depend>eigen3_cmake_module</buildtool_depend>
+  <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>
+
+  <build_depend>eigen</build_depend>
+  <build_export_depend>eigen</build_export_depend>
+
+  <depend>orocos_kdl</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/eigen_kdl/src/eigen_kdl.cpp
+++ b/eigen_kdl/src/eigen_kdl.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2009, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <eigen_kdl/eigen_kdl.h>
+
+namespace tf2 {
+
+void quaternionKDLToEigen(const KDL::Rotation &k, Eigen::Quaterniond &e)
+{
+  // // is it faster to do this?
+  k.GetQuaternion(e.x(), e.y(), e.z(), e.w());
+
+  // or this?
+  //double x, y, z, w;
+  //k.GetQuaternion(x, y, z, w);
+  //e = Eigen::Quaterniond(w, x, y, z);
+}
+
+void quaternionEigenToKDL(const Eigen::Quaterniond &e, KDL::Rotation &k)
+{
+  k = KDL::Rotation::Quaternion(e.x(), e.y(), e.z(), e.w());
+}
+
+namespace {
+  template<typename T>
+  void transformKDLToEigenImpl(const KDL::Frame &k, T &e)
+  {
+    // translation
+    for (unsigned int i = 0; i < 3; ++i)
+      e(i, 3) = k.p[i];
+
+    // rotation matrix
+    for (unsigned int i = 0; i < 9; ++i)
+      e(i/3, i%3) = k.M.data[i];
+
+    // "identity" row
+    e(3,0) = 0.0;
+    e(3,1) = 0.0;
+    e(3,2) = 0.0;
+    e(3,3) = 1.0;
+  }
+
+  template<typename T>
+  void transformEigenToKDLImpl(const T &e, KDL::Frame &k)
+  {
+    for (unsigned int i = 0; i < 3; ++i)
+      k.p[i] = e(i, 3);
+    for (unsigned int i = 0; i < 9; ++i)
+      k.M.data[i] = e(i/3, i%3);
+  }
+
+}
+
+void transformKDLToEigen(const KDL::Frame &k, Eigen::Affine3d &e)
+{
+  transformKDLToEigenImpl(k, e);
+}
+
+void transformKDLToEigen(const KDL::Frame &k, Eigen::Isometry3d &e)
+{
+  transformKDLToEigenImpl(k, e);
+}
+
+void transformEigenToKDL(const Eigen::Affine3d &e, KDL::Frame &k)
+{
+  transformEigenToKDLImpl(e, k);
+}
+
+void transformEigenToKDL(const Eigen::Isometry3d &e, KDL::Frame &k)
+{
+  transformEigenToKDLImpl(e, k);
+}
+
+void twistEigenToKDL(const Eigen::Matrix<double, 6, 1> &e, KDL::Twist &k)
+{
+  for(int i = 0; i < 6; ++i)
+    k[i] = e[i];
+}
+
+void twistKDLToEigen(const KDL::Twist &k, Eigen::Matrix<double, 6, 1> &e)
+{
+  for(int i = 0; i < 6; ++i)
+    e[i] = k[i];
+}
+
+void vectorEigenToKDL(const Eigen::Matrix<double, 3, 1> &e, KDL::Vector &k)
+{
+  for(int i = 0; i < 3; ++i)
+    k[i] = e[i];
+}
+void vectorKDLToEigen(const KDL::Vector &k, Eigen::Matrix<double, 3, 1> &e)
+{
+  for(int i = 0; i < 3; ++i)
+    e[i] = k[i];
+}
+
+void wrenchKDLToEigen(const KDL::Wrench &k, Eigen::Matrix<double, 6, 1> &e)
+{
+  for(int i = 0; i < 6; ++i)
+    e[i] = k[i];
+}
+
+void wrenchEigenToKDL(const Eigen::Matrix<double, 6, 1> &e, KDL::Wrench &k)
+{
+  for(int i = 0; i < 6; ++i)
+    k[i] = e[i];
+}
+
+
+} // namespace


### PR DESCRIPTION
This's a straight port for eigen_kdl.h/eigen_kdl.cpp https://github.com/ros/geometry/tree/melodic-devel/eigen_conversions into their own package and naming it eigen_kdl the other header and source file are already ported in tf2_eigen, I also renamed the namespace tf -> tf2, removed CHANGELOG.rst, and mainpage.dox

This package is needed for MoveIt2 and MoveIt task constructor

Please let me know if you think that this package shouldn't be here, or if it should be ported into a different repo,