### PR TITLE
relax test timings to pass with Connext

### DIFF
--- a/test_tf2/test/static_publisher.launch.py
+++ b/test_tf2/test/static_publisher.launch.py
@@ -42,7 +42,7 @@ def generate_test_description():
 class TestBufferClient(unittest.TestCase):
 
     def test_termination(self, node_under_test, proc_info):
-        proc_info.assertWaitForShutdown(process=node_under_test, timeout=(10))
+        proc_info.assertWaitForShutdown(process=node_under_test, timeout=(60))
 
 
 @launch_testing.post_shutdown_test()

--- a/test_tf2/test/test_static_publisher.cpp
+++ b/test_tf2/test/test_static_publisher.cpp
@@ -46,7 +46,7 @@
 
 #include "permuter.hpp"
 
-const int MAX_ATTEMPTS = 100;
+const int MAX_ATTEMPTS = 400;
 
 TEST(StaticTransformPublisher, a_b_different_times)
 {


### PR DESCRIPTION
Resolves test failures with Connext in the nightly job: http://build.ros2.org/view/Rci/job/Rci__nightly-connext_ubuntu_focal_amd64/42/testReport/

Before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11855)](https://ci.ros2.org/job/ci_linux/11855/)
After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11856)](https://ci.ros2.org/job/ci_linux/11856/)