### PR TITLE
Workaround with pragma push and pop for NO_ERROR collision

### DIFF
--- a/tf2/include/tf2/exceptions.h
+++ b/tf2/include/tf2/exceptions.h
@@ -39,6 +39,12 @@
 
 namespace tf2{
 
+// This workaround prevents a collision with Windows.h
+#if defined(_WIN32)
+#pragma push_macro("NO_ERROR")
+#undef NO_ERROR
+#endif
+
 enum class TF2Error : std::uint8_t {
   NO_ERROR = 0,
   LOOKUP_ERROR = 1,
@@ -49,6 +55,9 @@ enum class TF2Error : std::uint8_t {
   TRANSFORM_ERROR = 6
 };
 
+#if defined(_WIN32)
+#pragma pop_macro("NO_ERROR")
+#endif
 
 /** \brief A base class for all tf2 exceptions 
  * This inherits from ros::exception 


### PR DESCRIPTION
Fix for the collision with windows.h for Foxy because #349 will not be backported.

