### PR TITLE
Guard against access to null node pointer

### DIFF
--- a/tf2_ros/include/tf2_ros/buffer.h
+++ b/tf2_ros/include/tf2_ros/buffer.h
@@ -275,6 +275,9 @@ private:
   // conditionally error if dedicated_thread unset.
   bool checkAndErrorDedicatedThreadPresent(std::string * errstr) const;
 
+  /// Get the logger to use for calls to RCLCPP log macros.
+  rclcpp::Logger getLogger() const;
+
   // framegraph service
   rclcpp::Service<tf2_msgs::srv::FrameGraph>::SharedPtr frames_server_;
 

--- a/tf2_ros/src/buffer.cpp
+++ b/tf2_ros/src/buffer.cpp
@@ -100,10 +100,10 @@ void Buffer::onTimeJump(const rcl_time_jump_t & jump)
   if (RCL_ROS_TIME_ACTIVATED == jump.clock_change ||
     RCL_ROS_TIME_DEACTIVATED == jump.clock_change)
   {
-    RCLCPP_WARN(node_->get_logger(), "Detected time source change. Clearing TF buffer.");
+    RCLCPP_WARN(getLogger(), "Detected time source change. Clearing TF buffer.");
     clear();
   } else if (jump.delta.nanoseconds < 0) {
-    RCLCPP_WARN(node_->get_logger(), "Detected jump back in time. Clearing TF buffer.");
+    RCLCPP_WARN(getLogger(), "Detected jump back in time. Clearing TF buffer.");
     clear();
   }
 }
@@ -314,9 +314,13 @@ bool Buffer::checkAndErrorDedicatedThreadPresent(std::string * error_str) const
     *error_str = tf2_ros::threading_error;
   }
 
-  rclcpp::Logger logger = node_ ? node_->get_logger() : rclcpp::get_logger("tf2_buffer");
-  RCLCPP_ERROR(logger, "%s", tf2_ros::threading_error);
+  RCLCPP_ERROR(getLogger(), "%s", tf2_ros::threading_error);
   return false;
+}
+
+rclcpp::Logger Buffer::getLogger() const
+{
+  return node_ ? node_->get_logger() : rclcpp::get_logger("tf2_buffer");
 }
 
 }  // namespace tf2_ros


### PR DESCRIPTION
Ensure that whenever we are getting a logger, we are not accessing a nullptr.

Fixes https://github.com/ros2/rviz/issues/665