### PR TITLE
Adding date-time to frames filename

### DIFF
--- a/tf2_tools/tf2_tools/view_frames.py
+++ b/tf2_tools/tf2_tools/view_frames.py
@@ -87,18 +87,18 @@ def main():
             'Result:'+ str(result) )
         data = yaml.safe_load(result.frame_yaml)
         
-        frames_gv = "frames.gv"
-        frames_pdf = "frames.pdf"
+        frames_gv = 'frames.gv'
+        frames_pdf = 'frames.pdf'
 
         if parsed_args.datetime:
-            datetime = time.strftime("%Y-%m-%d_%H.%M")
-            frames_gv = "frames_{:s}.gv".format(datetime)
-            frames_pdf = "frames_{:s}.pdf".format(datetime)
+            datetime = time.strftime('%Y-%m-%d_%H.%M')
+            frames_gv = 'frames_{:s}.gv'.format(datetime)
+            frames_pdf = 'frames_{:s}.pdf'.format(datetime)
         
         with open(frames_gv, 'w') as f:
             f.write(generate_dot(data, node.get_clock().now().seconds_nanoseconds()))
         
-        cmd = ["dot", "-Tpdf", frames_gv, "-o", frames_pdf]
+        cmd = ['dot', '-Tpdf', frames_gv, '-o', frames_pdf]
         subprocess.Popen(cmd).communicate()
     finally:
         cli.destroy()

--- a/tf2_tools/tf2_tools/view_frames.py
+++ b/tf2_tools/tf2_tools/view_frames.py
@@ -49,7 +49,7 @@ def main():
     parser.add_argument(
         '--wait-time', '-t', type=float, default=5.0,
         help='Listen to the /tf topic for this many seconds before rendering the frame tree')
-    parser.add_argument('-d','--datetime', action='store_true', help="Add datetime to the end of the filename")
+    parser.add_argument('-o','--output', help='Output filename')
     parsed_args = parser.parse_args(args=args_without_ros[1:])
 
     node = rclpy.create_node('view_frames')
@@ -87,11 +87,12 @@ def main():
             'Result:'+ str(result) )
         data = yaml.safe_load(result.frame_yaml)
         
-        frames_gv = 'frames.gv'
-        frames_pdf = 'frames.pdf'
-
-        if parsed_args.datetime:
-            datetime = time.strftime('%Y-%m-%d_%H.%M')
+        if parsed_args.output is not None:
+            datetime = time.strftime('%Y-%m-%d_%H.%M.%S')
+            frames_gv = '{:s}_{:s}.gv'.format(parsed_args.output, datetime)
+            frames_pdf = '{:s}_{:s}.pdf'.format(parsed_args.output, datetime)
+        else:
+            datetime = time.strftime('%Y-%m-%d_%H.%M.%S')
             frames_gv = 'frames_{:s}.gv'.format(datetime)
             frames_pdf = 'frames_{:s}.pdf'.format(datetime)
         

--- a/tf2_tools/tf2_tools/view_frames.py
+++ b/tf2_tools/tf2_tools/view_frames.py
@@ -88,9 +88,8 @@ def main():
         data = yaml.safe_load(result.frame_yaml)
         
         if parsed_args.output is not None:
-            datetime = time.strftime('%Y-%m-%d_%H.%M.%S')
-            frames_gv = '{:s}_{:s}.gv'.format(parsed_args.output, datetime)
-            frames_pdf = '{:s}_{:s}.pdf'.format(parsed_args.output, datetime)
+            frames_gv = '{:s}.gv'.format(parsed_args.output)
+            frames_pdf = '{:s}.pdf'.format(parsed_args.output)
         else:
             datetime = time.strftime('%Y-%m-%d_%H.%M.%S')
             frames_gv = 'frames_{:s}.gv'.format(datetime)

--- a/tf2_tools/tf2_tools/view_frames.py
+++ b/tf2_tools/tf2_tools/view_frames.py
@@ -49,6 +49,7 @@ def main():
     parser.add_argument(
         '--wait-time', '-t', type=float, default=5.0,
         help='Listen to the /tf topic for this many seconds before rendering the frame tree')
+    parser.add_argument('-d','--datetime', action='store_true', help="Add datetime to the end of the filename")
     parsed_args = parser.parse_args(args=args_without_ros[1:])
 
     node = rclpy.create_node('view_frames')
@@ -85,9 +86,20 @@ def main():
         node.get_logger().info(
             'Result:'+ str(result) )
         data = yaml.safe_load(result.frame_yaml)
-        with open('frames.gv', 'w') as f:
-           f.write(generate_dot(data, node.get_clock().now().seconds_nanoseconds()))
-        subprocess.Popen('dot -Tpdf frames.gv -o frames.pdf'.split(' ')).communicate()
+        
+        frames_gv = "frames.gv"
+        frames_pdf = "frames.pdf"
+
+        if parsed_args.datetime:
+            datetime = time.strftime("%Y-%m-%d_%H.%M")
+            frames_gv = "frames_{:s}.gv".format(datetime)
+            frames_pdf = "frames_{:s}.pdf".format(datetime)
+        
+        with open(frames_gv, 'w') as f:
+            f.write(generate_dot(data, node.get_clock().now().seconds_nanoseconds()))
+        
+        cmd = ["dot", "-Tpdf", frames_gv, "-o", frames_pdf]
+        subprocess.Popen(cmd).communicate()
     finally:
         cli.destroy()
         node.destroy_node()


### PR DESCRIPTION
Working with a problem, creating multiple TF frames to see, what has changed and not noticing to make a copy of the file, overwriting a previous data.

With this, adding -d or --datetime as an argument on the run command, it adds a date-time stamp to the end of the file.

[Originally I used this on ros1](https://github.com/ros/geometry2/pull/506#issue-610373305), then instructed to make for future versions.