### PR TITLE
Update rclpy.Rate TODO with url to issue

### DIFF
--- a/tf2_ros_py/tf2_ros/buffer.py
+++ b/tf2_ros_py/tf2_ros/buffer.py
@@ -217,13 +217,13 @@ class Buffer(tf2.BufferCore, tf2_ros.BufferInterface):
         clock = rclpy.clock.Clock()
         if timeout != Duration():
             start_time = clock.now()
-            # TODO(vinnamkim): rclpy.Rate is not ready
-            # See https://github.com/ros2/rclpy/issues/186
-            # r = rospy.Rate(20)
             while (clock.now() < start_time + timeout and
                    not self.can_transform_core(target_frame, source_frame, time)[0] and
                    (clock.now() + Duration(seconds=3.0)) >= start_time): # big jumps in time are likely bag loops, so break for them
-                # r.sleep()
+                # TODO(Anyone): We can't use Rate here because it would never expire
+                # with a single-threaded executor.
+                # See https://github.com/ros2/geometry2/issues/327 for ideas on
+                # how to timeout waiting for transforms that don't block the executor.
                 sleep(0.02)
 
         core_result = self.can_transform_core(target_frame, source_frame, time)

--- a/tf2_ros_py/tf2_ros/buffer.py
+++ b/tf2_ros_py/tf2_ros/buffer.py
@@ -258,13 +258,13 @@ class Buffer(tf2.BufferCore, tf2_ros.BufferInterface):
         clock = rclpy.clock.Clock()
         if timeout != Duration():
             start_time = clock.now()
-            # TODO(vinnamkim): rclpy.Rate is not ready
-            # See https://github.com/ros2/rclpy/issues/186
-            # r = rospy.Rate(20)
+            # TODO(Anyone): We can't use Rate here because it would never expire
+            # with a single-threaded executor.
+            # See https://github.com/ros2/geometry2/issues/327 for ideas on
+            # how to timeout waiting for transforms that don't block the executor.
             while (clock.now() < start_time + timeout and
                    not self.can_transform_full_core(target_frame, target_time, source_frame, source_time, fixed_frame)[0] and
                    (clock.now() + Duration(seconds=3.0)) >= start_time): # big jumps in time are likely bag loops, so break for them
-                # r.sleep()
                 sleep(0.02)
         core_result = self.can_transform_full_core(target_frame, target_time, source_frame, source_time, fixed_frame)
         if return_debug_tuple:

--- a/tf2_ros_py/tf2_ros/buffer.py
+++ b/tf2_ros_py/tf2_ros/buffer.py
@@ -258,13 +258,13 @@ class Buffer(tf2.BufferCore, tf2_ros.BufferInterface):
         clock = rclpy.clock.Clock()
         if timeout != Duration():
             start_time = clock.now()
-            # TODO(Anyone): We can't use Rate here because it would never expire
-            # with a single-threaded executor.
-            # See https://github.com/ros2/geometry2/issues/327 for ideas on
-            # how to timeout waiting for transforms that don't block the executor.
             while (clock.now() < start_time + timeout and
                    not self.can_transform_full_core(target_frame, target_time, source_frame, source_time, fixed_frame)[0] and
                    (clock.now() + Duration(seconds=3.0)) >= start_time): # big jumps in time are likely bag loops, so break for them
+                # TODO(Anyone): We can't use Rate here because it would never expire
+                # with a single-threaded executor.
+                # See https://github.com/ros2/geometry2/issues/327 for ideas on
+                # how to timeout waiting for transforms that don't block the executor.
                 sleep(0.02)
         core_result = self.can_transform_full_core(target_frame, target_time, source_frame, source_time, fixed_frame)
         if return_debug_tuple:

--- a/tf2_ros_py/tf2_ros/buffer_client.py
+++ b/tf2_ros_py/tf2_ros/buffer_client.py
@@ -44,7 +44,6 @@ from rclpy.duration import Duration
 from rclpy.time import Time
 from rclpy.clock import Clock
 from rclpy.timer import Rate
-from time import sleep
 
 import builtin_interfaces.msg
 import tf2_py as tf2

--- a/tf2_ros_py/tf2_ros/buffer_client.py
+++ b/tf2_ros_py/tf2_ros/buffer_client.py
@@ -43,7 +43,7 @@ from rclpy.action.client import ActionClient
 from rclpy.duration import Duration
 from rclpy.time import Time
 from rclpy.clock import Clock
-from rclpy.timer import Rate
+from time import sleep
 
 import builtin_interfaces.msg
 import tf2_py as tf2
@@ -221,7 +221,7 @@ class BufferClient(tf2_ros.BufferInterface):
         send_goal_future = self.action_client.send_goal_async(goal)
         send_goal_future.add_done_callback(unblock)
 
-        def unblock_by_timeout(rate):
+        def unblock_by_timeout():
             nonlocal send_goal_future, goal, event
             clock = Clock()
             start_time = clock.now()
@@ -237,13 +237,11 @@ class BufferClient(tf2_ros.BufferInterface):
 
             event.set()
 
-        rate = self.node.create_rate(self.check_frequency)
-        t = threading.Thread(target=unblock_by_timeout, args=(rate,))
+        t = threading.Thread(target=unblock_by_timeout)
         t.start()
 
         event.wait()
 
-        rate.destroy()
 
         #This shouldn't happen, but could in rare cases where the server hangs
         if not send_goal_future.done():

--- a/tf2_ros_py/tf2_ros/buffer_client.py
+++ b/tf2_ros_py/tf2_ros/buffer_client.py
@@ -231,7 +231,8 @@ class BufferClient(tf2_ros.BufferInterface):
                 if clock.now() > start_time + timeout + timeout_padding:
                     break
                 # TODO(Anyone): We can't use Rate here because it would never expire
-                # with a single-threaded executor.  See #327 for ideas on
+                # with a single-threaded executor.
+                # See https://github.com/ros2/geometry2/issues/327 for ideas on
                 # how to timeout waiting for transforms that don't block the executor.
                 sleep(1.0 / self.check_frequency)
 

--- a/tf2_ros_py/tf2_ros/buffer_client.py
+++ b/tf2_ros_py/tf2_ros/buffer_client.py
@@ -241,6 +241,7 @@ class BufferClient(tf2_ros.BufferInterface):
         t.start()
 
         event.wait()
+
         rate.destroy()
 
         #This shouldn't happen, but could in rare cases where the server hangs

--- a/tf2_ros_py/tf2_ros/buffer_client.py
+++ b/tf2_ros_py/tf2_ros/buffer_client.py
@@ -242,7 +242,6 @@ class BufferClient(tf2_ros.BufferInterface):
 
         event.wait()
 
-
         #This shouldn't happen, but could in rare cases where the server hangs
         if not send_goal_future.done():
             raise tf2.TimeoutException("The LookupTransform goal sent to the BufferServer did not come back in the specified time. Something is likely wrong with the server.")


### PR DESCRIPTION
The `Rate` object was made available via [#443](https://github.com/ros2/rclpy/pull/443).

This PR addresses the following TODO:

https://github.com/surfertas/geometry2/blob/3cc8bbe1a67790b149b09fa7a04495b1262c168a/tf2_ros_py/tf2_ros/buffer_client.py#L233 

Steps taken:
1. Instantiate a `Rate` object in main thread with specified frequency.
2. Pass `Rate` object to thread handling `unblock_by_timeout()` and make a call to `sleep()`.
3. After unblock takes effect, the rate object is destroyed. Without this, a `rclpy.exceptions.ROSInterruptException` is raised as `rclpy.shutdown()`  is called without the threading event having been set.

 