### PR TITLE
Use global namespace for TransformListener topics

### DIFF
--- a/tf2_ros_py/tf2_ros/transform_listener.py
+++ b/tf2_ros_py/tf2_ros/transform_listener.py
@@ -83,9 +83,9 @@ class TransformListener:
         # from another callback in the same group.
         self.group = ReentrantCallbackGroup()
         self.tf_sub = node.create_subscription(
-            TFMessage, 'tf', self.callback, qos, callback_group=self.group)
+            TFMessage, '/tf', self.callback, qos, callback_group=self.group)
         self.tf_static_sub = node.create_subscription(
-            TFMessage, 'tf_static', self.static_callback, static_qos, callback_group=self.group)
+            TFMessage, '/tf_static', self.static_callback, static_qos, callback_group=self.group)
 
         if spin_thread:
             self.executor = SingleThreadedExecutor()


### PR DESCRIPTION
Adding a forward slash to the topic names ensures that when the associated node is namespaced, the topics are not.
This is the same behavior as the C++ counterpart and the ROS 1 implementation.

Fixes #389