### PR TITLE
Use underscores instead of dashes in setup.cfg.

### DIFF
--- a/examples_tf2_py/setup.cfg
+++ b/examples_tf2_py/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/examples_tf2_py
+script_dir=$base/lib/examples_tf2_py
 [install]
-install-scripts=$base/lib/examples_tf2_py
+install_scripts=$base/lib/examples_tf2_py

--- a/tf2_ros_py/setup.cfg
+++ b/tf2_ros_py/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/tf2_ros_py
+script_dir=$base/lib/tf2_ros_py
 [install]
-install-scripts=$base/lib/tf2_ros_py
+install_scripts=$base/lib/tf2_ros_py

--- a/tf2_tools/setup.cfg
+++ b/tf2_tools/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/tf2_tools
+script_dir=$base/lib/tf2_tools
 [install]
-install-scripts=$base/lib/tf2_tools
+install_scripts=$base/lib/tf2_tools


### PR DESCRIPTION
Newer setuptools warns about this.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>