### PR TITLE
Conversion tests for toMsg()

### DIFF
--- a/test_tf2/CMakeLists.txt
+++ b/test_tf2/CMakeLists.txt
@@ -80,28 +80,27 @@ if(TARGET test_utils)
   )
 endif()
 
-# TODO (ahcorde): activate when tf2_bullet is merged
-# add_executable(test_buffer_server test/test_buffer_server.cpp)
-# if(TARGET test_buffer_server)
-#   ament_target_dependencies(test_buffer_server
-#     rclcpp
-#     tf2_bullet
-#     tf2_ros
-#   )
-# endif()
+add_executable(test_buffer_server test/test_buffer_server.cpp)
+if(TARGET test_buffer_server)
+  ament_target_dependencies(test_buffer_server
+    rclcpp
+    tf2_bullet
+    tf2_ros
+  )
+endif()
 
-# TODO (ahcorde): activate when tf2_bullet is merged
-# add_executable(test_buffer_client test/test_buffer_client.cpp)
-# if(TARGET test_buffer_client)
-#   ament_target_dependencies(test_buffer_client
-#     rclcpp
-#     tf2_bullet
-#     tf2_kdl
-#     tf2_ros
-#   )
-#   target_link_libraries(test_buffer_client ${GTEST_LIBRARIES})
-#   add_launch_test(test/buffer_client_tester.launch.py)
-# endif()
+add_executable(test_buffer_client test/test_buffer_client.cpp)
+if(TARGET test_buffer_client)
+  ament_target_dependencies(test_buffer_client
+    rclcpp
+    tf2_bullet
+    tf2_geometry_msgs
+    tf2_kdl
+    tf2_ros
+  )
+  target_link_libraries(test_buffer_client ${GTEST_LIBRARIES})
+  add_launch_test(test/buffer_client_tester.launch.py)
+endif()
 
 add_executable(test_static_publisher test/test_static_publisher.cpp)
 if(TARGET test_static_publisher)
@@ -124,14 +123,14 @@ if(TARGET test_tf2_bullet)
       tf2_ros
   )
 endif()
-#
+
+# TODO(ahcorde): enable once python part of tf2_geometry_msgs is working
 # add_launch_test(test/test_buffer_client.launch.py)
-# add_rostest(${CMAKE_CURRENT_SOURCE_DIR}/test/test_tf2_bullet.launch)
 
 # install executables
 install(TARGETS
-  # test_buffer_client
-  # test_buffer_server
+  test_buffer_client
+  test_buffer_server
   test_static_publisher
   DESTINATION lib/${PROJECT_NAME}
 )

--- a/test_tf2/CMakeLists.txt
+++ b/test_tf2/CMakeLists.txt
@@ -20,6 +20,8 @@ endif()
 
 find_package(ament_cmake_gtest REQUIRED)
 find_package(builtin_interfaces REQUIRED)
+find_package(eigen3_cmake_module REQUIRED)
+find_package(Eigen3 REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(launch_testing_ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -58,6 +60,8 @@ endif()
 ament_add_gtest(test_convert test/test_convert.cpp)
 if(TARGET test_convert)
   ament_target_dependencies(test_convert
+    Eigen3
+    eigen3_cmake_module
     tf2
     tf2_bullet
     tf2_eigen

--- a/test_tf2/CMakeLists.txt
+++ b/test_tf2/CMakeLists.txt
@@ -24,18 +24,13 @@ find_package(geometry_msgs REQUIRED)
 find_package(launch_testing_ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(tf2 REQUIRED)
-# TODO (ahcorde): activate when tf2_bullet is merged
-# find_package(tf2_bullet REQUIRED)
+find_package(tf2_bullet REQUIRED)
+find_package(tf2_eigen REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_kdl REQUIRED)
 find_package(tf2_ros REQUIRED)
 
 ament_find_gtest()
-
-# TODO (ahcorde): activate when tf2_bullet is merged
-# find_package(PkgConfig REQUIRED)
-# pkg_check_modules(bullet REQUIRED bullet)
-# include_directories(include ${bullet_INCLUDE_DIRS})
 
 ament_add_gtest(buffer_core_test test/buffer_core_test.cpp)
 if(TARGET buffer_core_test)
@@ -60,14 +55,16 @@ if(TARGET test_message_filter)
   )
 endif()
 
-# TODO (ahcorde): activate when tf2_bullet is merged
-# ament_add_gtest(test_convert test/test_convert.cpp)
-# if(TARGET test_convert)
-#   ament_target_dependencies(test_convert
-#     tf2
-#     tf2_bullet
-#   )
-# endif()
+ament_add_gtest(test_convert test/test_convert.cpp)
+if(TARGET test_convert)
+  ament_target_dependencies(test_convert
+    tf2
+    tf2_bullet
+    tf2_eigen
+    tf2_geometry_msgs
+    tf2_kdl
+  )
+endif()
 
 ament_add_gtest(test_utils test/test_utils.cpp)
 if(TARGET test_utils)

--- a/test_tf2/CMakeLists.txt
+++ b/test_tf2/CMakeLists.txt
@@ -116,15 +116,14 @@ if(TARGET test_static_publisher)
   add_launch_test(test/static_publisher.launch.py)
 endif()
 
-# TODO (ahcorde): activate when tf2_bullet is merged
-# ament_add_gtest(test_tf2_bullet test/test_tf2_bullet.cpp)
-# if(TARGET test_tf2_bullet)
-#   ament_target_dependencies(test_tf2_bullet
-#       rclcpp
-#       tf2_bullet
-#       tf2_ros
-#   )
-# endif()
+ament_add_gtest(test_tf2_bullet test/test_tf2_bullet.cpp)
+if(TARGET test_tf2_bullet)
+  ament_target_dependencies(test_tf2_bullet
+      rclcpp
+      tf2_bullet
+      tf2_ros
+  )
+endif()
 #
 # add_launch_test(test/test_buffer_client.launch.py)
 # add_rostest(${CMAKE_CURRENT_SOURCE_DIR}/test/test_tf2_bullet.launch)

--- a/test_tf2/package.xml
+++ b/test_tf2/package.xml
@@ -17,6 +17,8 @@
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
   <depend>tf2</depend>
+  <depend>tf2_bullet</depend>
+  <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_kdl</depend>
   <depend>tf2_ros</depend>

--- a/test_tf2/package.xml
+++ b/test_tf2/package.xml
@@ -12,6 +12,9 @@
   <author>Eitan Marder-Eppstein</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>eigen3_cmake_module</buildtool_depend>
+
+  <build_depend>eigen</build_depend>
 
   <depend>builtin_interfaces</depend>
   <depend>geometry_msgs</depend>

--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.hpp
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.hpp
@@ -35,12 +35,15 @@
 #include <tf2/convert.h>
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2/LinearMath/Transform.h>
+#include <tf2/LinearMath/Vector3.h>
 #include <tf2_ros/buffer_interface.h>
 #include <geometry_msgs/msg/point_stamped.hpp>
 #include <geometry_msgs/msg/quaternion_stamped.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
+#include <geometry_msgs/msg/vector3.hpp>
 #include <geometry_msgs/msg/vector3_stamped.hpp>
 #include <geometry_msgs/msg/pose.hpp>
+#include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <kdl/frames.hpp>
@@ -60,6 +63,35 @@ KDL::Frame gmTransformToKDL(const geometry_msgs::msg::TransformStamped& t)
 		      KDL::Vector(t.transform.translation.x, t.transform.translation.y, t.transform.translation.z));
   }
 
+/*************/
+/** Vector3 **/
+/*************/
+
+/** \brief Convert a tf2 Vector3 type to its equivalent geometry_msgs representation.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param in A tf2 Vector3 object.
+ * \return The Vector3 converted to a geometry_msgs message type.
+ */
+inline
+geometry_msgs::msg::Vector3 toMsg(const tf2::Vector3 & in)
+{
+  geometry_msgs::msg::Vector3 out;
+  out.x = in.getX();
+  out.y = in.getY();
+  out.z = in.getZ();
+  return out;
+}
+
+/** \brief Convert a Vector3 message to its equivalent tf2 representation.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.h.
+ * \param in A Vector3 message type.
+ * \param out The Vector3 converted to a tf2 type.
+ */
+inline
+void fromMsg(const geometry_msgs::msg::Vector3 & in, tf2::Vector3 & out)
+{
+  out = tf2::Vector3(in.x, in.y, in.z);
+}
 
 /********************/
 /** Vector3Stamped **/
@@ -123,6 +155,35 @@ void fromMsg(const geometry_msgs::msg::Vector3Stamped& msg, geometry_msgs::msg::
   out = msg;
 }
 
+
+/***********/
+/** Point **/
+/***********/
+
+/** \brief Convert a tf2 Vector3 type to its equivalent geometry_msgs representation.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param in A tf2 Vector3 object.
+ * \return The Vector3 converted to a geometry_msgs message type.
+ */
+inline
+geometry_msgs::msg::Point & toMsg(const tf2::Vector3 & in, geometry_msgs::msg::Point & out)
+{
+  out.x = in.getX();
+  out.y = in.getY();
+  out.z = in.getZ();
+  return out;
+}
+
+/** \brief Convert a Vector3 message to its equivalent tf2 representation.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.h.
+ * \param in A Vector3 message type.
+ * \param out The Vector3 converted to a tf2 type.
+ */
+inline
+void fromMsg(const geometry_msgs::msg::Point & in, tf2::Vector3 & out)
+{
+  out = tf2::Vector3(in.x, in.y, in.z);
+}
 
 
 /******************/


### PR DESCRIPTION
Vectors can be converted to a Vector message or a Point Message, some libraries behave differently. This unit test will make sure that the default return value for `toMsg()` will stay the same.

This was separated from #368.