### PR TITLE
Avoid using invalid std::list iterators

### DIFF
--- a/tf2_ros/include/tf2_ros/message_filter.h
+++ b/tf2_ros/include/tf2_ros/message_filter.h
@@ -464,6 +464,7 @@ private:
     typename L_MessageInfo::iterator msg_end = messages_.end();
 
     MEvent saved_event;
+    bool event_found = false;
 
     {
       // We will be accessing and mutating messages now, require unique lock
@@ -479,15 +480,14 @@ private:
             saved_event = msg_it->event;
             messages_.erase(msg_it);
             --message_count_;
-          } else {
-            msg_it = msg_end;
-          }
+            event_found = true;
+          } 
           break;
         }
       }
     }
 
-    if (msg_it == msg_end) {
+    if (!event_found) {
       return;
     }
 


### PR DESCRIPTION
The previous implementation of this made use of a `std::list::iterator` after it has been invalidated by a `std::list::erase` call.
This replaces that implementation with a boolean flag.

Reference: https://en.cppreference.com/w/cpp/container/list/erase
> References and iterators to the erased elements are invalidated. Other references and iterators are not affected.

This problem specifically manifested in Windows Debug builds, which have specific checking for "incompatible iterators"

 Signed-off-by: Michael Carroll <michael@openrobotics.org>