### PR TITLE
`tf2_ros`: Fix deprecated subscriber callbacks

### DIFF
--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -119,7 +119,7 @@ private:
   {
     node_logging_interface_ = node->get_node_logging_interface();
 
-    using callback_t = std::function<void (tf2_msgs::msg::TFMessage::SharedPtr)>;
+    using callback_t = std::function<void (tf2_msgs::msg::TFMessage::ConstSharedPtr)>;
     callback_t cb = std::bind(
       &TransformListener::subscription_callback, this, std::placeholders::_1, false);
     callback_t static_cb = std::bind(
@@ -149,7 +149,7 @@ private:
 
   /// Callback function for ros message subscriptoin
   TF2_ROS_PUBLIC
-  void subscription_callback(tf2_msgs::msg::TFMessage::SharedPtr msg, bool is_static);
+  void subscription_callback(tf2_msgs::msg::TFMessage::ConstSharedPtr msg, bool is_static);
 
   // ros::CallbackQueue tf_message_callback_queue_;
   using thread_ptr =

--- a/tf2_ros/src/tf2_monitor.cpp
+++ b/tf2_ros/src/tf2_monitor.cpp
@@ -65,7 +65,7 @@ public:
   tf2_msgs::msg::TFMessage message_;
   std::mutex map_mutex_;
 
-  void callback(const tf2_msgs::msg::TFMessage::SharedPtr msg)
+  void callback(const tf2_msgs::msg::TFMessage::ConstSharedPtr msg)
   {
     const tf2_msgs::msg::TFMessage & message = *(msg);
     // TODO(tfoote): recover authority info

--- a/tf2_ros/src/transform_listener.cpp
+++ b/tf2_ros/src/transform_listener.cpp
@@ -91,7 +91,7 @@ void TransformListener::initThread(
 }
 
 void TransformListener::subscription_callback(
-  const tf2_msgs::msg::TFMessage::SharedPtr msg,
+  const tf2_msgs::msg::TFMessage::ConstSharedPtr msg,
   bool is_static)
 {
   const tf2_msgs::msg::TFMessage & msg_in = *msg;


### PR DESCRIPTION
ros2/rclcpp#1713 deprecates the `void shared_ptr<T>` subscription callback signatures, so this PR migrates away from said signatures.

Signed-off-by: Abrar Rahman Protyasha abrar@openrobotics.org