### PR TITLE
[foxy backport] Add in pytest.ini so tests succeed locally. (#280)

### DIFF
--- a/examples_tf2_py/pytest.ini
+++ b/examples_tf2_py/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2

--- a/tf2_py/pytest.ini
+++ b/tf2_py/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2

--- a/tf2_ros/pytest.ini
+++ b/tf2_ros/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2


### PR DESCRIPTION
Backport #280 to Foxy.

This should help resolve one of the outstanding failures in ros2/ci#503