### PR TITLE
[eloquent] Add missing visibility header include (#246)

### DIFF
--- a/tf2_ros/include/tf2_ros/buffer_server.h
+++ b/tf2_ros/include/tf2_ros/buffer_server.h
@@ -46,6 +46,7 @@
 #include <tf2_msgs/action/lookup_transform.hpp>
 
 #include <tf2/buffer_core_interface.h>
+#include <tf2_ros/visibility_control.h>
 
 namespace tf2_ros
 {


### PR DESCRIPTION
Backport #246 to Eloquent.