### PR TITLE
fix accessing freed resources

### DIFF
--- a/tf2_ros/include/tf2_ros/message_filter.h
+++ b/tf2_ros/include/tf2_ros/message_filter.h
@@ -482,16 +482,16 @@ private:
   {
     namespace mt = message_filters::message_traits;
 
-    // find the message this request is associated with
-    typename L_MessageInfo::iterator msg_it = messages_.begin();
-    typename L_MessageInfo::iterator msg_end = messages_.end();
-
     MEvent saved_event;
     bool event_found = false;
 
     {
       // We will be accessing and mutating messages now, require unique lock
       std::unique_lock<std::mutex> lock(messages_mutex_);
+
+      // find the message this request is associated with
+      typename L_MessageInfo::iterator msg_it = messages_.begin();
+      typename L_MessageInfo::iterator msg_end = messages_.end();
 
       for (; msg_it != msg_end; ++msg_it) {
         MessageInfo & info = *msg_it;


### PR DESCRIPTION
`messages_` may be accessed before take the lock.
This leads to memory corruption and a crashing slam_toolbox.

Related: #279

```
#0  tf2_ros::MessageFilter<sensor_msgs::msg::LaserScan_<std::allocator<void> >, tf2_ros::Buffer>::transformReadyCallback (this=0x555589d120, future=..., handle=2109) at /opt/ros/rolling/include/tf2_ros/message_filter.h:498
#1  0x0000007fb721d0a8 in ?? () from /opt/ros/rolling/lib/libtf2_ros.so
#2  0x0000007fb6f313f4 in tf2::BufferCore::testTransformableRequests() () from /opt/ros/rolling/lib/libtf2.so
#3  0x0000007fb6f323d4 in tf2::BufferCore::setTransformImpl(tf2::Transform const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) ()
   from /opt/ros/rolling/lib/libtf2.so
#4  0x0000007fb6f33354 in tf2::BufferCore::setTransform(geometry_msgs::msg::TransformStamped_<std::allocator<void> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) ()
   from /opt/ros/rolling/lib/libtf2.so
#5  0x0000007fb7228df8 in tf2_ros::TransformListener::subscription_callback(std::shared_ptr<tf2_msgs::msg::TFMessage_<std::allocator<void> > >, bool) () from /opt/ros/rolling/lib/libtf2_ros.so
#6  0x0000007fb72302c0 in std::_Function_handler<void (std::shared_ptr<tf2_msgs::msg::TFMessage_<std::allocator<void> > >), std::_Bind<void (tf2_ros::TransformListener::*(tf2_ros::TransformListener*, std::_Placeholder<1>, bool))(std::shared_ptr<tf2_msgs::msg::TFMessage_<std::allocator<void> > >, bool)> >::_M_invoke(std::_Any_data const&, std::shared_ptr<tf2_msgs::msg::TFMessage_<std::allocator<void> > >&&) () from /opt/ros/rolling/lib/libtf2_ros.so
#7  0x0000007fb72414c0 in rclcpp::AnySubscriptionCallback<tf2_msgs::msg::TFMessage_<std::allocator<void> >, std::allocator<void> >::dispatch(std::shared_ptr<tf2_msgs::msg::TFMessage_<std::allocator<void> > >, rclcpp::MessageInfo const&) () from /opt/ros/rolling/lib/libtf2_ros.so
#8  0x0000007fb7241da4 in rclcpp::Subscription<tf2_msgs::msg::TFMessage_<std::allocator<void> >, std::allocator<void>, rclcpp::message_memory_strategy::MessageMemoryStrategy<tf2_msgs::msg::TFMessage_<std::allocator<void> >, std::allocator<void> > >::handle_message(std::shared_ptr<void>&, rclcpp::MessageInfo const&) ()
   from /opt/ros/rolling/lib/libtf2_ros.so
#9  0x0000007fb79a76bc in ?? () from /opt/ros/rolling/lib/librclcpp.so
#10 0x0000007fb79a82a8 in rclcpp::Executor::execute_subscription(std::shared_ptr<rclcpp::SubscriptionBase>) ()
   from /opt/ros/rolling/lib/librclcpp.so
#11 0x0000007fb79a8ad4 in rclcpp::Executor::execute_any_executable(rclcpp::AnyExecutable&) ()
   from /opt/ros/rolling/lib/librclcpp.so
#12 0x0000007fb79b1f34 in rclcpp::executors::SingleThreadedExecutor::spin() ()
#13 0x0000007fb722843c in ?? () from /opt/ros/rolling/lib/libtf2_ros.so
#14 0x0000007fb772dc2c in ?? () from /lib/aarch64-linux-gnu/libstdc++.so.6
#15 0x0000007fb73d04fc in start_thread (arg=0x7fffffb98f) at pthread_create.c:477
#16 0x0000007fb759d67c in thread_start () at ../sysdeps/unix/sysv/linux/aarch64/clone.S:78
```
https://answers.ros.org/question/373199/segmentation-fault-on-tf2_ros/