### PR TITLE
fix time-reset test with Connext

### DIFF
--- a/tf2_ros/test/time_reset_test.cpp
+++ b/tf2_ros/test/time_reset_test.cpp
@@ -57,13 +57,15 @@ TEST(tf2_ros_time_reset_test, time_backwards)
 
   auto clock_pub = node_->create_publisher<rosgraph_msgs::msg::Clock>("/clock", 1);
 
+  // basic test
+  ASSERT_FALSE(buffer.canTransform("foo", "bar", rclcpp::Time(101, 0)));
+
+  // make sure endpoints have discovered each other
+  spin_for_a_second(node_);
 
   rosgraph_msgs::msg::Clock c;
   c.clock = rclcpp::Time(100, 0);
   clock_pub->publish(c);
-
-  // basic test
-  ASSERT_FALSE(buffer.canTransform("foo", "bar", rclcpp::Time(101, 0)));
 
   // set the transform
   geometry_msgs::msg::TransformStamped msg;


### PR DESCRIPTION
The test was failing with Connext since it has been added in #202.

The patch makes sure to wait a bit before publishing to ensure endpoints had a chance to discover each other.

Before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11879)](https://ci.ros2.org/job/ci_linux/11879/)
After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11880)](https://ci.ros2.org/job/ci_linux/11880/)