### PR TITLE
Fix cache_time None check in buffer.py

### DIFF
--- a/tf2_ros_py/test/test_buffer.py
+++ b/tf2_ros_py/test/test_buffer.py
@@ -140,6 +140,22 @@ class TestBuffer(unittest.TestCase):
         self.assertEqual(transform, cm.exception.value)
         coro.close()
 
+    def test_buffer_non_default_cache(self):
+        buffer = Buffer(cache_time=rclpy.duration.Duration(seconds=10.0))
+        clock = rclpy.clock.Clock()
+        rclpy_time = clock.now()
+        transform = self.build_transform('foo', 'bar', rclpy_time)
+
+        self.assertEqual(buffer.set_transform(transform, 'unittest'), None)
+
+        self.assertEqual(buffer.can_transform('foo', 'bar', rclpy_time), True)
+
+        output = buffer.lookup_transform('foo', 'bar', rclpy_time)
+        self.assertEqual(transform.child_frame_id, output.child_frame_id)
+        self.assertEqual(transform.transform.translation.x, output.transform.translation.x)
+        self.assertEqual(transform.transform.translation.y, output.transform.translation.y)
+        self.assertEqual(transform.transform.translation.z, output.transform.translation.z)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tf2_ros_py/tf2_ros/buffer.py
+++ b/tf2_ros_py/tf2_ros/buffer.py
@@ -58,7 +58,7 @@ class Buffer(tf2.BufferCore, tf2_ros.BufferInterface):
         :param cache_time: (Optional) How long to retain past information in BufferCore.
         :param node: (Optional) If node create a tf2_frames service, It responses all frames as a yaml
         """
-        if cache_time != None:
+        if cache_time is not None:
             tf2.BufferCore.__init__(self, cache_time)
         else:
             tf2.BufferCore.__init__(self)

--- a/tf2_ros_py/tf2_ros/buffer.py
+++ b/tf2_ros_py/tf2_ros/buffer.py
@@ -55,7 +55,7 @@ class Buffer(tf2.BufferCore, tf2_ros.BufferInterface):
         """
         Constructor.
 
-        :param cache_time: (Optional) How long to retain past information in BufferCore.
+        :param cache_time: (Optional) Duration object describing how long to retain past information in BufferCore.
         :param node: (Optional) If node create a tf2_frames service, It responses all frames as a yaml
         """
         if cache_time is not None:


### PR DESCRIPTION
This fix allows me to pass in Duration values to the Buffer class.  Otherwise I get this exception:

File "build_368/ros2-linux/lib/python3.6/site-packages/tf2_ros/buffer.py", line 61, in __init__
    if cache_time != None:
  File "build_368/ros2-linux/lib/python3.6/site-packages/rclpy/time.py", line 108, in __ne__
    return not self.__eq__(other)
  File "build_368/ros2-linux/lib/python3.6/site-packages/rclpy/time.py", line 105, in __eq__
    raise TypeError("Can't compare time with object of type: ", type(other))
TypeError: ("Can't compare time with object of type: ", <class 'NoneType'>)
