### PR TITLE
Make sure to add a test_depend on ament_cmake_gtest.

### DIFF
--- a/tf2_eigen_kdl/package.xml
+++ b/tf2_eigen_kdl/package.xml
@@ -25,6 +25,7 @@
   <depend>orocos_kdl</depend>
   <depend>tf2</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix the failing builds in http://build.ros2.org/view/Rci/job/Rci__nightly-connext_ubuntu_focal_amd64/114 (and elsewhere).