### PR TITLE
Minor code cleanups in tf2

### DIFF
--- a/tf2/include/tf2/buffer_core.h
+++ b/tf2/include/tf2/buffer_core.h
@@ -425,11 +425,6 @@ private:
     CompactFrameID target_frame, CompactFrameID source_frame,
     TimePoint & time, std::string * error_string) const;
 
-  template<typename F>
-  tf2::TF2Error walkToTopParent(
-    F & f, TimePoint time, CompactFrameID target_id,
-    CompactFrameID source_id, std::string * error_string) const;
-
   /**@brief Traverse the transform tree. If frame_chain is not NULL, store the traversed frame tree in vector frame_chain.
    * */
   template<typename F>

--- a/tf2/include/tf2/buffer_core.h
+++ b/tf2/include/tf2/buffer_core.h
@@ -434,12 +434,9 @@ private:
     std::vector<CompactFrameID> * frame_chain) const;
 
   void testTransformableRequests();
-  // Thread safe transform check, acquire lock and call canTransformNoLock.
-  bool canTransformInternal(
-    CompactFrameID target_id, CompactFrameID source_id,
-    const TimePoint & time, std::string * error_msg) const;
+
   // Actual implementation to walk the transform tree and find out if a transform exists.
-  bool canTransformNoLock(
+  bool canTransformInternal(
     CompactFrameID target_id, CompactFrameID source_id,
     const TimePoint & time, std::string * error_msg) const;
 

--- a/tf2/include/tf2/buffer_core.h
+++ b/tf2/include/tf2/buffer_core.h
@@ -161,13 +161,13 @@ public:
    * \param target_frame The frame into which to transform
    * \param source_frame The frame from which to transform
    * \param time The time at which to transform
-   * \param error_msg A pointer to a string which will be filled with why the transform failed, if not NULL
+   * \param error_msg A pointer to a string which will be filled with why the transform failed, if not nullptr
    * \return True if the transform is possible, false otherwise
    */
   TF2_PUBLIC
   bool canTransform(
     const std::string & target_frame, const std::string & source_frame,
-    const TimePoint & time, std::string * error_msg = NULL) const override;
+    const TimePoint & time, std::string * error_msg = nullptr) const override;
 
   /** \brief Test if a transform is possible
    * \param target_frame The frame into which to transform
@@ -175,14 +175,14 @@ public:
    * \param source_frame The frame from which to transform
    * \param source_time The time from which to transform
    * \param fixed_frame The frame in which to treat the transform as constant in time
-   * \param error_msg A pointer to a string which will be filled with why the transform failed, if not NULL
+   * \param error_msg A pointer to a string which will be filled with why the transform failed, if not nullptr
    * \return True if the transform is possible, false otherwise
    */
   TF2_PUBLIC
   bool canTransform(
     const std::string & target_frame, const TimePoint & target_time,
     const std::string & source_frame, const TimePoint & source_time,
-    const std::string & fixed_frame, std::string * error_msg = NULL) const override;
+    const std::string & fixed_frame, std::string * error_msg = nullptr) const override;
 
   /** \brief Get all frames that exist in the system.
    */
@@ -382,7 +382,7 @@ private:
     * \param function_name_arg string to print out in the message,
     *   the current function and argument name being validated
     * \param frame_id name of the tf frame to validate
-    * \param[out] error_msg if non-NULL, fill with produced error messaging.
+    * \param[out] error_msg if non-nullptr, fill with produced error messaging.
     *   Otherwise messages are logged as warning.
     * \return The CompactFrameID of the frame or 0 if not found.
     */
@@ -423,7 +423,7 @@ private:
     CompactFrameID target_frame, CompactFrameID source_frame,
     TimePoint & time, std::string * error_string) const;
 
-  /**@brief Traverse the transform tree. If frame_chain is not NULL, store the traversed frame tree in vector frame_chain.
+  /**@brief Traverse the transform tree. If frame_chain is not nullptr, store the traversed frame tree in vector frame_chain.
    * */
   template<typename F>
   tf2::TF2Error walkToTopParent(

--- a/tf2/include/tf2/buffer_core.h
+++ b/tf2/include/tf2/buffer_core.h
@@ -303,12 +303,6 @@ public:
     std::vector<std::string> & output) const;
 
 private:
-  /** \brief A way to see what frames have been cached
-   * Useful for debugging. Use this call internally.
-   */
-  std::string allFramesAsStringNoLock() const;
-
-
   /******************** Internal Storage ****************/
 
   /** \brief The pointers to potential frames that the tree can be made of.
@@ -354,8 +348,14 @@ private:
   std::mutex transformable_requests_mutex_;
   uint64_t transformable_requests_counter_;
 
+  bool using_dedicated_thread_;
 
   /************************* Internal Functions ****************************/
+
+  /** \brief A way to see what frames have been cached
+   * Useful for debugging. Use this call internally.
+   */
+  std::string allFramesAsStringNoLock() const;
 
   bool setTransformImpl(
     const tf2::Transform & transform_in, const std::string frame_id,
@@ -437,10 +437,6 @@ private:
   bool canTransformInternal(
     CompactFrameID target_id, CompactFrameID source_id,
     const TimePoint & time, std::string * error_msg) const;
-
-  // Whether it is safe to use canTransform with a timeout.
-  // (If another thread is not provided it will always timeout.)
-  bool using_dedicated_thread_;
 };
 }  // namespace tf2
 

--- a/tf2/include/tf2/buffer_core.h
+++ b/tf2/include/tf2/buffer_core.h
@@ -370,11 +370,8 @@ private:
     const std::string & source_frame, const TimePoint & source_time,
     const std::string & fixed_frame, tf2::Transform & transform, TimePoint & time_out) const;
 
-  /** \brief An accessor to get a frame, which will throw an exception if the frame is no there.
+  /** \brief An accessor to get a frame.
    * \param frame_number The frameID of the desired Reference Frame
-   *
-   * This is an internal function which will get the pointer to the frame associated with the frame id
-   * Possible Exception: tf::LookupException
    */
   TimeCacheInterfacePtr getFrame(CompactFrameID c_frame_id) const;
 

--- a/tf2/include/tf2/buffer_core.h
+++ b/tf2/include/tf2/buffer_core.h
@@ -33,6 +33,7 @@
 #define TF2__BUFFER_CORE_H_
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <functional>
 #include <map>

--- a/tf2/include/tf2/buffer_core_interface.h
+++ b/tf2/include/tf2/buffer_core_interface.h
@@ -98,7 +98,7 @@ public:
    * \param source_frame The frame from which to transform.
    * \param time The time at which to transform.
    * \param error_msg A pointer to a string which will be filled with why the transform failed.
-   *   Ignored if NULL.
+   *   Ignored if nullptr.
    * \return true if the transform is possible, false otherwise.
    */
   TF2_PUBLIC
@@ -117,7 +117,7 @@ public:
    * \param source_time The time from which to transform.
    * \param fixed_frame The frame in which to treat the transform as constant in time.
    * \param error_msg A pointer to a string which will be filled with why the transform failed.
-   *   Ignored if NULL.
+   *   Ignored if nullptr.
    * \return true if the transform is possible, false otherwise.
    */
   TF2_PUBLIC

--- a/tf2/include/tf2/convert.h
+++ b/tf2/include/tf2/convert.h
@@ -35,7 +35,6 @@
 #include <array>
 #include <string>
 
-#include "builtin_interfaces/msg/time.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "rosidl_runtime_cpp/traits.hpp"
 #include "tf2/exceptions.h"

--- a/tf2/include/tf2/time.h
+++ b/tf2/include/tf2/time.h
@@ -44,46 +44,20 @@ using IDuration = std::chrono::duration<int, std::nano>;
 // This is the zero time in ROS
 static const TimePoint TimePointZero = TimePoint(IDuration::zero());
 
-inline TimePoint get_now()
-{
-  return std::chrono::system_clock::now();
-}
+TF2_PUBLIC
+TimePoint get_now();
 
-inline Duration durationFromSec(double t_sec)
-{
-  int32_t sec, nsec;
-  sec = static_cast<int32_t>(floor(t_sec));
-  nsec = static_cast<int32_t>(std::round((t_sec - sec) * 1e9));
-  // avoid rounding errors
-  sec += (nsec / 1000000000l);
-  nsec %= 1000000000l;
-  return std::chrono::seconds(sec) + std::chrono::nanoseconds(nsec);
-}
+TF2_PUBLIC
+Duration durationFromSec(double t_sec);
 
-inline TimePoint timeFromSec(double t_sec)
-{
-  return tf2::TimePoint(durationFromSec(t_sec));
-}
+TF2_PUBLIC
+TimePoint timeFromSec(double t_sec);
 
-inline double durationToSec(const tf2::Duration & input)
-{
-  int64_t count = input.count();
+TF2_PUBLIC
+double durationToSec(const tf2::Duration & input);
 
-  // scale the nanoseconds separately for improved accuracy
-  int32_t sec, nsec;
-  nsec = static_cast<int32_t>(count % 1000000000l);
-  sec = static_cast<int32_t>((count - nsec) / 1000000000l);
-
-  double sec_double, nsec_double;
-  nsec_double = 1e-9 * static_cast<double>(nsec);
-  sec_double = static_cast<double>(sec);
-  return sec_double + nsec_double;
-}
-
-inline double timeToSec(const TimePoint & timepoint)
-{
-  return durationToSec(Duration(timepoint.time_since_epoch()));
-}
+TF2_PUBLIC
+double timeToSec(const TimePoint & timepoint);
 
 TF2_PUBLIC
 std::string displayTimePoint(const TimePoint & stamp);

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -339,7 +339,7 @@ bool BufferCore::setTransformImpl(
     std::unique_lock<std::mutex> lock(frame_mutex_);
     CompactFrameID frame_number = lookupOrInsertFrameNumber(stripped_child_frame_id);
     TimeCacheInterfacePtr frame = getFrame(frame_number);
-    if (frame == NULL) {
+    if (frame == nullptr) {
       frame = allocateFrame(frame_number, is_static);
     } else {
       // Overwrite TimeCacheInterface type with a current input
@@ -944,7 +944,7 @@ std::string BufferCore::allFramesAsStringNoLock() const
   // regular transforms
   for (size_t counter = 1; counter < frames_.size(); counter++) {
     TimeCacheInterfacePtr frame_ptr = getFrame(static_cast<CompactFrameID>(counter));
-    if (frame_ptr == NULL) {
+    if (frame_ptr == nullptr) {
       continue;
     }
     CompactFrameID frame_id_num;
@@ -1308,7 +1308,7 @@ bool BufferCore::_getParent(
     return false;
   }
 
-  CompactFrameID parent_id = frame->getParent(time, NULL);
+  CompactFrameID parent_id = frame->getParent(time, nullptr);
   if (parent_id == 0) {
     return false;
   }

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -385,16 +385,6 @@ enum WalkEnding
   FullPath,
 };
 
-// TODO(anyone): for Jade: Merge walkToTopParent functions; this is now a stub to preserve ABI
-template<typename F>
-tf2::TF2Error BufferCore::walkToTopParent(
-  F & f, TimePoint time, CompactFrameID target_id,
-  CompactFrameID source_id,
-  std::string * error_string) const
-{
-  return walkToTopParent(f, time, target_id, source_id, error_string, NULL);
-}
-
 template<typename F>
 tf2::TF2Error BufferCore::walkToTopParent(
   F & f, TimePoint time, CompactFrameID target_id,
@@ -729,7 +719,7 @@ void BufferCore::lookupTransformImpl(
 
   std::string error_string;
   TransformAccum accum;
-  tf2::TF2Error retval = walkToTopParent(accum, time, target_id, source_id, &error_string);
+  tf2::TF2Error retval = walkToTopParent(accum, time, target_id, source_id, &error_string, nullptr);
   if (retval != tf2::TF2Error::TF2_NO_ERROR) {
     switch (retval) {
       case tf2::TF2Error::TF2_CONNECTIVITY_ERROR:
@@ -806,7 +796,7 @@ bool BufferCore::canTransformNoLock(
   }
 
   CanTransformAccum accum;
-  if (walkToTopParent(accum, time, target_id, source_id, error_msg) == tf2::TF2Error::TF2_NO_ERROR) {
+  if (walkToTopParent(accum, time, target_id, source_id, error_msg, nullptr) == tf2::TF2Error::TF2_NO_ERROR) {
     return true;
   }
 

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -373,6 +373,7 @@ bool BufferCore::setTransformImpl(
   return true;
 }
 
+// This method expects that the caller is holding frame_mutex_
 TimeCacheInterfacePtr BufferCore::allocateFrame(CompactFrameID cfid, bool is_static)
 {
   if (is_static) {

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -586,8 +586,8 @@ BufferCore::lookupTransform(
     time_out.time_since_epoch());
   std::chrono::seconds s = std::chrono::duration_cast<std::chrono::seconds>(
     time_out.time_since_epoch());
-  msg.header.stamp.sec = (int32_t)s.count();
-  msg.header.stamp.nanosec = (uint32_t)(ns.count() % 1000000000ull);
+  msg.header.stamp.sec = static_cast<int32_t>(s.count());
+  msg.header.stamp.nanosec = static_cast<uint32_t>(ns.count() % 1000000000ull);
   msg.header.frame_id = target_frame;
   msg.child_frame_id = source_frame;
 
@@ -617,8 +617,8 @@ BufferCore::lookupTransform(
     time_out.time_since_epoch());
   std::chrono::seconds s = std::chrono::duration_cast<std::chrono::seconds>(
     time_out.time_since_epoch());
-  msg.header.stamp.sec = (int32_t)s.count();
-  msg.header.stamp.nanosec = (uint32_t)(ns.count() % 1000000000ull);
+  msg.header.stamp.sec = static_cast<int32_t>(s.count());
+  msg.header.stamp.nanosec = static_cast<uint32_t>(ns.count() % 1000000000ull);
   msg.header.frame_id = target_frame;
   msg.child_frame_id = source_frame;
 

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -284,14 +284,14 @@ bool BufferCore::setTransformImpl(
     error_exists = true;
   }
 
-  if (stripped_child_frame_id == "") {
+  if (stripped_child_frame_id.empty()) {
     CONSOLE_BRIDGE_logError(
       "TF_NO_CHILD_FRAME_ID: Ignoring transform from authority \"%s\" because child_frame_id not"
       " set ", authority.c_str());
     error_exists = true;
   }
 
-  if (stripped_frame_id == "") {
+  if (stripped_frame_id.empty()) {
     CONSOLE_BRIDGE_logError(
       "TF_NO_FRAME_ID: Ignoring transform with child_frame_id \"%s\"  from authority \"%s\" "
       "because frame_id not set", stripped_child_frame_id.c_str(), authority.c_str());

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -1263,7 +1263,7 @@ void BufferCore::testTransformableRequests()
 {
   std::unique_lock<std::mutex> lock(transformable_requests_mutex_);
   V_TransformableRequest::iterator it = transformable_requests_.begin();
-  for (; it != transformable_requests_.end(); ) {
+  while (it != transformable_requests_.end()) {
     TransformableRequest & req = *it;
 
     // One or both of the frames may not have existed when the request was originally made.

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -780,10 +780,11 @@ struct CanTransformAccum
   TransformStorage st;
 };
 
-bool BufferCore::canTransformNoLock(
+bool BufferCore::canTransformInternal(
   CompactFrameID target_id, CompactFrameID source_id,
   const TimePoint & time, std::string * error_msg) const
 {
+  std::unique_lock<std::mutex> lock(frame_mutex_);
   if (target_id == 0 || source_id == 0) {
     if (error_msg) {
       *error_msg = "Source or target frame is not yet defined";
@@ -801,14 +802,6 @@ bool BufferCore::canTransformNoLock(
   }
 
   return false;
-}
-
-bool BufferCore::canTransformInternal(
-  CompactFrameID target_id, CompactFrameID source_id,
-  const TimePoint & time, std::string * error_msg) const
-{
-  std::unique_lock<std::mutex> lock(frame_mutex_);
-  return canTransformNoLock(target_id, source_id, time, error_msg);
 }
 
 bool BufferCore::canTransform(

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -30,7 +30,9 @@
 
 #include <algorithm>
 #include <cassert>
+#include <chrono>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <utility>
@@ -41,7 +43,13 @@
 #include "tf2/exceptions.h"
 
 #include "console_bridge/console.h"
+#include "tf2/LinearMath/Quaternion.h"
 #include "tf2/LinearMath/Transform.h"
+#include "tf2/LinearMath/Vector3.h"
+
+#include "builtin_interfaces/msg/time.hpp"
+#include "geometry_msgs/msg/transform.hpp"
+#include "geometry_msgs/msg/transform_stamped.hpp"
 
 namespace tf2
 {

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -375,11 +375,10 @@ bool BufferCore::setTransformImpl(
 
 TimeCacheInterfacePtr BufferCore::allocateFrame(CompactFrameID cfid, bool is_static)
 {
-  TimeCacheInterfacePtr frame_ptr = frames_[cfid];
   if (is_static) {
-    frames_[cfid] = TimeCacheInterfacePtr(new StaticCache());
+    frames_[cfid] = std::make_shared<StaticCache>();
   } else {
-    frames_[cfid] = TimeCacheInterfacePtr(new TimeCache(cache_time_));
+    frames_[cfid] = std::make_shared<TimeCache>(cache_time_);
   }
 
   return frames_[cfid];

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -54,79 +54,11 @@
 namespace tf2
 {
 
+namespace
+{
+
 // Tolerance for acceptable quaternion normalization
 constexpr static double QUATERNION_NORMALIZATION_TOLERANCE = 10e-3;
-
-/** \brief convert Transform msg to Transform */
-void transformMsgToTF2(const geometry_msgs::msg::Transform & msg, tf2::Transform & tf2)
-{
-  tf2 =
-    tf2::Transform(
-    tf2::Quaternion(
-      msg.rotation.x, msg.rotation.y, msg.rotation.z,
-      msg.rotation.w),
-    tf2::Vector3(msg.translation.x, msg.translation.y, msg.translation.z));
-}
-
-/** \brief convert Transform to Transform msg*/
-void transformTF2ToMsg(const tf2::Transform & tf2, geometry_msgs::msg::Transform & msg)
-{
-  msg.translation.x = tf2.getOrigin().x();
-  msg.translation.y = tf2.getOrigin().y();
-  msg.translation.z = tf2.getOrigin().z();
-  msg.rotation.x = tf2.getRotation().x();
-  msg.rotation.y = tf2.getRotation().y();
-  msg.rotation.z = tf2.getRotation().z();
-  msg.rotation.w = tf2.getRotation().w();
-}
-
-/** \brief convert Transform to Transform msg*/
-void transformTF2ToMsg(
-  const tf2::Transform & tf2, geometry_msgs::msg::TransformStamped & msg,
-  builtin_interfaces::msg::Time stamp, const std::string & frame_id,
-  const std::string & child_frame_id)
-{
-  transformTF2ToMsg(tf2, msg.transform);
-  msg.header.stamp = stamp;
-  msg.header.frame_id = frame_id;
-  msg.child_frame_id = child_frame_id;
-}
-
-void transformTF2ToMsg(
-  const tf2::Quaternion & orient, const tf2::Vector3 & pos,
-  geometry_msgs::msg::Transform & msg)
-{
-  msg.translation.x = pos.x();
-  msg.translation.y = pos.y();
-  msg.translation.z = pos.z();
-  msg.rotation.x = orient.x();
-  msg.rotation.y = orient.y();
-  msg.rotation.z = orient.z();
-  msg.rotation.w = orient.w();
-}
-
-void transformTF2ToMsg(
-  const tf2::Quaternion & orient, const tf2::Vector3 & pos,
-  geometry_msgs::msg::TransformStamped & msg,
-  builtin_interfaces::msg::Time stamp, const std::string & frame_id,
-  const std::string & child_frame_id)
-{
-  transformTF2ToMsg(orient, pos, msg.transform);
-  msg.header.stamp = stamp;
-  msg.header.frame_id = frame_id;
-  msg.child_frame_id = child_frame_id;
-}
-
-void setIdentity(geometry_msgs::msg::Transform & tx)
-{
-  tx.translation.x = 0;
-  tx.translation.y = 0;
-  tx.translation.z = 0;
-  tx.rotation.x = 0;
-  tx.rotation.y = 0;
-  tx.rotation.z = 0;
-  tx.rotation.w = 1;
-}
 
 bool startsWithSlash(const std::string & frame_id)
 {
@@ -146,9 +78,6 @@ std::string stripSlash(const std::string & in)
   }
   return out;
 }
-
-namespace
-{
 
 void fillOrWarnMessageForInvalidFrame(
   const char * function_name_arg,

--- a/tf2/src/cache.cpp
+++ b/tf2/src/cache.cpp
@@ -28,8 +28,8 @@
 
 /** \author Tully Foote */
 
-#include <assert.h>
-
+#include <cassert>
+#include <sstream>
 #include <string>
 #include <utility>
 

--- a/tf2/src/time.cpp
+++ b/tf2/src/time.cpp
@@ -28,12 +28,54 @@
 
 /** \author Tully Foote */
 
+#include <chrono>
 #include <stdexcept>
 #include <string>
 
 #include "rcutils/snprintf.h"
 #include "rcutils/strerror.h"
 #include "tf2/time.h"
+
+tf2::TimePoint tf2::get_now()
+{
+  return std::chrono::system_clock::now();
+}
+
+tf2::Duration tf2::durationFromSec(double t_sec)
+{
+  int32_t sec, nsec;
+  sec = static_cast<int32_t>(floor(t_sec));
+  nsec = static_cast<int32_t>(std::round((t_sec - sec) * 1e9));
+  // avoid rounding errors
+  sec += (nsec / 1000000000l);
+  nsec %= 1000000000l;
+  return std::chrono::seconds(sec) + std::chrono::nanoseconds(nsec);
+}
+
+tf2::TimePoint tf2::timeFromSec(double t_sec)
+{
+  return tf2::TimePoint(durationFromSec(t_sec));
+}
+
+double tf2::durationToSec(const tf2::Duration & input)
+{
+  int64_t count = input.count();
+
+  // scale the nanoseconds separately for improved accuracy
+  int32_t sec, nsec;
+  nsec = static_cast<int32_t>(count % 1000000000l);
+  sec = static_cast<int32_t>((count - nsec) / 1000000000l);
+
+  double sec_double, nsec_double;
+  nsec_double = 1e-9 * static_cast<double>(nsec);
+  sec_double = static_cast<double>(sec);
+  return sec_double + nsec_double;
+}
+
+double tf2::timeToSec(const tf2::TimePoint & timepoint)
+{
+  return durationToSec(tf2::Duration(timepoint.time_since_epoch()));
+}
 
 std::string tf2::displayTimePoint(const tf2::TimePoint & stamp)
 {

--- a/tf2/src/time.cpp
+++ b/tf2/src/time.cpp
@@ -42,7 +42,7 @@ std::string tf2::displayTimePoint(const tf2::TimePoint & stamp)
 
   // Determine how many bytes to allocate for the string. If successful, buff_size does not count
   // null terminating character. http://www.cplusplus.com/reference/cstdio/snprintf/
-  int buff_size = rcutils_snprintf(NULL, 0, format_str, current_time);
+  int buff_size = rcutils_snprintf(nullptr, 0, format_str, current_time);
   if (buff_size < 0) {
     char errmsg[200];
     rcutils_strerror(errmsg, sizeof(errmsg));

--- a/tf2/test/cache_unittest.cpp
+++ b/tf2/test/cache_unittest.cpp
@@ -28,6 +28,7 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <cmath>
 #include <stdexcept>
 #include <string>

--- a/tf2/test/simple_tf2_core.cpp
+++ b/tf2/test/simple_tf2_core.cpp
@@ -28,11 +28,15 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <array>
 #include <chrono>
 #include <numeric>
 #include <string>
 #include <vector>
+
+#include "builtin_interfaces/msg/time.hpp"
+#include "geometry_msgs/msg/transform_stamped.hpp"
 
 #include "tf2/buffer_core.h"
 #include "tf2/convert.h"

--- a/tf2/test/static_cache_test.cpp
+++ b/tf2/test/static_cache_test.cpp
@@ -27,10 +27,12 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include <gtest/gtest.h>
-#include <tf2/time_cache.h>
+
+#include <chrono>
+#include <cmath>
 #include <stdexcept>
 
-#include <cmath>
+#include <tf2/time_cache.h>
 
 void setIdentity(tf2::TransformStorage & stor)
 {


### PR DESCRIPTION
This series of patches aims to do a bit of minor cleanup on the code in tf2.  There should be no functional change with this in place.  The changes include:

1. Removing a long-deprecated function overload
2. Removal of an unnecessary internal function
3. Include-what-you-use in a few places
4. Use `foo.empty()` instead of `foo == ""`
5. Use `std::make_shared` where possible
6. Replace NULL with nullptr
7. Remove unused code
8. Switch to C++ style casts
9. Move some functions from a header file to the C++ file