### PR TITLE
Reduce transform listener nodes

### DIFF
--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -101,7 +101,6 @@ public:
   : buffer_(buffer)
   {
     init(node, spin_thread, qos, static_qos, options, static_options);
-    node_logging_interface_ = node->get_node_logging_interface();
   }
 
   TF2_ROS_PUBLIC
@@ -117,6 +116,8 @@ private:
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options)
   {
+    spin_thread_ = spin_thread;
+    node_base_interface_ = node->get_node_base_interface();
     node_logging_interface_ = node->get_node_logging_interface();
 
     using callback_t = std::function<void (tf2_msgs::msg::TFMessage::SharedPtr)>;
@@ -125,36 +126,41 @@ private:
     callback_t static_cb = std::bind(
       &TransformListener::subscription_callback, this, std::placeholders::_1, true);
 
-    message_subscription_tf_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
-      node,
-      "/tf",
-      qos,
-      std::move(cb),
-      options);
-    message_subscription_tf_static_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
-      node,
-      "/tf_static",
-      static_qos,
-      std::move(static_cb),
-      static_options);
-
-    if (spin_thread) {
-      initThread(node->get_node_base_interface());
+    if (spin_thread_) {
+      // Create new callback group for message_subscription of tf and tf_static
+      callback_group_ = node_base_interface_->create_callback_group(
+        rclcpp::CallbackGroupType::MutuallyExclusive, false);
+      // Duplicate to modify option of subscription
+      rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> options2 = options;
+      rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> static_options2 = static_options;
+      options2.callback_group = callback_group_;
+      static_options2.callback_group = callback_group_;
+      message_subscription_tf_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
+        node, "/tf", qos, std::move(cb), options2);
+      message_subscription_tf_static_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
+        node, "/tf_static", static_qos, std::move(static_cb), static_options2);
+      // Create executor with dedicated thread to spin.
+      executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+      executor_->add_callback_group(callback_group_, node_base_interface_);
+      dedicated_listener_thread_ = std::make_unique<std::thread>([&]() {executor_->spin();});
+      // Tell the buffer we have a dedicated thread to enable timeouts
+      buffer_.setUsingDedicatedThread(true);
+    } else {
+      message_subscription_tf_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
+        node, "/tf", qos, std::move(cb), options);
+      message_subscription_tf_static_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
+        node, "/tf_static", static_qos, std::move(static_cb), static_options);
     }
   }
-
-  TF2_ROS_PUBLIC
-  void initThread(
-    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface);
-
   /// Callback function for ros message subscriptoin
   TF2_ROS_PUBLIC
   void subscription_callback(tf2_msgs::msg::TFMessage::SharedPtr msg, bool is_static);
 
   // ros::CallbackQueue tf_message_callback_queue_;
-  using thread_ptr =
-    std::unique_ptr<std::thread, std::function<void (std::thread *)>>;
-  thread_ptr dedicated_listener_thread_;
+  bool spin_thread_{false};
+  std::unique_ptr<std::thread> dedicated_listener_thread_;
+  rclcpp::CallbackGroup::SharedPtr callback_group_{nullptr};
+  rclcpp::executors::SingleThreadedExecutor::SharedPtr executor_;
 
   rclcpp::Node::SharedPtr optional_default_node_ = nullptr;
   rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr message_subscription_tf_;
@@ -162,6 +168,7 @@ private:
   tf2::BufferCore & buffer_;
   tf2::TimePoint last_update_;
   rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_interface_;
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface_;
 };
 }  // namespace tf2_ros
 

--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -131,14 +131,16 @@ private:
       callback_group_ = node_base_interface_->create_callback_group(
         rclcpp::CallbackGroupType::MutuallyExclusive, false);
       // Duplicate to modify option of subscription
-      rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> options2 = options;
-      rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> static_options2 = static_options;
-      options2.callback_group = callback_group_;
-      static_options2.callback_group = callback_group_;
+      rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> tf_options = options;
+      rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> tf_static_options = static_options;
+      tf_options.callback_group = callback_group_;
+      tf_static_options.callback_group = callback_group_;
+
       message_subscription_tf_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
-        node, "/tf", qos, std::move(cb), options2);
+        node, "/tf", qos, std::move(cb), tf_options);
       message_subscription_tf_static_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
-        node, "/tf_static", static_qos, std::move(static_cb), static_options2);
+        node, "/tf_static", static_qos, std::move(static_cb), tf_static_options);
+
       // Create executor with dedicated thread to spin.
       executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
       executor_->add_callback_group(callback_group_, node_base_interface_);

--- a/tf2_ros/src/transform_listener.cpp
+++ b/tf2_ros/src/transform_listener.cpp
@@ -52,7 +52,6 @@ TransformListener::TransformListener(tf2::BufferCore & buffer, bool spin_thread)
   options.start_parameter_event_publisher(false);
   options.start_parameter_services(false);
   optional_default_node_ = rclcpp::Node::make_shared("_", options);
-
   init(
     optional_default_node_, spin_thread, DynamicListenerQoS(), StaticListenerQoS(),
     detail::get_default_transform_listener_sub_options(),

--- a/tf2_ros/src/transform_listener.cpp
+++ b/tf2_ros/src/transform_listener.cpp
@@ -52,6 +52,7 @@ TransformListener::TransformListener(tf2::BufferCore & buffer, bool spin_thread)
   options.start_parameter_event_publisher(false);
   options.start_parameter_services(false);
   optional_default_node_ = rclcpp::Node::make_shared("_", options);
+
   init(
     optional_default_node_, spin_thread, DynamicListenerQoS(), StaticListenerQoS(),
     detail::get_default_transform_listener_sub_options(),
@@ -60,35 +61,12 @@ TransformListener::TransformListener(tf2::BufferCore & buffer, bool spin_thread)
 
 TransformListener::~TransformListener()
 {
+  if (spin_thread_) {
+    executor_->cancel();
+    dedicated_listener_thread_->join();
+  }
 }
 
-void TransformListener::initThread(
-  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface)
-{
-  auto executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
-
-  // This lambda is required because `std::thread` cannot infer the correct
-  // rclcpp::spin, since there are more than one versions of it (overloaded).
-  // see: http://stackoverflow.com/a/27389714/671658
-  // I (wjwwood) chose to use the lamda rather than the static cast solution.
-  auto run_func =
-    [executor](rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface) {
-      executor->add_node(node_base_interface);
-      executor->spin();
-      executor->remove_node(node_base_interface);
-    };
-  dedicated_listener_thread_ = thread_ptr(
-    new std::thread(run_func, node_base_interface),
-    [executor](std::thread * t) {
-      executor->cancel();
-      t->join();
-      delete t;
-      // TODO(tfoote) reenable callback queue processing
-      // tf_message_callback_queue_.callAvailable(ros::WallDuration(0.01));
-    });
-  // Tell the buffer we have a dedicated thread to enable timeouts
-  buffer_.setUsingDedicatedThread(true);
-}
 
 void TransformListener::subscription_callback(
   const tf2_msgs::msg::TFMessage::SharedPtr msg,


### PR DESCRIPTION
Signed-off-by: zhenpeng ge <zhenpeng.ge@qq.com>

As described in https://github.com/ros2/geometry2/issues/440, I use new callback group and executor with dedicated thread so that we could avoid creating internal node which is overhead. 

currently, i don't break the API, but i think the constructor `TransformListener(tf2::BufferCore & buffer, bool spin_thread = true)` need be deprecated, due to create internal Node.

the another constructor is enough to use like this.
```c++
tf_buffer_ = std::make_shared<tf2_ros::Buffer>(get_clock());
//case1: spin in dedicated thread (use new callback group and executor)
tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_, shared_from_this(), true);
//case2: its on the application to spin
tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_, shared_from_this(), false);
```