### PR TITLE
Fix tf2_bullet dependency export

### DIFF
--- a/tf2_bullet/CMakeLists.txt
+++ b/tf2_bullet/CMakeLists.txt
@@ -46,5 +46,4 @@ if(BUILD_TESTING)
 endif()
 
 ament_export_include_directories(include)
-ament_export_libraries(${PROJECT_NAME})
-ament_package()
+ament_package(CONFIG_EXTRAS bullet-extras.cmake)

--- a/tf2_bullet/bullet-extras.cmake
+++ b/tf2_bullet/bullet-extras.cmake
@@ -1,0 +1,34 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the Open Source Robotics Foundation, Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+if(WIN32)
+  set(BULLET_ROOT $ENV{ChocolateyInstall}/lib/bullet)
+endif()
+find_package(Bullet REQUIRED)
+
+include_directories(SYSTEM ${BULLET_INCLUDE_DIRS})

--- a/tf2_bullet/include/tf2_bullet/tf2_bullet.h
+++ b/tf2_bullet/include/tf2_bullet/tf2_bullet.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2008, Willow Garage, Inc. All rights reserved.
+// Copyright 2008 Willow Garage, Inc.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -10,7 +10,7 @@
 //      notice, this list of conditions and the following disclaimer in the
 //      documentation and/or other materials provided with the distribution.
 //
-//    * Neither the name of the Willo Garage, Inc nor the names of its
+//    * Neither the name of the Willow Garage, Inc. nor the names of its
 //      contributors may be used to endorse or promote products derived from
 //      this software without specific prior written permission.
 //

--- a/tf2_bullet/include/tf2_bullet/tf2_bullet.hpp
+++ b/tf2_bullet/include/tf2_bullet/tf2_bullet.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2008, Willow Garage, Inc. All rights reserved.
+// Copyright 2008 Willow Garage, Inc.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -10,7 +10,7 @@
 //      notice, this list of conditions and the following disclaimer in the
 //      documentation and/or other materials provided with the distribution.
 //
-//    * Neither the name of the Willo Garage, Inc nor the names of its
+//    * Neither the name of the Willow Garage, Inc. nor the names of its
 //      contributors may be used to endorse or promote products derived from
 //      this software without specific prior written permission.
 //

--- a/tf2_bullet/include/tf2_bullet/tf2_bullet.hpp
+++ b/tf2_bullet/include/tf2_bullet/tf2_bullet.hpp
@@ -32,6 +32,7 @@
 #define TF2_BULLET__TF2_BULLET_HPP_
 
 #include <tf2/convert.h>
+#include <LinearMath/btQuaternion.h>
 #include <LinearMath/btScalar.h>
 #include <LinearMath/btTransform.h>
 #include <geometry_msgs/msg/point_stamped.hpp>

--- a/tf2_bullet/test/test_tf2_bullet.cpp
+++ b/tf2_bullet/test/test_tf2_bullet.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2008, Willow Garage, Inc. All rights reserved.
+// Copyright 2008 Willow Garage, Inc.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -10,7 +10,7 @@
 //      notice, this list of conditions and the following disclaimer in the
 //      documentation and/or other materials provided with the distribution.
 //
-//    * Neither the name of the Willo Garage, Inc nor the names of its
+//    * Neither the name of the Willow Garage, Inc. nor the names of its
 //      contributors may be used to endorse or promote products derived from
 //      this software without specific prior written permission.
 //


### PR DESCRIPTION
tf2_bullet does not have the dependencies on the bullet library exported. The standard approach of ament does not work because of two reasons:
  - the CMake variable `BULLET_ROOT` seems to be needed on windows
  - `FindBullet` sets the `INCLUDE_DIRS` and `LIBRARIES` all uppercase, which is unexpected by ament.
 
This was split out of #423.