### PR TITLE
Remove usage of deprecated rclcpp::Duration constructor

### DIFF
--- a/tf2_ros/include/tf2_ros/buffer.h
+++ b/tf2_ros/include/tf2_ros/buffer.h
@@ -98,7 +98,8 @@ public:
   geometry_msgs::msg::TransformStamped
   lookupTransform(
     const std::string & target_frame, const std::string & source_frame,
-    const rclcpp::Time & time, const rclcpp::Duration timeout = rclcpp::Duration(0)) const
+    const rclcpp::Time & time,
+    const rclcpp::Duration timeout = rclcpp::Duration::from_nanoseconds(0)) const
   {
     return lookupTransform(target_frame, source_frame, fromRclcpp(time), fromRclcpp(timeout));
   }
@@ -132,7 +133,8 @@ public:
   lookupTransform(
     const std::string & target_frame, const rclcpp::Time & target_time,
     const std::string & source_frame, const rclcpp::Time & source_time,
-    const std::string & fixed_frame, const rclcpp::Duration timeout = rclcpp::Duration(0)) const
+    const std::string & fixed_frame,
+    const rclcpp::Duration timeout = rclcpp::Duration::from_nanoseconds(0)) const
   {
     return lookupTransform(
       target_frame, fromRclcpp(target_time),
@@ -163,7 +165,8 @@ public:
   bool
   canTransform(
     const std::string & target_frame, const std::string & source_frame,
-    const rclcpp::Time & time, const rclcpp::Duration timeout = rclcpp::Duration(0),
+    const rclcpp::Time & time,
+    const rclcpp::Duration timeout = rclcpp::Duration::from_nanoseconds(0),
     std::string * errstr = NULL) const
   {
     return canTransform(target_frame, source_frame, fromRclcpp(time), fromRclcpp(timeout), errstr);
@@ -198,7 +201,8 @@ public:
   canTransform(
     const std::string & target_frame, const rclcpp::Time & target_time,
     const std::string & source_frame, const rclcpp::Time & source_time,
-    const std::string & fixed_frame, const rclcpp::Duration timeout = rclcpp::Duration(0),
+    const std::string & fixed_frame,
+    const rclcpp::Duration timeout = rclcpp::Duration::from_nanoseconds(0),
     std::string * errstr = NULL) const
   {
     return canTransform(

--- a/tf2_ros/src/buffer.cpp
+++ b/tf2_ros/src/buffer.cpp
@@ -90,7 +90,7 @@ inline
 rclcpp::Duration
 to_rclcpp(const tf2::Duration & duration)
 {
-  return rclcpp::Duration(std::chrono::nanoseconds(duration).count());
+  return rclcpp::Duration(std::chrono::nanoseconds(duration));
 }
 
 geometry_msgs::msg::TransformStamped


### PR DESCRIPTION
See https://github.com/ros2/rclcpp/pull/1432.