### PR TITLE
[Foxy backport] Fix tf2_echo does not work with ros-args (#407)

### DIFF
--- a/tf2_ros/src/tf2_echo.cpp
+++ b/tf2_ros/src/tf2_echo.cpp
@@ -31,6 +31,7 @@
 #include <cstdio>
 #include <cstring>
 #include <memory>
+#include <vector>
 
 #include "tf2_ros/transform_listener.h"
 #include "rclcpp/rclcpp.hpp"
@@ -61,11 +62,11 @@ private:
 
 int main(int argc, char ** argv)
 {
-  //Initialize ROS
-  rclcpp::init(argc, argv);
+  // Initialize ROS
+  std::vector<std::string> args = rclcpp::init_and_remove_ros_arguments(argc, argv);
 
   // Allow 2 or 3 command line arguments
-  if (argc < 3 || argc > 4)
+  if (args.size() < 3 || args.size() > 4)
   {
     printf("Usage: tf2_echo source_frame target_frame [echo_rate]\n\n");
     printf("This will echo the transform from the coordinate frame of the source_frame\n");
@@ -80,10 +81,10 @@ int main(int argc, char ** argv)
   rclcpp::Node::SharedPtr nh = rclcpp::Node::make_shared("tf2_echo");
 
   double rate_hz;
-  if (argc == 4)
+  if (args.size() == 4)
   {
     // read rate from command line
-    rate_hz = atof(argv[3]);
+    rate_hz = std::stof(args[3]);
   }
   else
   {
@@ -100,8 +101,8 @@ int main(int argc, char ** argv)
   echoListener echoListener(clock);
 
 
-  std::string source_frameid = std::string(argv[1]);
-  std::string target_frameid = std::string(argv[2]);
+  std::string source_frameid = std::string(args[1]);
+  std::string target_frameid = std::string(args[2]);
 
   // Wait for up to one second for the first transforms to become avaiable.
   std::string warning_msg;
@@ -132,7 +133,7 @@ int main(int argc, char ** argv)
         auto translation = echo_transform.transform.translation;
         auto rotation = echo_transform.transform.rotation;
         std::cout << "- Translation: [" << translation.x << ", " << translation.y << ", " << translation.z << "]" << std::endl;
-        std::cout << "- Rotation: in Quaternion [" << rotation.x << ", " << rotation.y << ", " 
+        std::cout << "- Rotation: in Quaternion [" << rotation.x << ", " << rotation.y << ", "
                   << rotation.z << ", " << rotation.w << "]" << std::endl;
                   //TODO(tfoote) restory rpy
                   // << "            in RPY (radian) [" <<  roll << ", " << pitch << ", " << yaw << "]" << std::endl
@@ -146,7 +147,7 @@ int main(int argc, char ** argv)
         std::cout << "Exception thrown:" << ex.what()<< std::endl;
         std::cout << "The current list of frames is:" <<std::endl;
         std::cout << echoListener.buffer_.allFramesAsString()<<std::endl;
-        
+
       }
       rate.sleep();
     }


### PR DESCRIPTION
[Foxy backport of #408]

Enables the usage of --ros-args by removing them before parsing the other command line parameters.
Fixes #407