### PR TITLE
Clarify the role of child_frame_id and header.frame_id in the documentation.

### DIFF
--- a/tf2_ros/include/tf2_ros/transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/transform_broadcaster.h
@@ -67,12 +67,25 @@ public:
   }
 
   /** \brief Send a TransformStamped message
-   * The stamped data structure includes frame_id, and time, and parent_id already.  */
+   *
+   * The transform \f$^hT_c\f$ added is from `child_frame_id` \f$c\f$ to
+   * `header.frame_id` \f$h\f$. That is, position in `child_frame_id`
+   * \f$^c\mathbf{p} \in \mathbb{R}^3\f$ can be transformed to position in
+   * `header.frame_id` \f$^h\mathbf{p} \in \mathbb{R}^3 \f$ such that
+   * \f$^h\mathbf{p} = ^hT_c {}^c\mathbf{p}\f$.
+   *
+   */
   TF2_ROS_PUBLIC
   void sendTransform(const geometry_msgs::msg::TransformStamped & transform);
 
   /** \brief Send a vector of TransformStamped messages
-   * The stamped data structure includes frame_id, and time, and parent_id already.  */
+   *
+   * The transforms \f$^hT_c\f$ added are from `child_frame_id` \f$c\f$ to
+   * `header.frame_id` \f$h\f$. That is, position in `child_frame_id`
+   * \f$^c\mathbf{p} \in \mathbb{R}^3\f$ can be transformed to position in
+   * `header.frame_id` \f$^h\mathbf{p} \in \mathbb{R}^3 \f$ such that
+   * \f$^h\mathbf{p} = ^hT_c {}^c\mathbf{p}\f$.
+   */
   TF2_ROS_PUBLIC
   void sendTransform(const std::vector<geometry_msgs::msg::TransformStamped> & transforms);
 

--- a/tf2_ros/include/tf2_ros/transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/transform_broadcaster.h
@@ -68,11 +68,9 @@ public:
 
   /** \brief Send a TransformStamped message
    *
-   * The transform \f$^hT_c\f$ added is from `child_frame_id` \f$c\f$ to
-   * `header.frame_id` \f$h\f$. That is, position in `child_frame_id`
-   * \f$^c\mathbf{p} \in \mathbb{R}^3\f$ can be transformed to position in
-   * `header.frame_id` \f$^h\mathbf{p} \in \mathbb{R}^3 \f$ such that
-   * \f$^h\mathbf{p} = ^hT_c {}^c\mathbf{p}\f$.
+   * The transform ʰTₐ added is from `child_frame_id`, `a` to `header.frame_id`,
+   * `h`. That is, position in `child_frame_id` ᵃp can be transformed to
+   * position in `header.frame_id` ʰp such that ʰp = ʰTₐ ᵃp .
    *
    */
   TF2_ROS_PUBLIC
@@ -80,11 +78,9 @@ public:
 
   /** \brief Send a vector of TransformStamped messages
    *
-   * The transforms \f$^hT_c\f$ added are from `child_frame_id` \f$c\f$ to
-   * `header.frame_id` \f$h\f$. That is, position in `child_frame_id`
-   * \f$^c\mathbf{p} \in \mathbb{R}^3\f$ can be transformed to position in
-   * `header.frame_id` \f$^h\mathbf{p} \in \mathbb{R}^3 \f$ such that
-   * \f$^h\mathbf{p} = ^hT_c {}^c\mathbf{p}\f$.
+   * The transforms ʰTₐ added are from `child_frame_id`, `a` to `header.frame_id`,
+   * `h`. That is, position in `child_frame_id` ᵃp can be transformed to
+   * position in `header.frame_id` ʰp such that ʰp = ʰTₐ ᵃp .
    */
   TF2_ROS_PUBLIC
   void sendTransform(const std::vector<geometry_msgs::msg::TransformStamped> & transforms);


### PR DESCRIPTION
I think the description in `geometry_msgs/TransformStamped` is wrong with respect to the behaviour of sendTransform.

> This expresses a transform from coordinate frame header.frame_id to the coordinate frame child_frame_id

Source: http://docs.ros.org/en/api/geometry_msgs/html/msg/TransformStamped.html

However, `Broadcaster::sendTransform` adds a transform from `child_frame_id` to `header.frame_id`. 

What does a transform from `child_frame_id` to `header.frame_id` mean? It is better to be concrete than to be vague. Hence, the symbols included in the documentation. One can also refer to the tf/Overview wiki http://wiki.ros.org/tf/Overview/Transformations