### PR TITLE
Add PoseWithCovarianceStamped transform support

### DIFF
--- a/tf2/include/tf2/convert.h
+++ b/tf2/include/tf2/convert.h
@@ -31,6 +31,7 @@
 #ifndef TF2__CONVERT_H_
 #define TF2__CONVERT_H_
 
+#include <array>
 #include <string>
 
 #include "builtin_interfaces/msg/time.hpp"
@@ -161,10 +162,10 @@ void convert(const A & a1, A & a2)
 /**\brief Function that converts from a row-major representation of a 6x6
  * covariance matrix to a nested array representation.
  * \param row_major A row-major array of 36 covariance values.
- * \param nested_array A nested array representation of 6x6 covariance values.
+ * \return A nested array representation of 6x6 covariance values.
  */
 inline
-std::array<std::array<double, 6>, 6> convertCovariance(const std::array<double, 36> & row_major)
+std::array<std::array<double, 6>, 6> covarianceRowMajorToNested(const std::array<double, 36> & row_major)
 {
   std::array<std::array<double, 6>, 6> nested_array = {};
   size_t l1 = 0, l2 = 0;
@@ -173,7 +174,7 @@ std::array<std::array<double, 6>, 6> convertCovariance(const std::array<double, 
 
     l1++;
 
-    if (l1 == 6) {
+    if (l1 == nested_array[0].size()) {
       l1 = 0;
       l2++;
     }
@@ -184,10 +185,10 @@ std::array<std::array<double, 6>, 6> convertCovariance(const std::array<double, 
 /**\brief Function that converts from a nested array representation of a 6x6
  * covariance matrix to a row-major representation.
  * \param nested_array A nested array representation of 6x6 covariance values.
- * \param row_major A row-major array of 36 covariance values.
+ * \return A row-major array of 36 covariance values.
  */
 inline
-std::array<double, 36> convertCovariance(const std::array<std::array<double, 6>, 6> & nested_array)
+std::array<double, 36> covarianceNestedToRowMajor(const std::array<std::array<double, 6>, 6> & nested_array)
 {
   std::array<double, 36> row_major = {};
   size_t counter = 0;

--- a/tf2/include/tf2/convert.h
+++ b/tf2/include/tf2/convert.h
@@ -72,6 +72,13 @@ tf2::TimePoint getTimestamp(const T & t);
 template<class T>
 std::string getFrameId(const T & t);
 
+/**\brief Get the covariance matrix from data
+ * \param[in] t The data input.
+ * \return The covariance matrix associated with the data.
+ */
+template<class T>
+std::array<std::array<double, 6>, 6> getCovarianceMatrix(const T & t);
+
 /**\brief Get the frame_id from data
  *
  * An implementation for Stamped<P> datatypes.
@@ -96,6 +103,19 @@ template<class P>
 std::string getFrameId(const tf2::Stamped<P> & t)
 {
   return t.frame_id_;
+}
+
+/**\brief Get the covariance matrix from data
+ *
+ * An implementation for WithCovarianceStamped<P> datatypes.
+ *
+ * \param[in] c The data input.
+ * \return The covariance matrix associated with the data.
+ */
+template<class P>
+std::array<std::array<double, 6>, 6> getCovarianceMatrix(const tf2::WithCovarianceStamped<P> & t)
+{
+  return t.cov_mat_;
 }
 
 /**\brief Function that converts from one type to a ROS message type. It has to be
@@ -136,6 +156,48 @@ void convert(const A & a1, A & a2)
   if (&a1 != &a2) {
     a2 = a1;
   }
+}
+
+/**\brief Function that converts from a row-major representation of a 6x6
+ * covariance matrix to a nested array representation.
+ * \param row_major A row-major array of 36 covariance values.
+ * \param nested_array A nested array representation of 6x6 covariance values.
+ */
+inline
+std::array<std::array<double, 6>, 6> convertCovariance(const std::array<double, 36> & row_major)
+{
+  std::array<std::array<double, 6>, 6> nested_array = {};
+  size_t l1 = 0, l2 = 0;
+  for (const double & val : row_major) {
+    nested_array[l2][l1] = val;
+
+    l1++;
+
+    if (l1 == 6) {
+      l1 = 0;
+      l2++;
+    }
+  }
+  return nested_array;
+}
+
+/**\brief Function that converts from a nested array representation of a 6x6
+ * covariance matrix to a row-major representation.
+ * \param nested_array A nested array representation of 6x6 covariance values.
+ * \param row_major A row-major array of 36 covariance values.
+ */
+inline
+std::array<double, 36> convertCovariance(const std::array<std::array<double, 6>, 6> & nested_array)
+{
+  std::array<double, 36> row_major = {};
+  size_t counter = 0;
+  for (const auto & arr : nested_array) {
+    for (const double & val : arr) {
+      row_major[counter] = val;
+      counter++;
+    }
+  }
+  return row_major;
 }
 }  // namespace tf2
 

--- a/tf2/include/tf2/transform_datatypes.h
+++ b/tf2/include/tf2/transform_datatypes.h
@@ -88,6 +88,63 @@ bool operator==(const Stamped<T> & a, const Stamped<T> & b)
          static_cast<const T &>(a) == static_cast<const T &>(b);
 }
 
+/** \brief The data type which will be cross compatable with geometry_msgs
+ * This is the tf2 datatype equivalent of a MessageWithCovarianceStamped */
+template<typename T>
+class WithCovarianceStamped : public T
+{
+public:
+  TimePoint stamp_;   ///< The timestamp associated with this data
+  std::string frame_id_;   ///< The frame_id associated this data
+  std::array<std::array<double, 6>, 6> cov_mat_;  ///< The covariance matrix associated with this data
+
+  /** Default constructor */
+  WithCovarianceStamped()
+  : frame_id_("NO_ID_STAMPED_DEFAULT_CONSTRUCTION"),
+    cov_mat_{}
+  {
+  }
+
+  /** Full constructor */
+  WithCovarianceStamped(
+    const T & input,
+    const TimePoint & timestamp,
+    const std::string & frame_id,
+    const std::array<std::array<double, 6>, 6> & covariance_matrix
+  )
+  : stamp_(timestamp),
+    frame_id_(frame_id),
+    cov_mat_(covariance_matrix)
+  {
+  }
+
+  /** Copy constructor */
+  WithCovarianceStamped(const WithCovarianceStamped<T> & w)
+  : T(w)
+  {
+  }
+
+  /** Set the data element */
+  void setData(const T & input) {*static_cast<T *>(this) = input;}
+
+  WithCovarianceStamped & operator=(const WithCovarianceStamped<T> & w)
+  {
+    T::operator=(w);
+    this->stamp_ = w.stamp_;
+    this->frame_id_ = w.frame_id_;
+    this->cov_mat_ = w.cov_mat_;
+    return *this;
+  }
+};
+
+/** \brief Comparison operator for WithCovarianceStamped datatypes */
+template<typename T>
+bool operator==(const WithCovarianceStamped<T> & a, const WithCovarianceStamped<T> & b)
+{
+  return a.frame_id_ == b.frame_id_ && a.stamp_ == b.stamp_ &&
+         a.cov_mat_ == b.cov_mat_ && static_cast<const T &>(a) == static_cast<const T &>(b);
+}
+
 }  // namespace tf2
 
 #endif  // TF2__TRANSFORM_DATATYPES_H_

--- a/tf2/include/tf2/transform_datatypes.h
+++ b/tf2/include/tf2/transform_datatypes.h
@@ -31,6 +31,7 @@
 #ifndef TF2__TRANSFORM_DATATYPES_H_
 #define TF2__TRANSFORM_DATATYPES_H_
 
+#include <array>
 #include <chrono>
 #include <string>
 
@@ -112,7 +113,8 @@ public:
     const std::string & frame_id,
     const std::array<std::array<double, 6>, 6> & covariance_matrix
   )
-  : stamp_(timestamp),
+  : T(input),
+    stamp_(timestamp),
     frame_id_(frame_id),
     cov_mat_(covariance_matrix)
   {
@@ -120,7 +122,10 @@ public:
 
   /** Copy constructor */
   WithCovarianceStamped(const WithCovarianceStamped<T> & w)
-  : T(w)
+  : T(w),
+    stamp_(w.stamp_),
+    frame_id_(w.frame_id_),
+    cov_mat_(w.cov_mat_)
   {
   }
 

--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
@@ -284,7 +284,7 @@ inline
  */
 template <>
 inline
-  std::array<std::array<double, 6>, 6> getCovarianceMatrix(const geometry_msgs::msg::PoseWithCovarianceStamped& t)  {return convertCovariance(t.pose.covariance);}
+  std::array<std::array<double, 6>, 6> getCovarianceMatrix(const geometry_msgs::msg::PoseWithCovarianceStamped& t)  {return covarianceRowMajorToNested(t.pose.covariance);}
 
 /** \brief Apply a geometry_msgs TransformStamped to an geometry_msgs Pose type.
  * This function is a specialization of the doTransform template defined in tf2/convert.h.
@@ -343,7 +343,7 @@ geometry_msgs::msg::PoseWithCovarianceStamped toMsg(const tf2::WithCovarianceSta
   geometry_msgs::msg::PoseWithCovarianceStamped out;
   out.header.stamp = tf2_ros::toMsg(in.stamp_);
   out.header.frame_id = in.frame_id_;
-  out.pose.covariance = convertCovariance(in.cov_mat_);
+  out.pose.covariance = covarianceNestedToRowMajor(in.cov_mat_);
   out.pose.pose.orientation.x = in.getRotation().getX();
   out.pose.pose.orientation.y = in.getRotation().getY();
   out.pose.pose.orientation.z = in.getRotation().getZ();
@@ -365,7 +365,7 @@ void fromMsg(const geometry_msgs::msg::PoseWithCovarianceStamped& in, tf2::WithC
 {
   out.stamp_ = tf2_ros::fromMsg(in.header.stamp);
   out.frame_id_ = in.header.frame_id;
-  out.cov_mat_ = convertCovariance(in.pose.covariance);
+  out.cov_mat_ = covarianceRowMajorToNested(in.pose.covariance);
   tf2::Transform tmp;
   fromMsg(in.pose.pose, tmp);
   out.setData(tmp);

--- a/tf2_geometry_msgs/scripts/test.py
+++ b/tf2_geometry_msgs/scripts/test.py
@@ -5,7 +5,7 @@ import rclpy
 import PyKDL
 import tf2_ros
 import tf2_geometry_msgs
-from geometry_msgs.msg import TransformStamped, PointStamped, Vector3Stamped, PoseStamped, Quaternion
+from geometry_msgs.msg import TransformStamped, PointStamped, Vector3Stamped, PoseStamped, PoseWithCovarianceStamped, Quaternion
 
 class GeometryMsgs(unittest.TestCase):
     def test_transform(self):
@@ -46,6 +46,27 @@ class GeometryMsgs(unittest.TestCase):
         self.assertEqual(out.pose.position.x, 0)
         self.assertEqual(out.pose.position.y, -2)
         self.assertEqual(out.pose.position.z, -3)
+
+        v = PoseWithCovarianceStamped()
+        v.header.stamp = rclpy.time.Time(seconds=2.0).to_msg()
+        v.header.frame_id = 'a'
+        v.pose.covariance = (
+          1.0, 2.0, 3.0, 4.0, 5.0, 6.0,
+          1.0, 2.0, 3.0, 4.0, 5.0, 6.0,
+          1.0, 2.0, 3.0, 4.0, 5.0, 6.0,
+          1.0, 2.0, 3.0, 4.0, 5.0, 6.0,
+          1.0, 2.0, 3.0, 4.0, 5.0, 6.0,
+          1.0, 2.0, 3.0, 4.0, 5.0, 6.0
+        )
+        v.pose.pose.position.x = 1.0
+        v.pose.pose.position.y = 2.0
+        v.pose.pose.position.z = 3.0
+        v.pose.pose.orientation = Quaternion(w=0.0, x=1.0, y=0.0, z=0.0)
+        out = b.transform(v, 'b')
+        self.assertEqual(out.pose.pose.position.x, 0)
+        self.assertEqual(out.pose.pose.position.y, -2)
+        self.assertEqual(out.pose.pose.position.z, -3)
+        self.assertEqual(out.pose.covariance, v.pose.covariance)
 
         # Translation shouldn't affect Vector3
         t = TransformStamped()

--- a/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
+++ b/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
@@ -27,7 +27,7 @@
 
 # author: Wim Meeussen
 
-from geometry_msgs.msg import PoseStamped, Vector3Stamped, PointStamped
+from geometry_msgs.msg import PoseStamped, Vector3Stamped, PointStamped, PoseWithCovarianceStamped
 import PyKDL
 import tf2_ros
 
@@ -92,3 +92,18 @@ def do_transform_pose(pose, transform):
     res.header = transform.header
     return res
 tf2_ros.TransformRegistration().add(PoseStamped, do_transform_pose)
+
+# PoseWithCovarianceStamped
+def do_transform_pose_with_covariance_stamped(pose, transform):
+    f = transform_to_kdl(transform) * PyKDL.Frame(PyKDL.Rotation.Quaternion(pose.pose.pose.orientation.x, pose.pose.pose.orientation.y,
+                                                                          pose.pose.pose.orientation.z, pose.pose.pose.orientation.w),
+                                                PyKDL.Vector(pose.pose.pose.position.x, pose.pose.pose.position.y, pose.pose.pose.position.z))
+    res = PoseWithCovarianceStamped()
+    res.pose.pose.position.x = f.p[0]
+    res.pose.pose.position.y = f.p[1]
+    res.pose.pose.position.z = f.p[2]
+    (res.pose.pose.orientation.x, res.pose.pose.orientation.y, res.pose.pose.orientation.z, res.pose.pose.orientation.w) = f.M.GetQuaternion()
+    res.pose.covariance = pose.pose.covariance
+    res.header = transform.header
+    return res
+tf2_ros.TransformRegistration().add(PoseWithCovarianceStamped, do_transform_pose_with_covariance_stamped)

--- a/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
+++ b/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
@@ -136,6 +136,52 @@ TEST(TfGeometry, Frame)
 }
 
 
+TEST(TfGeometry, FrameWithCovariance)
+{
+  geometry_msgs::msg::PoseWithCovarianceStamped v1;
+  v1.pose.pose.position.x = 1;
+  v1.pose.pose.position.y = 2;
+  v1.pose.pose.position.z = 3;
+  v1.pose.pose.orientation.w = 0;
+  v1.pose.pose.orientation.x = 1;
+  v1.pose.pose.orientation.y = 0;
+  v1.pose.pose.orientation.z = 0;
+  v1.header.stamp = tf2_ros::toMsg(tf2::timeFromSec(2));
+  v1.header.frame_id = "A";
+  v1.pose.covariance = {
+    1.0, 2.0, 3.0, 4.0, 5.0, 6.0,
+    1.0, 2.0, 3.0, 4.0, 5.0, 6.0,
+    1.0, 2.0, 3.0, 4.0, 5.0, 6.0,
+    1.0, 2.0, 3.0, 4.0, 5.0, 6.0,
+    1.0, 2.0, 3.0, 4.0, 5.0, 6.0,
+    1.0, 2.0, 3.0, 4.0, 5.0, 6.0
+  };
+
+  // simple api
+  geometry_msgs::msg::PoseWithCovarianceStamped v_simple = tf_buffer->transform(v1, "B", tf2::durationFromSec(2.0));
+  EXPECT_NEAR(v_simple.pose.pose.position.x, -9, EPS);
+  EXPECT_NEAR(v_simple.pose.pose.position.y, 18, EPS);
+  EXPECT_NEAR(v_simple.pose.pose.position.z, 27, EPS);
+  EXPECT_NEAR(v_simple.pose.pose.orientation.x, 0.0, EPS);
+  EXPECT_NEAR(v_simple.pose.pose.orientation.y, 0.0, EPS);
+  EXPECT_NEAR(v_simple.pose.pose.orientation.z, 0.0, EPS);
+  EXPECT_NEAR(v_simple.pose.pose.orientation.w, 1.0, EPS);
+  EXPECT_EQ(v_simple.pose.covariance, v1.pose.covariance);
+
+
+  // advanced api
+  geometry_msgs::msg::PoseWithCovarianceStamped v_advanced = tf_buffer->transform(v1, "B", tf2::timeFromSec(2.0),
+							      "A", tf2::durationFromSec(3.0));
+  EXPECT_NEAR(v_advanced.pose.pose.position.x, -9, EPS);
+  EXPECT_NEAR(v_advanced.pose.pose.position.y, 18, EPS);
+  EXPECT_NEAR(v_advanced.pose.pose.position.z, 27, EPS);
+  EXPECT_NEAR(v_advanced.pose.pose.orientation.x, 0.0, EPS);
+  EXPECT_NEAR(v_advanced.pose.pose.orientation.y, 0.0, EPS);
+  EXPECT_NEAR(v_advanced.pose.pose.orientation.z, 0.0, EPS);
+  EXPECT_NEAR(v_advanced.pose.pose.orientation.w, 1.0, EPS);
+  EXPECT_EQ(v_advanced.pose.covariance, v1.pose.covariance);
+}
+
 
 TEST(TfGeometry, Vector)
 {


### PR DESCRIPTION
Adds support to `tf2_geometry_msgs` for transforming the `geometry_msgs::msg::PoseWithCovarianceStamped` type. Part of #310. Will add to `tf2_kdl` and `tf2_eigen` if requiested.