### PR TITLE
[Foxy backport] Fixed memory leak in Buffer::waitForTransform (#281)

### DIFF
--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -1491,6 +1491,7 @@ void BufferCore::testTransformableRequests()
         {
           const TransformableCallback& cb = it->second;
           cb(req.request_handle, lookupFrameString(req.target_id), lookupFrameString(req.source_id), req.time, result);
+          transformable_callbacks_.erase(req.cb_handle);
         }
       }
 

--- a/tf2_ros/include/tf2_ros/buffer.h
+++ b/tf2_ros/include/tf2_ros/buffer.h
@@ -69,7 +69,6 @@ namespace tf2_ros
      * @return 
      */
     TF2_ROS_PUBLIC Buffer(rclcpp::Clock::SharedPtr clock, tf2::Duration cache_time = tf2::Duration(tf2::BUFFER_CORE_DEFAULT_CACHE_TIME));
-    TF2_ROS_PUBLIC ~Buffer();
 
     /** \brief Get the transform between two frames by frame ID.
      * \param target_frame The frame to which data should be transformed

--- a/tf2_ros/include/tf2_ros/buffer.h
+++ b/tf2_ros/include/tf2_ros/buffer.h
@@ -262,6 +262,7 @@ namespace tf2_ros
 
     /// \brief A map from active timers to BufferCore request handles
     std::unordered_map<TimerHandle, tf2::TransformableRequestHandle> timer_to_request_map_;
+    std::unordered_map<TimerHandle, tf2::TransformableCallbackHandle> timer_to_callback_map_;
 
     /// \brief A mutex on the timer_to_request_map_ data
     std::mutex timer_to_request_map_mutex_;

--- a/tf2_ros/include/tf2_ros/buffer.h
+++ b/tf2_ros/include/tf2_ros/buffer.h
@@ -69,6 +69,7 @@ namespace tf2_ros
      * @return 
      */
     TF2_ROS_PUBLIC Buffer(rclcpp::Clock::SharedPtr clock, tf2::Duration cache_time = tf2::Duration(tf2::BUFFER_CORE_DEFAULT_CACHE_TIME));
+    TF2_ROS_PUBLIC ~Buffer();
 
     /** \brief Get the transform between two frames by frame ID.
      * \param target_frame The frame to which data should be transformed
@@ -262,7 +263,6 @@ namespace tf2_ros
 
     /// \brief A map from active timers to BufferCore request handles
     std::unordered_map<TimerHandle, tf2::TransformableRequestHandle> timer_to_request_map_;
-    std::unordered_map<TimerHandle, tf2::TransformableCallbackHandle> timer_to_callback_map_;
 
     /// \brief A mutex on the timer_to_request_map_ data
     std::mutex timer_to_request_map_mutex_;

--- a/tf2_ros/src/buffer.cpp
+++ b/tf2_ros/src/buffer.cpp
@@ -240,7 +240,7 @@ Buffer::waitForTransform(const std::string& target_frame, const std::string& sou
             this->timer_to_request_map_.erase(timer_handle);
             {
               std::lock_guard<std::mutex> lock(g_object_map_to_cb_handle_mutex);
-              // Remove the  callback function.
+              // Remove the callback function.
               deleteTransformCallbackHandle(this, timer_handle);
             }
             timeout_occurred = false;
@@ -311,7 +311,7 @@ Buffer::timerCallback(const TimerHandle & timer_handle,
       std::lock_guard<std::mutex> lock(g_object_map_to_cb_handle_mutex);
       if (g_object_map_to_cb_handle.find(this) != g_object_map_to_cb_handle.end())
       {
-        // Only if the map to callback handle isn't alreade removed.
+        // Only if the map to callback handle isn't already removed.
         auto timer_and_callback_it = g_object_map_to_cb_handle.at(this).find(timer_handle);
         timer_is_valid = (g_object_map_to_cb_handle.at(this).end() != timer_and_callback_it);
 


### PR DESCRIPTION
* Make BufferCore callback handle maintenance internal.

That is, there is really no reason for external users to know
about TranformableCallbackHandle at all.  Instead, hide all of
the implementation detail about the handles within BufferCore
itself.  This gets simplifies the API, and allows us to ensure
that cleanup happens properly.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Co-authored-by: Chris Lalancette <clalancette@openrobotics.org>