### PR TITLE
Remove unused import

### DIFF
--- a/tf2_tools/tf2_tools/view_frames.py
+++ b/tf2_tools/tf2_tools/view_frames.py
@@ -36,7 +36,6 @@ import yaml
 
 import rclpy
 from tf2_msgs.srv import FrameGraph
-import tf2_py as tf2
 import tf2_ros
 
 


### PR DESCRIPTION
Removes unused import in `view_frames.py` that breaks this script on macOS.
If someone could test this on Ubuntu before merging that would be great, thanks :)