### PR TITLE
Replace '/tf', '/tf_static' with 'tf' and 'tf_static to support node namespace

### DIFF
--- a/tf2_ros/include/tf2_ros/static_transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/static_transform_broadcaster.h
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2008, Willow Garage, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright
  *       notice, this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright
@@ -13,7 +13,7 @@
  *     * Neither the name of the Willow Garage, Inc. nor the names of its
  *       contributors may be used to endorse or promote products derived from
  *       this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -59,7 +59,7 @@ public:
       rclcpp::PublisherOptionsWithAllocator<AllocatorT>())
   {
     publisher_ = rclcpp::create_publisher<tf2_msgs::msg::TFMessage>(
-      node, "/tf_static", qos, options);
+      node, "tf_static", qos, options);
   }
 
   /** \brief Send a TransformStamped message

--- a/tf2_ros/include/tf2_ros/transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/transform_broadcaster.h
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2008, Willow Garage, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright
  *       notice, this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright
@@ -13,7 +13,7 @@
  *     * Neither the name of the Willow Garage, Inc. nor the names of its
  *       contributors may be used to endorse or promote products derived from
  *       this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -57,7 +57,7 @@ public:
       rclcpp::PublisherOptionsWithAllocator<AllocatorT>())
   {
     publisher_ = rclcpp::create_publisher<tf2_msgs::msg::TFMessage>(
-      node, "/tf", qos, options);
+      node, "tf", qos, options);
   }
 
   /** \brief Send a StampedTransform

--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -87,13 +87,13 @@ private:
 
     message_subscription_tf_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
       node,
-      "/tf",
+      "tf",
       qos,
       std::move(cb),
       options);
     message_subscription_tf_static_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
       node,
-      "/tf_static",
+      "tf_static",
       static_qos,
       std::move(static_cb),
       options);

--- a/tf2_ros_py/tf2_ros/static_transform_broadcaster.py
+++ b/tf2_ros_py/tf2_ros/static_transform_broadcaster.py
@@ -43,7 +43,7 @@ from geometry_msgs.msg import TransformStamped
 
 class StaticTransformBroadcaster:
     """
-    :class:`StaticTransformBroadcaster` is a convenient way to send static transformation on the ``"/tf_static"`` message topic.
+    :class:`StaticTransformBroadcaster` is a convenient way to send static transformation on the ``"tf_static"`` message topic.
     """
 
     def __init__(self, node: Node, qos: Optional[Union[QoSProfile, int]] = None) -> None:
@@ -59,7 +59,7 @@ class StaticTransformBroadcaster:
                 durability=DurabilityPolicy.TRANSIENT_LOCAL,
                 history=HistoryPolicy.KEEP_LAST,
                 )
-        self.pub_tf = node.create_publisher(TFMessage, "/tf_static", qos)
+        self.pub_tf = node.create_publisher(TFMessage, "tf_static", qos)
 
     def sendTransform(self, transform: Union[TransformStamped, List[TransformStamped]]) -> None:
         if not isinstance(transform, list):

--- a/tf2_ros_py/tf2_ros/transform_broadcaster.py
+++ b/tf2_ros_py/tf2_ros/transform_broadcaster.py
@@ -41,7 +41,7 @@ from geometry_msgs.msg import TransformStamped
 
 class TransformBroadcaster:
     """
-    :class:`TransformBroadcaster` is a convenient way to send transformation updates on the ``"/tf"`` message topic.
+    :class:`TransformBroadcaster` is a convenient way to send transformation updates on the ``"tf"`` message topic.
     """
     def __init__(
         self,
@@ -58,7 +58,7 @@ class TransformBroadcaster:
         """
         if qos is None:
             qos = QoSProfile(depth=100)
-        self.pub_tf = node.create_publisher(TFMessage, "/tf", qos)
+        self.pub_tf = node.create_publisher(TFMessage, "tf", qos)
 
     def sendTransform(
         self,


### PR DESCRIPTION
Hi all,

Since several month ago, I'm researching multi-robot scenario based on ROS2 using node namespace to separate the group of topics for each robot. (Not ROS_DOMAIN_ID)

And I could easily separate by the namespace on other ROS2 nodes but '/tf' and '/tf_static'.
It always needs topic remapping like /tf:=tf  and /tf_static:=tf.

So, here is the idea and code suggestion.
Why don't we just use relative topic name for those??

I don't see the reason that we should use an absolute path for.

Could any guys let me know the history? if not I'd like suggest to change a absolute path to relative path for 'TF' :)


PLUS, navigation2 package also remap the tf and tf_static in multi robot launch script as you can [see here](https://github.com/ros-planning/navigation2/blob/main/nav2_bringup/bringup/launch/tb3_simulation_launch.py).


Signed-off-by: Hyunseok Yang <hyunseok7.yang@lge.com>