### PR TITLE
Add deprecation warnings to lookup_transform to handle the passing of the incorrect Time object.

### DIFF
--- a/tf2_ros_py/test/test_buffer_client.py
+++ b/tf2_ros_py/test/test_buffer_client.py
@@ -39,6 +39,7 @@ from geometry_msgs.msg import TransformStamped
 from tf2_msgs.action import LookupTransform
 from tf2_py import BufferCore, LookupException
 from rclpy.executors import SingleThreadedExecutor
+from rclpy.time import Time
 from tf2_msgs.msg import TF2Error
 
 
@@ -75,13 +76,13 @@ class MockBufferServer():
             if not goal_handle.request.advanced:
                 transform = self.buffer_core.lookup_transform_core(target_frame=goal_handle.request.target_frame,
                                                                    source_frame=goal_handle.request.source_frame,
-                                                                   time=goal_handle.request.source_time)
+                                                                   time=Time.from_msg(goal_handle.request.source_time))
             else:
                 transform = self.buffer_core.lookup_transform_full_core(
                     target_frame=goal_handle.request.target_frame,
+                    target_time=Time.from_msg(goal_handle.request.target_time),
                     source_frame=goal_handle.request.source_frame,
-                    source_time=goal_handle.request.source_time,
-                    target_time=goal_handle.request.target_time,
+                    source_time=Time.from_msg(goal_handle.request.source_time),
                     fixed_frame=goal_handle.request.fixed_frame
                 )
             response.transform = transform
@@ -129,7 +130,7 @@ class TestBufferClient(unittest.TestCase):
             self.node, 'lookup_transform', check_frequency=10.0, timeout_padding=0.0)
 
         result = buffer_client.lookup_transform(
-            'foo', 'bar', rclpy.time.Time().to_msg(), rclpy.duration.Duration(seconds=5.0))
+            'foo', 'bar', rclpy.time.Time(), rclpy.duration.Duration(seconds=5.0))
 
         self.assertEqual(build_transform(
             'foo', 'bar', rclpy.time.Time().to_msg()), result)
@@ -140,7 +141,7 @@ class TestBufferClient(unittest.TestCase):
 
         with self.assertRaises(LookupException) as ex:
             result = buffer_client.lookup_transform(
-                'bar', 'baz', rclpy.time.Time().to_msg(), rclpy.duration.Duration(seconds=5.0))
+                'bar', 'baz', rclpy.time.Time(), rclpy.duration.Duration(seconds=5.0))
 
         self.assertEqual(LookupException, type(ex.exception))
 

--- a/tf2_ros_py/tf2_ros/buffer_client.py
+++ b/tf2_ros_py/tf2_ros/buffer_client.py
@@ -44,9 +44,12 @@ from rclpy.duration import Duration
 from rclpy.time import Time
 from rclpy.clock import Clock
 from time import sleep
+
+import builtin_interfaces.msg
 import tf2_py as tf2
 import tf2_ros
 import threading
+import warnings
 
 from tf2_msgs.action import LookupTransform
 
@@ -99,10 +102,20 @@ class BufferClient(tf2_ros.BufferInterface):
         :param timeout: Time to wait for the target frame to become available.
         :return: The transform between the frames.
         """
+        if isinstance(time, builtin_interfaces.msg.Time):
+            source_time = Time.from_msg(time)
+            warnings.warn(
+                'Passing a builtin_interfaces.msg.Time argument is deprecated, and will be removed in the near future. '
+                'Use rclpy.time.Time instead.')
+        elif isinstance(time, Time):
+            source_time = time
+        else:
+            raise TypeError('Must pass a rclpy.time.Time object.')
+
         goal = LookupTransform.Goal()
         goal.target_frame = target_frame
         goal.source_frame = source_frame
-        goal.source_time = time
+        goal.source_time = source_time.to_msg()
         goal.timeout = timeout.to_msg()
         goal.advanced = False
 


### PR DESCRIPTION
@clalancette 
1. Handle when the incorrect type `builtin_interfaces.msg.Time` is passed to `lookup_transform()`.
2. Convert from `rclpy.time.Time` to `builtin_interfaces.msg.Time` and pass to `goal.source_time`.
3. When ready to deprecate, can just remove type check.


closes #318 

