### PR TITLE
Isolate timer interface

### DIFF
--- a/tf2_ros/include/tf2_ros/create_timer_ros.h
+++ b/tf2_ros/include/tf2_ros/create_timer_ros.h
@@ -53,7 +53,8 @@ public:
   TF2_ROS_PUBLIC
   CreateTimerROS(
     rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
-    rclcpp::node_interfaces::NodeTimersInterface::SharedPtr node_timers);
+    rclcpp::node_interfaces::NodeTimersInterface::SharedPtr node_timers,
+    rclcpp::CallbackGroup::SharedPtr callback_group = nullptr);
 
   virtual ~CreateTimerROS() = default;
 
@@ -123,6 +124,8 @@ private:
   TimerHandle next_timer_handle_index_;
   std::unordered_map<TimerHandle, rclcpp::TimerBase::SharedPtr> timers_map_;
   std::mutex timers_map_mutex_;
+
+  rclcpp::CallbackGroup::SharedPtr callback_group_;
 };  // class CreateTimerROS
 
 }  // namespace tf2_ros

--- a/tf2_ros/src/create_timer_ros.cpp
+++ b/tf2_ros/src/create_timer_ros.cpp
@@ -43,8 +43,10 @@ namespace tf2_ros
 
 CreateTimerROS::CreateTimerROS(
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
-  rclcpp::node_interfaces::NodeTimersInterface::SharedPtr node_timers)
-: node_base_(node_base), node_timers_(node_timers), next_timer_handle_index_(0)
+  rclcpp::node_interfaces::NodeTimersInterface::SharedPtr node_timers,
+  rclcpp::CallbackGroup::SharedPtr callback_group)
+: node_base_(node_base), node_timers_(node_timers), next_timer_handle_index_(0),
+  callback_group_(callback_group)
 {
 }
 
@@ -61,7 +63,8 @@ CreateTimerROS::createTimer(
     node_timers_,
     clock,
     period,
-    std::bind(&CreateTimerROS::timerCallback, this, timer_handle_index, callback));
+    std::bind(&CreateTimerROS::timerCallback, this, timer_handle_index, callback),
+    callback_group_);
   timers_map_[timer_handle_index] = timer;
   return timer_handle_index;
 }


### PR DESCRIPTION
Signed-off-by: zhenpeng ge <zhenpeng.ge@qq.com>

As described in https://github.com/ros2/geometry2/issues/446,  `CreateTimerROS`  create timers by using application's Node, there are some potential issue when application has some long running callback of services, etc. 

In this PR, a dedicated callback group and executor with thread are used to isolate TF timer so that timers won't be blocked by application's callback.