### PR TITLE
Moved unique_lock of messages_mutex_ to guarantee pointer

### DIFF
--- a/tf2_ros/include/tf2_ros/message_filter.h
+++ b/tf2_ros/include/tf2_ros/message_filter.h
@@ -429,7 +429,8 @@ public:
         --message_count_;
       }
 
-      // Add the message to our list
+      // Add the message to our list while keeping a lock on the messages.
+      std::unique_lock<std::mutex> unique_lock(messages_mutex_);
       info.event = evt;
       messages_.push_back(info);
       ++message_count_;

--- a/tf2_ros/include/tf2_ros/message_filter.h
+++ b/tf2_ros/include/tf2_ros/message_filter.h
@@ -491,6 +491,9 @@ private:
   {
     namespace mt = message_filters::message_traits;
 
+    // We will be accessing and mutating messages now, require unique lock
+    std::unique_lock<std::mutex> lock(messages_mutex_);
+
     // find the message this request is associated with
     typename L_MessageInfo::iterator msg_it = messages_.begin();
     typename L_MessageInfo::iterator msg_end = messages_.end();
@@ -551,8 +554,6 @@ private:
       can_transform = false;
     }
 
-    // We will be mutating messages now, require unique lock
-    std::unique_lock<std::mutex> lock(messages_mutex_);
     if (can_transform) {
       TF2_ROS_MESSAGEFILTER_DEBUG("Message ready in frame %s at time %.3f, count now %d",
         frame_id.c_str(), stamp.seconds(), message_count_ - 1);

--- a/tf2_ros/include/tf2_ros/message_filter.h
+++ b/tf2_ros/include/tf2_ros/message_filter.h
@@ -409,11 +409,12 @@ public:
     if (info.success_count == expected_success_count_) {
       messageReady(evt);
     } else {
+
+      // Keep a lock on the messages
+      std::unique_lock<std::mutex> unique_lock(messages_mutex_);
+
       // If this message is about to push us past our queue size, erase the oldest message
       if (queue_size_ != 0 && message_count_ + 1 > queue_size_) {
-
-        // While we're using the reference keep a lock on the messages.
-        std::unique_lock<std::mutex> unique_lock(messages_mutex_);
 
         ++dropped_message_count_;
         const MessageInfo & front = messages_.front();
@@ -429,8 +430,7 @@ public:
         --message_count_;
       }
 
-      // Add the message to our list while keeping a lock on the messages.
-      std::unique_lock<std::mutex> unique_lock(messages_mutex_);
+      // Add the message to our list
       info.event = evt;
       messages_.push_back(info);
       ++message_count_;
@@ -492,19 +492,31 @@ private:
   {
     namespace mt = message_filters::message_traits;
 
-    // We will be accessing and mutating messages now, require unique lock
-    std::unique_lock<std::mutex> lock(messages_mutex_);
-
     // find the message this request is associated with
     typename L_MessageInfo::iterator msg_it = messages_.begin();
     typename L_MessageInfo::iterator msg_end = messages_.end();
-    for (; msg_it != msg_end; ++msg_it) {
-      MessageInfo & info = *msg_it;
-      auto handle_it = std::find(info.handles.begin(), info.handles.end(), handle);
-      if (handle_it != info.handles.end()) {
-        // found msg_it
-        ++info.success_count;
-        break;
+
+    MessageInfo saved_msg;
+
+    {
+      // We will be accessing and mutating messages now, require unique lock
+      std::unique_lock<std::mutex> lock(messages_mutex_);
+
+      for (; msg_it != msg_end; ++msg_it) {
+        MessageInfo & info = *msg_it;
+        auto handle_it = std::find(info.handles.begin(), info.handles.end(), handle);
+        if (handle_it != info.handles.end()) {
+          // found msg_it
+          ++info.success_count;
+          if (info.success_count >= expected_success_count_) {
+            saved_msg = *msg_it;
+            messages_.erase(msg_it);
+            --message_count_;
+          } else {
+            return;
+          }
+          break;
+        }
       }
     }
 
@@ -512,13 +524,8 @@ private:
       return;
     }
 
-    const MessageInfo & info = *msg_it;
-    if (info.success_count < expected_success_count_) {
-      return;
-    }
-
     bool can_transform = true;
-    const MConstPtr & message = info.event.getMessage();
+    const MConstPtr & message = saved_msg.event.getMessage();
     std::string frame_id = stripSlash(mt::FrameId<M>::value(*message));
     rclcpp::Time stamp = mt::TimeStamp<M>::value(*message);
 
@@ -560,17 +567,14 @@ private:
         frame_id.c_str(), stamp.seconds(), message_count_ - 1);
 
       ++successful_transform_count_;
-      messageReady(info.event);
+      messageReady(saved_msg.event);
     } else {
       ++dropped_message_count_;
 
       TF2_ROS_MESSAGEFILTER_DEBUG("Discarding message in frame %s at time %.3f, count now %d",
         frame_id.c_str(), stamp.seconds(), message_count_ - 1);
-      messageDropped(info.event, filter_failure_reasons::Unknown);
+      messageDropped(saved_msg.event, filter_failure_reasons::Unknown);
     }
-
-    messages_.erase(msg_it);
-    --message_count_;
   }
 
   /**
@@ -755,3 +759,4 @@ private:
 } // namespace tf2
 
 #endif
+


### PR DESCRIPTION
**messages_mutex_** will be locked after **msg_it** was set. When publishing a laser scan at a high rate (150Hz) or when when you have any hick-ups in your pipeline it is not guaranteed that the iterator msg_it is still pointing at the expected element in messages_.

This leads to memory corruption and a crashing amcl. 

Corrected message_mutex to be in line with original (ROS1) code:
https://github.com/ros/geometry2/blob/noetic-devel/tf2_ros/include/tf2_ros/message_filter.h

Related: https://github.com/ros2/geometry2/issues/213
Possibly related: https://github.com/ros2/geometry2/issues/200