### PR TITLE
tf2: Enable common linter tests

### DIFF
--- a/tf2/CMakeLists.txt
+++ b/tf2/CMakeLists.txt
@@ -72,8 +72,8 @@ if(BUILD_TESTING)
   ament_cpplint(EXCLUDE ${_linter_excludes})
   ament_lint_cmake()
   ament_uncrustify(
-      EXCLUDE ${_linter_excludes}
-      LANGUAGE c++
+    EXCLUDE ${_linter_excludes}
+    LANGUAGE c++
   )
   ament_xmllint()
 

--- a/tf2/CMakeLists.txt
+++ b/tf2/CMakeLists.txt
@@ -45,9 +45,39 @@ install(DIRECTORY include/${PROJECT_NAME}/
 
 # Tests
 if(BUILD_TESTING)
-  # TODO(clalancette) enable linters once https://github.com/ament/ament_lint/pull/238 lands
+  find_package(ament_cmake_copyright REQUIRED)
+  find_package(ament_cmake_cppcheck REQUIRED)
+  find_package(ament_cmake_cpplint REQUIRED)
+  find_package(ament_cmake_lint_cmake REQUIRED)
+  find_package(ament_cmake_uncrustify REQUIRED)
+  find_package(ament_cmake_xmllint REQUIRED)
 
-  find_package(ament_cmake_gtest)
+  # Should not lint external code
+  set(
+    _linter_excludes
+    include/tf2/LinearMath/Matrix3x3.h
+    include/tf2/LinearMath/MinMax.h
+    include/tf2/LinearMath/QuadWord.h
+    include/tf2/LinearMath/Quaternion.h
+    include/tf2/LinearMath/Scalar.h
+    include/tf2/LinearMath/Transform.h
+    include/tf2/LinearMath/Vector3.h
+  )
+
+  ament_copyright(EXCLUDE ${_linter_excludes})
+  ament_cppcheck(
+    EXCLUDE ${_linter_excludes}
+    LANGUAGE c++
+  )
+  ament_cpplint(EXCLUDE ${_linter_excludes})
+  ament_lint_cmake()
+  ament_uncrustify(
+      EXCLUDE ${_linter_excludes}
+      LANGUAGE c++
+  )
+  ament_xmllint()
+
+  find_package(ament_cmake_gtest REQUIRED)
 
   ament_add_gtest(test_cache_unittest test/cache_unittest.cpp)
   if(TARGET test_cache_unittest)

--- a/tf2/include/tf2/convert.h
+++ b/tf2/include/tf2/convert.h
@@ -165,7 +165,8 @@ void convert(const A & a1, A & a2)
  * \return A nested array representation of 6x6 covariance values.
  */
 inline
-std::array<std::array<double, 6>, 6> covarianceRowMajorToNested(const std::array<double, 36> & row_major)
+std::array<std::array<double, 6>, 6> covarianceRowMajorToNested(
+  const std::array<double, 36> & row_major)
 {
   std::array<std::array<double, 6>, 6> nested_array;
   std::array<double, 36>::const_iterator ss = row_major.begin();
@@ -182,7 +183,8 @@ std::array<std::array<double, 6>, 6> covarianceRowMajorToNested(const std::array
  * \return A row-major array of 36 covariance values.
  */
 inline
-std::array<double, 36> covarianceNestedToRowMajor(const std::array<std::array<double, 6>, 6> & nested_array)
+std::array<double, 36> covarianceNestedToRowMajor(
+  const std::array<std::array<double, 6>, 6> & nested_array)
 {
   std::array<double, 36> row_major = {};
   size_t counter = 0;

--- a/tf2/include/tf2/transform_datatypes.h
+++ b/tf2/include/tf2/transform_datatypes.h
@@ -97,7 +97,7 @@ class WithCovarianceStamped : public T
 public:
   TimePoint stamp_;   ///< The timestamp associated with this data
   std::string frame_id_;   ///< The frame_id associated this data
-  std::array<std::array<double, 6>, 6> cov_mat_;  ///< The covariance matrix associated with this data
+  std::array<std::array<double, 6>, 6> cov_mat_;  ///< The covariance matrix associated with this data // NOLINT
 
   /** Default constructor */
   WithCovarianceStamped()

--- a/tf2/package.xml
+++ b/tf2/package.xml
@@ -29,8 +29,12 @@
   <depend>rcutils</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_copyright</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
+  <test_depend>ament_cmake_cpplint</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_uncrustify</test_depend>
+  <test_depend>ament_cmake_xmllint</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -734,7 +734,10 @@ bool BufferCore::canTransformInternal(
   }
 
   CanTransformAccum accum;
-  if (walkToTopParent(accum, time, target_id, source_id, error_msg, nullptr) == tf2::TF2Error::TF2_NO_ERROR) {
+  if (walkToTopParent(
+      accum, time, target_id, source_id,
+      error_msg, nullptr) == tf2::TF2Error::TF2_NO_ERROR)
+  {
     return true;
   }
 
@@ -1209,8 +1212,9 @@ void BufferCore::cancelTransformableRequest(TransformableRequestHandle handle)
   std::unique_lock<std::mutex> tr_lock(transformable_requests_mutex_);
   std::unique_lock<std::mutex> tc_lock(transformable_callbacks_mutex_);
 
-  V_TransformableRequest::iterator remove_it = std::remove_if(transformable_requests_.begin(), transformable_requests_.end(),
-                                                              [handle](TransformableRequest req) { return handle == req.request_handle; });
+  V_TransformableRequest::iterator remove_it = std::remove_if(
+    transformable_requests_.begin(), transformable_requests_.end(),
+    [handle](TransformableRequest req) {return handle == req.request_handle;});
   for (V_TransformableRequest::iterator it = remove_it; it != transformable_requests_.end(); ++it) {
     transformable_callbacks_.erase(it->cb_handle);
   }
@@ -1345,7 +1349,9 @@ std::string BufferCore::_allFramesAsDot(TimePoint current_time) const
       frame_id_num = temp.frame_id_;
     }
     std::string authority = "no recorded authority";
-    std::map<CompactFrameID, std::string>::const_iterator it = frame_authority_.find(static_cast<CompactFrameID>(counter));
+    std::map<CompactFrameID,
+      std::string>::const_iterator it =
+      frame_authority_.find(static_cast<CompactFrameID>(counter));
     if (it != frame_authority_.end()) {
       authority = it->second;
     }

--- a/tf2/test/simple_tf2_core.cpp
+++ b/tf2/test/simple_tf2_core.cpp
@@ -81,12 +81,12 @@ TEST(tf2, setTransformValidWithCallback)
 
   auto cb =
     [&received_request_handle, &received_target_frame, &received_source_frame, &received_time_point,
-    &transform_available](
-      tf2::TransformableRequestHandle request_handle,
-      const std::string & target_frame,
-      const std::string & source_frame,
-      tf2::TimePoint time,
-      tf2::TransformableResult result)
+      &transform_available](
+    tf2::TransformableRequestHandle request_handle,
+    const std::string & target_frame,
+    const std::string & source_frame,
+    tf2::TimePoint time,
+    tf2::TransformableResult result)
     {
       received_request_handle = request_handle;
       received_target_frame = target_frame;
@@ -287,8 +287,7 @@ TEST(tf2_convert, Covariance_RowMajor_To_Nested)
   // setup the expected output
   std::array<std::array<double, 6>, 6> expected;
   double start = 0;
-  for (std::array<double, 6> & ee : expected)
-  {
+  for (std::array<double, 6> & ee : expected) {
     std::iota(ee.begin(), ee.end(), start);
     start += static_cast<double>(ee.size());
   }

--- a/tf2/test/static_cache_test.cpp
+++ b/tf2/test/static_cache_test.cpp
@@ -26,13 +26,13 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include <tf2/time_cache.h>
+
 #include <gtest/gtest.h>
 
 #include <chrono>
 #include <cmath>
 #include <stdexcept>
-
-#include <tf2/time_cache.h>
 
 void setIdentity(tf2::TransformStorage & stor)
 {

--- a/tf2/test/test_time.cpp
+++ b/tf2/test/test_time.cpp
@@ -1,31 +1,30 @@
-/*
- * Copyright (c) 2020, Open Source Robotics Foundation, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *     * Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in the
- *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the Willow Garage, Inc. nor the names of its
- *       contributors may be used to endorse or promote products derived from
- *       this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+// Copyright (c) 2020, Open Source Robotics Foundation, Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Willow Garage nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #include <gtest/gtest.h>
 #include <chrono>


### PR DESCRIPTION
As discussed in https://github.com/ros2/geometry2/pull/467, this PR:

- Enables a subset of relevant linter tests from `ament_lint_common` in `tf2`.
- Excludes LinearMath headers (include/tf2/LinearMath) from being linted.
- Fixes line-length formatting issues in a few source files, so that there are no lint failures in the current state.

Note that individual linters had to be invoked rather than use `ament_lint_auto` because the LinearMath headers should not have linters run on them - see https://github.com/ros2/geometry2/pull/258#issuecomment-621499030 for more information - and because `ament_lint_auto` does not provide a general way of providing file exclusion lists.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>