### PR TITLE
Fix for building on Windows

### DIFF
--- a/tf2/include/tf2/exceptions.h
+++ b/tf2/include/tf2/exceptions.h
@@ -37,6 +37,10 @@
 
 #include "tf2/visibility_control.h"
 
+#if defined(_WIN32) && defined(NO_ERROR)
+  #undef NO_ERROR
+#endif
+
 namespace tf2
 {
 


### PR DESCRIPTION
Undefine NO_ERROR when building on Windows to avoid collision with Windows.h