### PR TITLE
Fixed memory leak in Buffer::waitForTransform

### DIFF
--- a/test_tf2/test/buffer_core_test.cpp
+++ b/test_tf2/test/buffer_core_test.cpp
@@ -1823,34 +1823,34 @@ TEST(BufferCore_transformableCallbacks, alreadyTransformable)
       std::chrono::seconds(1) +
       std::chrono::nanoseconds(0));
 
-  tf2::TransformableCallbackHandle cb_handle = b.addTransformableCallback(std::bind(&TransformableHelper::callback,
+  tf2::BufferCore::TransformableCallback cb = std::bind(&TransformableHelper::callback,
       &h,
       std::placeholders::_1,
       std::placeholders::_2,
       std::placeholders::_3,
       std::placeholders::_4,
-      std::placeholders::_5));
+      std::placeholders::_5);
 
-  EXPECT_EQ(b.addTransformableRequest(cb_handle, "a", "b", eval_time_time_point), 0U);
+  EXPECT_EQ(b.addTransformableRequest(cb, "a", "b", eval_time_time_point), 0U);
 }
 
 TEST(BufferCore_transformableCallbacks, waitForNewTransform)
 {
   tf2::BufferCore b;
   TransformableHelper h;
-  tf2::TransformableCallbackHandle cb_handle = b.addTransformableCallback(std::bind(&TransformableHelper::callback,
+  tf2::BufferCore::TransformableCallback cb = std::bind(&TransformableHelper::callback,
       &h,
       std::placeholders::_1,
       std::placeholders::_2,
       std::placeholders::_3,
       std::placeholders::_4,
-      std::placeholders::_5));
+      std::placeholders::_5);
 
   tf2::TimePoint eval_time_time_point = tf2::TimePoint(
       std::chrono::seconds(10) +
       std::chrono::nanoseconds(0));
 
-  EXPECT_GT(b.addTransformableRequest(cb_handle, "a", "b", eval_time_time_point), 0U);
+  EXPECT_GT(b.addTransformableRequest(cb, "a", "b", eval_time_time_point), 0U);
 
   geometry_msgs::msg::TransformStamped t;
   for (uint32_t i = 1; i <= 10; ++i)
@@ -1876,19 +1876,19 @@ TEST(BufferCore_transformableCallbacks, waitForOldTransform)
 {
   tf2::BufferCore b;
   TransformableHelper h;
-  tf2::TransformableCallbackHandle cb_handle = b.addTransformableCallback(std::bind(&TransformableHelper::callback,
+  tf2::BufferCore::TransformableCallback cb = std::bind(&TransformableHelper::callback,
       &h,
       std::placeholders::_1,
       std::placeholders::_2,
       std::placeholders::_3,
       std::placeholders::_4,
-      std::placeholders::_5));
+      std::placeholders::_5);
 
   tf2::TimePoint eval_time_time_point = tf2::TimePoint(
       std::chrono::seconds(1) +
       std::chrono::nanoseconds(0));
 
-  EXPECT_GT(b.addTransformableRequest(cb_handle, "a", "b", eval_time_time_point), 0U);
+  EXPECT_GT(b.addTransformableRequest(cb, "a", "b", eval_time_time_point), 0U);
 
   geometry_msgs::msg::TransformStamped t;
   for (uint32_t i = 10; i > 0; --i)

--- a/tf2/include/tf2/buffer_core.h
+++ b/tf2/include/tf2/buffer_core.h
@@ -54,7 +54,6 @@ namespace tf2
 {
 
 typedef std::pair<TimePoint, CompactFrameID> P_TimeAndFrameID;
-typedef uint32_t TransformableCallbackHandle;
 typedef uint64_t TransformableRequestHandle;
 
 class TimeCacheInterface;
@@ -256,14 +255,8 @@ public:
 
   /// \brief Internal use only
   TF2_PUBLIC
-  TransformableCallbackHandle addTransformableCallback(const TransformableCallback & cb);
-  /// \brief Internal use only
-  TF2_PUBLIC
-  void removeTransformableCallback(TransformableCallbackHandle handle);
-  /// \brief Internal use only
-  TF2_PUBLIC
   TransformableRequestHandle addTransformableRequest(
-    TransformableCallbackHandle handle,
+    const TransformableCallback & cb,
     const std::string & target_frame,
     const std::string & source_frame,
     TimePoint time);
@@ -380,6 +373,8 @@ private:
   /// How long to cache transform history
   tf2::Duration cache_time_;
 
+  typedef uint32_t TransformableCallbackHandle;
+
   typedef std::unordered_map<TransformableCallbackHandle,
       TransformableCallback> M_TransformableCallback;
   M_TransformableCallback transformable_callbacks_;
@@ -400,9 +395,6 @@ private:
   V_TransformableRequest transformable_requests_;
   std::mutex transformable_requests_mutex_;
   uint64_t transformable_requests_counter_;
-
-  struct RemoveRequestByCallback;
-  struct RemoveRequestByID;
 
 
   /************************* Internal Functions ****************************/

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -1474,6 +1474,7 @@ void BufferCore::testTransformableRequests()
           cb(
             req.request_handle, lookupFrameString(req.target_id), lookupFrameString(
               req.source_id), req.time, result);
+          transformable_callbacks_.erase(req.cb_handle);
         }
       }
 

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -32,6 +32,7 @@
 
 #include <algorithm>
 #include <map>
+#include <mutex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -1276,49 +1277,8 @@ std::string BufferCore::allFramesAsYAML() const
   return this->allFramesAsYAML(TimePointZero);
 }
 
-TransformableCallbackHandle BufferCore::addTransformableCallback(const TransformableCallback & cb)
-{
-  std::unique_lock<std::mutex> lock(transformable_callbacks_mutex_);
-  TransformableCallbackHandle handle = ++transformable_callbacks_counter_;
-  while (!transformable_callbacks_.insert(std::make_pair(handle, cb)).second) {
-    handle = ++transformable_callbacks_counter_;
-  }
-
-  return handle;
-}
-
-struct BufferCore::RemoveRequestByCallback
-{
-  explicit RemoveRequestByCallback(TransformableCallbackHandle handle)
-  : handle_(handle)
-  {}
-
-  bool operator()(const TransformableRequest & req)
-  {
-    return req.cb_handle == handle_;
-  }
-
-  TransformableCallbackHandle handle_;
-};
-
-void BufferCore::removeTransformableCallback(TransformableCallbackHandle handle)
-{
-  {
-    std::unique_lock<std::mutex> lock(transformable_callbacks_mutex_);
-    transformable_callbacks_.erase(handle);
-  }
-
-  {
-    std::unique_lock<std::mutex> lock(transformable_requests_mutex_);
-    V_TransformableRequest::iterator it = std::remove_if(
-      transformable_requests_.begin(), transformable_requests_.end(),
-      RemoveRequestByCallback(handle));
-    transformable_requests_.erase(it, transformable_requests_.end());
-  }
-}
-
 TransformableRequestHandle BufferCore::addTransformableRequest(
-  TransformableCallbackHandle handle,
+  const TransformableCallback & cb,
   const std::string & target_frame,
   const std::string & source_frame,
   TimePoint time)
@@ -1348,7 +1308,16 @@ TransformableRequestHandle BufferCore::addTransformableRequest(
     }
   }
 
-  req.cb_handle = handle;
+  {
+    std::unique_lock<std::mutex> lock(transformable_callbacks_mutex_);
+    TransformableCallbackHandle handle = ++transformable_callbacks_counter_;
+    while (!transformable_callbacks_.insert(std::make_pair(handle, cb)).second) {
+      handle = ++transformable_callbacks_counter_;
+    }
+
+    req.cb_handle = handle;
+  }
+
   req.time = time;
   req.request_handle = ++transformable_requests_counter_;
   if (req.request_handle == 0 || req.request_handle == 0xffffffffffffffffULL) {
@@ -1369,29 +1338,18 @@ TransformableRequestHandle BufferCore::addTransformableRequest(
   return req.request_handle;
 }
 
-struct BufferCore::RemoveRequestByID
-{
-  explicit RemoveRequestByID(TransformableRequestHandle handle)
-  : handle_((TransformableCallbackHandle)handle)
-  {}
-
-  bool operator()(const TransformableRequest & req)
-  {
-    return req.request_handle == handle_;
-  }
-
-  TransformableCallbackHandle handle_;
-};
-
 void BufferCore::cancelTransformableRequest(TransformableRequestHandle handle)
 {
-  std::unique_lock<std::mutex> lock(transformable_requests_mutex_);
-  V_TransformableRequest::iterator it = std::remove_if(
-    transformable_requests_.begin(), transformable_requests_.end(), RemoveRequestByID(handle));
+  std::unique_lock<std::mutex> tr_lock(transformable_requests_mutex_);
+  std::unique_lock<std::mutex> tc_lock(transformable_callbacks_mutex_);
 
-  if (it != transformable_requests_.end()) {
-    transformable_requests_.erase(it, transformable_requests_.end());
+  V_TransformableRequest::iterator remove_it = std::remove_if(transformable_requests_.begin(), transformable_requests_.end(),
+                                                              [handle](TransformableRequest req) { return handle == req.request_handle; });
+  for (V_TransformableRequest::iterator it = remove_it; it != transformable_requests_.end(); ++it) {
+    transformable_callbacks_.erase(it->cb_handle);
   }
+
+  transformable_requests_.erase(remove_it, transformable_requests_.end());
 }
 
 // backwards compability for tf methods
@@ -1493,9 +1451,6 @@ void BufferCore::testTransformableRequests()
       ++it;
     }
   }
-
-  // unlock before allowing possible user callbacks to avoid potential detadlock (#91)
-  lock.unlock();
 }
 
 

--- a/tf2/test/simple_tf2_core.cpp
+++ b/tf2/test/simple_tf2_core.cpp
@@ -72,7 +72,7 @@ TEST(tf2, setTransformValidWithCallback)
   tf2::TimePoint received_time_point;
   bool transform_available = false;
 
-  auto cb_handle = buffer.addTransformableCallback(
+  auto cb =
     [&received_request_handle, &received_target_frame, &received_source_frame, &received_time_point,
     &transform_available](
       tf2::TransformableRequestHandle request_handle,
@@ -86,10 +86,10 @@ TEST(tf2, setTransformValidWithCallback)
       received_source_frame = source_frame;
       received_time_point = time;
       transform_available = tf2::TransformAvailable == result;
-    });
+    };
 
   tf2::TransformableRequestHandle request_handle = buffer.addTransformableRequest(
-    cb_handle, target_frame, source_frame, time_point);
+    cb, target_frame, source_frame, time_point);
   ASSERT_NE(request_handle, 0u);
 
   geometry_msgs::msg::TransformStamped transform_msg;

--- a/tf2_ros/include/tf2_ros/buffer.h
+++ b/tf2_ros/include/tf2_ros/buffer.h
@@ -261,7 +261,11 @@ namespace tf2_ros
     CreateTimerInterface::SharedPtr timer_interface_;
 
     /// \brief A map from active timers to BufferCore request handles
-    std::unordered_map<TimerHandle, tf2::TransformableRequestHandle> timer_to_request_map_;
+    typedef struct {
+      tf2::TransformableRequestHandle request_handle;
+      tf2::TransformableCallbackHandle callback_handle;
+    } TransformableHandles;
+    std::unordered_map<TimerHandle, TransformableHandles> timer_to_request_map_;
 
     /// \brief A mutex on the timer_to_request_map_ data
     std::mutex timer_to_request_map_mutex_;

--- a/tf2_ros/include/tf2_ros/buffer.h
+++ b/tf2_ros/include/tf2_ros/buffer.h
@@ -261,11 +261,7 @@ namespace tf2_ros
     CreateTimerInterface::SharedPtr timer_interface_;
 
     /// \brief A map from active timers to BufferCore request handles
-    typedef struct {
-      tf2::TransformableRequestHandle request_handle;
-      tf2::TransformableCallbackHandle callback_handle;
-    } TransformableHandles;
-    std::unordered_map<TimerHandle, TransformableHandles> timer_to_request_map_;
+    std::unordered_map<TimerHandle, tf2::TransformableRequestHandle> timer_to_request_map_;
 
     /// \brief A mutex on the timer_to_request_map_ data
     std::mutex timer_to_request_map_mutex_;

--- a/tf2_ros/src/buffer.cpp
+++ b/tf2_ros/src/buffer.cpp
@@ -202,7 +202,7 @@ Buffer::waitForTransform(const std::string& target_frame, const std::string& sou
   auto promise = std::make_shared<std::promise<geometry_msgs::msg::TransformStamped>>();
   TransformStampedFuture future(promise->get_future());
 
-  auto cb_handle = addTransformableCallback([this, promise, callback, future](
+  auto cb = [this, promise, callback, future](
     tf2::TransformableRequestHandle request_handle, const std::string& target_frame,
     const std::string& source_frame, tf2::TimePoint time, tf2::TransformableResult result)
     {
@@ -213,7 +213,7 @@ Buffer::waitForTransform(const std::string& target_frame, const std::string& sou
         std::lock_guard<std::mutex> lock(this->timer_to_request_map_mutex_);
         // Check if a timeout already occurred
         for (auto it = timer_to_request_map_.begin(); it != timer_to_request_map_.end(); ++it) {
-          if (request_handle == it->second.request_handle) {
+          if (request_handle == it->second) {
             // The request handle was found, so a timeout has not occurred
             this->timer_interface_->remove(it->first);
             this->timer_to_request_map_.erase(it->first);
@@ -235,20 +235,18 @@ Buffer::waitForTransform(const std::string& target_frame, const std::string& sou
             "Failed to transform from " + source_frame + " to " + target_frame)));
       }
       callback(future);
-    });
+    };
 
-  auto handle = addTransformableRequest(cb_handle, target_frame, source_frame, time);
+  auto handle = addTransformableRequest(cb, target_frame, source_frame, time);
   if (0 == handle) {
     // Immediately transformable
     geometry_msgs::msg::TransformStamped msg_stamped = lookupTransform(target_frame, source_frame, time);
     promise->set_value(msg_stamped);
-    removeTransformableCallback(cb_handle);
     callback(future);
   } else if (0xffffffffffffffffULL == handle) {
     // Never transformable
     promise->set_exception(std::make_exception_ptr(tf2::LookupException(
           "Failed to transform from " + source_frame + " to " + target_frame)));
-    removeTransformableCallback(cb_handle);
     callback(future);
   } else {
     std::lock_guard<std::mutex> lock(timer_to_request_map_mutex_);
@@ -257,8 +255,8 @@ Buffer::waitForTransform(const std::string& target_frame, const std::string& sou
       timeout,
       std::bind(&Buffer::timerCallback, this, std::placeholders::_1, promise, future, callback));
 
-    // Save association between timer and request/callback handle
-    timer_to_request_map_[timer_handle] = {handle, cb_handle};
+    // Save association between timer and request handle
+    timer_to_request_map_[timer_handle] = handle;
   }
   return future;
 }
@@ -270,20 +268,20 @@ Buffer::timerCallback(const TimerHandle & timer_handle,
                       TransformReadyCallback callback)
 {
   bool timer_is_valid = false;
-  tf2::TransformableCallbackHandle callback_handle = 0u;
+  tf2::TransformableRequestHandle request_handle = 0u;
   {
     std::lock_guard<std::mutex> lock(timer_to_request_map_mutex_);
     auto timer_and_request_it = timer_to_request_map_.find(timer_handle);
     timer_is_valid = (timer_to_request_map_.end() != timer_and_request_it);
     if (timer_is_valid) {
-      callback_handle = timer_and_request_it->second.callback_handle;
+      request_handle = timer_and_request_it->second;
     }
     timer_to_request_map_.erase(timer_handle);
     timer_interface_->remove(timer_handle);
   }
 
   if (timer_is_valid) {
-    removeTransformableCallback(callback_handle);
+    cancelTransformableRequest(request_handle);
     promise->set_exception(
       std::make_exception_ptr(tf2::TimeoutException(std::string("Timed out waiting for transform"))));
     callback(future);

--- a/tf2_ros/src/buffer.cpp
+++ b/tf2_ros/src/buffer.cpp
@@ -213,7 +213,7 @@ Buffer::waitForTransform(const std::string& target_frame, const std::string& sou
         std::lock_guard<std::mutex> lock(this->timer_to_request_map_mutex_);
         // Check if a timeout already occurred
         for (auto it = timer_to_request_map_.begin(); it != timer_to_request_map_.end(); ++it) {
-          if (request_handle == it->second) {
+          if (request_handle == it->second.request_handle) {
             // The request handle was found, so a timeout has not occurred
             this->timer_interface_->remove(it->first);
             this->timer_to_request_map_.erase(it->first);
@@ -242,11 +242,13 @@ Buffer::waitForTransform(const std::string& target_frame, const std::string& sou
     // Immediately transformable
     geometry_msgs::msg::TransformStamped msg_stamped = lookupTransform(target_frame, source_frame, time);
     promise->set_value(msg_stamped);
+    removeTransformableCallback(cb_handle);
     callback(future);
   } else if (0xffffffffffffffffULL == handle) {
     // Never transformable
     promise->set_exception(std::make_exception_ptr(tf2::LookupException(
           "Failed to transform from " + source_frame + " to " + target_frame)));
+    removeTransformableCallback(cb_handle);
     callback(future);
   } else {
     std::lock_guard<std::mutex> lock(timer_to_request_map_mutex_);
@@ -255,8 +257,8 @@ Buffer::waitForTransform(const std::string& target_frame, const std::string& sou
       timeout,
       std::bind(&Buffer::timerCallback, this, std::placeholders::_1, promise, future, callback));
 
-    // Save association between timer and request handle
-    timer_to_request_map_[timer_handle] = handle;
+    // Save association between timer and request/callback handle
+    timer_to_request_map_[timer_handle] = {handle, cb_handle};
   }
   return future;
 }
@@ -268,20 +270,20 @@ Buffer::timerCallback(const TimerHandle & timer_handle,
                       TransformReadyCallback callback)
 {
   bool timer_is_valid = false;
-  tf2::TransformableRequestHandle request_handle = 0u;
+  tf2::TransformableCallbackHandle callback_handle = 0u;
   {
     std::lock_guard<std::mutex> lock(timer_to_request_map_mutex_);
     auto timer_and_request_it = timer_to_request_map_.find(timer_handle);
     timer_is_valid = (timer_to_request_map_.end() != timer_and_request_it);
     if (timer_is_valid) {
-      request_handle = timer_and_request_it->second;
+      callback_handle = timer_and_request_it->second.callback_handle;
     }
     timer_to_request_map_.erase(timer_handle);
     timer_interface_->remove(timer_handle);
   }
 
   if (timer_is_valid) {
-    cancelTransformableRequest(request_handle);
+    removeTransformableCallback(callback_handle);
     promise->set_exception(
       std::make_exception_ptr(tf2::TimeoutException(std::string("Timed out waiting for transform"))));
     callback(future);


### PR DESCRIPTION
We found that the memory usage of nav2_amcl was increasing in time. After a couple of days running this resulted in a crash. By simulating a high-speed laser-scan (150Hz) we were able to speed-up the process and trace the leak.

Amcl is using a MessageFilter on the laser_scan (message_filter.h).  On the following line, a _waitForTransform_ is called:

```
auto future = buffer_.waitForTransform(
            target_frame,
            frame_id,
            tf2::timeFromSec(stamp.seconds()),
            buffer_timeout_,
            std::bind(&MessageFilter::transformReadyCallback, this, std::placeholders::_1, next_handle_index_));
```
In waitForTransform ([tf2_ros/src/buffer.cpp](https://github.com/ros2/geometry2/blob/eloquent/tf2_ros/src/buffer.cpp)) a call is made to **addTransformableCallback()** and **addTransformableRequest()** in [tf2/src/buffer_core.cpp](https://github.com/ros2/geometry2/blob/eloquent/tf2/src/buffer_core.cpp). These functions are adding to the unordered_map **transformable_callbacks_** and vector **transformable_requests_**. 

Elements of transformable_callbacks_ are never removed. Resulting an a growing list, eating up the memory. 

![fix2](https://user-images.githubusercontent.com/22637552/86006824-d55e5f00-ba16-11ea-9458-239a21003ab2.png)

The fix below is not the prettiest, but it does the job. I'm happy to iterate on this. 

### Related issues:
- https://github.com/ros2/geometry2/issues/213
- https://github.com/ros2/geometry2/issues/200
