### PR TITLE
Dima/covar speedup

### DIFF
--- a/tf2/include/tf2/convert.h
+++ b/tf2/include/tf2/convert.h
@@ -31,6 +31,7 @@
 #ifndef TF2__CONVERT_H_
 #define TF2__CONVERT_H_
 
+#include <algorithm>
 #include <array>
 #include <string>
 
@@ -167,17 +168,11 @@ void convert(const A & a1, A & a2)
 inline
 std::array<std::array<double, 6>, 6> covarianceRowMajorToNested(const std::array<double, 36> & row_major)
 {
-  std::array<std::array<double, 6>, 6> nested_array = {};
-  size_t l1 = 0, l2 = 0;
-  for (const double & val : row_major) {
-    nested_array[l2][l1] = val;
-
-    l1++;
-
-    if (l1 == nested_array[0].size()) {
-      l1 = 0;
-      l2++;
-    }
+  std::array<std::array<double, 6>, 6> nested_array;
+  auto ss = row_major.begin();
+  for (auto& dd : nested_array) {
+    std::copy_n(ss, dd.size(), dd.begin());
+    ss += dd.size();
   }
   return nested_array;
 }

--- a/tf2/include/tf2/convert.h
+++ b/tf2/include/tf2/convert.h
@@ -169,8 +169,8 @@ inline
 std::array<std::array<double, 6>, 6> covarianceRowMajorToNested(const std::array<double, 36> & row_major)
 {
   std::array<std::array<double, 6>, 6> nested_array;
-  auto ss = row_major.begin();
-  for (auto& dd : nested_array) {
+  std::array<double, 36>::const_iterator ss = row_major.begin();
+  for (std::array<double, 6> & dd : nested_array) {
     std::copy_n(ss, dd.size(), dd.begin());
     ss += dd.size();
   }

--- a/tf2/test/simple_tf2_core.cpp
+++ b/tf2/test/simple_tf2_core.cpp
@@ -28,11 +28,14 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <chrono>
+#include <numeric>
 #include <string>
 #include <vector>
 
 #include "tf2/buffer_core.h"
+#include "tf2/convert.h"
 #include "tf2/LinearMath/Vector3.h"
 #include "tf2/exceptions.h"
 #include "tf2/time.h"
@@ -267,6 +270,30 @@ TEST(tf2_time, To_From_Duration)
 
     EXPECT_TRUE(error_duration < tf2::Duration(std::chrono::nanoseconds(tol_ns)));
   }
+}
+
+TEST(tf2_convert, Covariance_RowMajor_To_Nested)
+{
+  // test verifies the correct conversion of the flat covariance array to a
+  // nested covariance array.
+  // create a dummy input with some values
+  std::array<double, 36> input;
+  std::iota(input.begin(), input.end(), 0);
+
+  // setup the expected output
+  std::array<std::array<double, 6>, 6> expected;
+  double start = 0;
+  for (auto &ee : expected)
+  {
+    std::iota(ee.begin(), ee.end(), start);
+    start += static_cast<double>(ee.size());
+  }
+
+  // call the tested method
+  const auto result = tf2::covarianceRowMajorToNested(input);
+
+  // check the result
+  ASSERT_EQ(expected, result);
 }
 
 int main(int argc, char ** argv)

--- a/tf2/test/simple_tf2_core.cpp
+++ b/tf2/test/simple_tf2_core.cpp
@@ -283,14 +283,14 @@ TEST(tf2_convert, Covariance_RowMajor_To_Nested)
   // setup the expected output
   std::array<std::array<double, 6>, 6> expected;
   double start = 0;
-  for (auto &ee : expected)
+  for (std::array<double, 6> & ee : expected)
   {
     std::iota(ee.begin(), ee.end(), start);
     start += static_cast<double>(ee.size());
   }
 
   // call the tested method
-  const auto result = tf2::covarianceRowMajorToNested(input);
+  const std::array<std::array<double, 6>, 6> result = tf2::covarianceRowMajorToNested(input);
 
   // check the result
   ASSERT_EQ(expected, result);


### PR DESCRIPTION
Hey everyone,
here is a small contribution to speedup the conversion of the flat array into a nested array. The new implementation is brachless and yields under gcc9.3 in a 6 (with O2) to 8 (with O3) times faster computation: 

https://quick-bench.com/q/rShFc-mEK290Dcms2cUx1XcwuMs

Play around with the lib-versions and settings (don't pick clang since clang will remove the operations entirely).

Best, 
Dima