### PR TITLE
Clear callbacks_to_remove variable after removing

### DIFF
--- a/tf2_ros_py/tf2_ros/buffer.py
+++ b/tf2_ros_py/tf2_ros/buffer.py
@@ -89,6 +89,7 @@ class Buffer(tf2.BufferCore, tf2_ros.BufferInterface):
         # Remove callbacks after to avoid modifying list being iterated on
             for callback in self._callbacks_to_remove:
                 self._new_data_callbacks.remove(callback)
+            self._callbacks_to_remove.clear()
 
     def _remove_callback(self, callback):
         with self._callbacks_lock:


### PR DESCRIPTION
Prevents a `ValueError` when calling `_call_new_data_callbacks` after a callback has been removed.