### PR TITLE
Allow to reconfigure durability for /tf topic broadcaster/listener

### DIFF
--- a/tf2_ros/include/tf2_ros/transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/transform_broadcaster.h
@@ -63,6 +63,7 @@ public:
       rclcpp::PublisherOptionsWithAllocator<AllocatorT> options;
       options.qos_overriding_options = rclcpp::QosOverridingOptions{
         rclcpp::QosPolicyKind::Depth,
+        rclcpp::QosPolicyKind::Durability,
         rclcpp::QosPolicyKind::History,
         rclcpp::QosPolicyKind::Reliability};
       return options;

--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -76,7 +76,7 @@ get_default_transform_listener_static_sub_options()
     rclcpp::QosPolicyKind::Reliability};
   return options;
 }
-}  //namespace detail
+}  // namespace detail
 
 /** \brief This class provides an easy way to request and receive coordinate frame transform information.
  */

--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -88,6 +88,15 @@ private:
       rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> options;
       options.qos_overriding_options = rclcpp::QosOverridingOptions{
         rclcpp::QosPolicyKind::Depth,
+        rclcpp::QosPolicyKind::Durability,
+        rclcpp::QosPolicyKind::History,
+        rclcpp::QosPolicyKind::Reliability};
+      return options;
+    } (),
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options = []() {
+      rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> options;
+      options.qos_overriding_options = rclcpp::QosOverridingOptions{
+        rclcpp::QosPolicyKind::Depth,
         rclcpp::QosPolicyKind::History,
         rclcpp::QosPolicyKind::Reliability};
       return options;
@@ -112,7 +121,7 @@ private:
       "/tf_static",
       static_qos,
       std::move(static_cb),
-      options);
+      static_options);
 
     if (spin_thread) {
       initThread(node->get_node_base_interface());

--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -50,6 +50,34 @@
 namespace tf2_ros
 {
 
+namespace detail
+{
+template<class AllocatorT>
+rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>
+get_default_transform_listener_sub_options()
+{
+  rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> options;
+  options.qos_overriding_options = rclcpp::QosOverridingOptions{
+    rclcpp::QosPolicyKind::Depth,
+    rclcpp::QosPolicyKind::Durability,
+    rclcpp::QosPolicyKind::History,
+    rclcpp::QosPolicyKind::Reliability};
+  return options;
+}
+
+template<class AllocatorT>
+rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>
+get_default_transform_listener_static_sub_options()
+{
+  rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> options;
+  options.qos_overriding_options = rclcpp::QosOverridingOptions{
+    rclcpp::QosPolicyKind::Depth,
+    rclcpp::QosPolicyKind::History,
+    rclcpp::QosPolicyKind::Reliability};
+  return options;
+}
+}  //namespace detail
+
 /** \brief This class provides an easy way to request and receive coordinate frame transform information.
  */
 class TransformListener
@@ -67,10 +95,12 @@ public:
     const rclcpp::QoS & qos = DynamicListenerQoS(),
     const rclcpp::QoS & static_qos = StaticListenerQoS(),
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options =
-    rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>())
+    detail::get_default_transform_listener_sub_options<AllocatorT>(),
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options =
+    detail::get_default_transform_listener_static_sub_options<AllocatorT>())
   : buffer_(buffer)
   {
-    init(node, spin_thread, qos, static_qos, options);
+    init(node, spin_thread, qos, static_qos, options, static_options);
     node_logging_interface_ = node->get_node_logging_interface();
   }
 
@@ -84,23 +114,10 @@ private:
     bool spin_thread,
     const rclcpp::QoS & qos,
     const rclcpp::QoS & static_qos,
-    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options = []() {
-      rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> options;
-      options.qos_overriding_options = rclcpp::QosOverridingOptions{
-        rclcpp::QosPolicyKind::Depth,
-        rclcpp::QosPolicyKind::Durability,
-        rclcpp::QosPolicyKind::History,
-        rclcpp::QosPolicyKind::Reliability};
-      return options;
-    } (),
-    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options = []() {
-      rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> options;
-      options.qos_overriding_options = rclcpp::QosOverridingOptions{
-        rclcpp::QosPolicyKind::Depth,
-        rclcpp::QosPolicyKind::History,
-        rclcpp::QosPolicyKind::Reliability};
-      return options;
-    } ())
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options =
+    detail::get_default_transform_listener_sub_options<AllocatorT>(),
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options =
+    detail::get_default_transform_listener_static_sub_options<AllocatorT>())
   {
     node_logging_interface_ = node->get_node_logging_interface();
 

--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -52,7 +52,7 @@ namespace tf2_ros
 
 namespace detail
 {
-template<class AllocatorT>
+template<class AllocatorT = std::allocator<void>>
 rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>
 get_default_transform_listener_sub_options()
 {
@@ -65,7 +65,7 @@ get_default_transform_listener_sub_options()
   return options;
 }
 
-template<class AllocatorT>
+template<class AllocatorT = std::allocator<void>>
 rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>
 get_default_transform_listener_static_sub_options()
 {
@@ -114,10 +114,8 @@ private:
     bool spin_thread,
     const rclcpp::QoS & qos,
     const rclcpp::QoS & static_qos,
-    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options =
-    detail::get_default_transform_listener_sub_options<AllocatorT>(),
-    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options =
-    detail::get_default_transform_listener_static_sub_options<AllocatorT>())
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options)
   {
     node_logging_interface_ = node->get_node_logging_interface();
 

--- a/tf2_ros/src/transform_listener.cpp
+++ b/tf2_ros/src/transform_listener.cpp
@@ -52,7 +52,10 @@ TransformListener::TransformListener(tf2::BufferCore & buffer, bool spin_thread)
   options.start_parameter_event_publisher(false);
   options.start_parameter_services(false);
   optional_default_node_ = rclcpp::Node::make_shared("_", options);
-  init(optional_default_node_, spin_thread, DynamicListenerQoS(), StaticListenerQoS());
+  init(
+    optional_default_node_, spin_thread, DynamicListenerQoS(), StaticListenerQoS(),
+    detail::get_default_transform_listener_sub_options(),
+    detail::get_default_transform_listener_static_sub_options());
 }
 
 TransformListener::~TransformListener()


### PR DESCRIPTION
Follow up of https://github.com/ros2/geometry2/pull/381.

Allows reconfiguring the durability qos setting for /tf broadcaster/listener.
This wasn't applied to /tf_static, as in that case durability must always be transient local.