### PR TITLE
Hide canTransform console output

### DIFF
--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -35,6 +35,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <string.h>
 
 #include "tf2/buffer_core.h"
 #include "tf2/time_cache.h"

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -30,12 +30,12 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstring>
 #include <map>
 #include <mutex>
 #include <string>
 #include <utility>
 #include <vector>
-#include <string.h>
 
 #include "tf2/buffer_core.h"
 #include "tf2/time_cache.h"
@@ -178,7 +178,7 @@ CompactFrameID BufferCore::validateFrameId(
   }
 
   CompactFrameID id = lookupFrameNumber(frame_id);
-  if (id == 0 && strstr(function_name_arg, "canTransform") == NULL) {
+  if (id == 0 && strstr(function_name_arg, "canTransform") == nullptr) {
     fillOrWarnMessageForInvalidFrame(
       function_name_arg, frame_id, error_msg, "frame does not exist");
   }

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -177,7 +177,7 @@ CompactFrameID BufferCore::validateFrameId(
   }
 
   CompactFrameID id = lookupFrameNumber(frame_id);
-  if (id == 0) {
+  if (id == 0 && std::strstr(function_name_arg, "canTransform") == NULL) {
     fillOrWarnMessageForInvalidFrame(
       function_name_arg, frame_id, error_msg, "frame does not exist");
   }

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -178,7 +178,7 @@ CompactFrameID BufferCore::validateFrameId(
   }
 
   CompactFrameID id = lookupFrameNumber(frame_id);
-  if (id == 0 && std::strstr(function_name_arg, "canTransform") == NULL) {
+  if (id == 0 && strstr(function_name_arg, "canTransform") == NULL) {
     fillOrWarnMessageForInvalidFrame(
       function_name_arg, frame_id, error_msg, "frame does not exist");
   }


### PR DESCRIPTION
I got sick of seeing `canTransform` spam the terminal with the message:

```
Warning: Invalid frame ID "robot/base_link" passed to canTransform argument source_frame - frame does not exist
at line 156 in /Users/steve/Documents/ros2_galactic/src/ros2/geometry2/tf2/src/buffer_core.cpp
```

Obviously its desired behavior that canTransform should be checking for frames that don't exist yet. I'm sure there are cleaner ways of doing this but here is my method. Relevant issue is https://github.com/ros2/geometry2/issues/405.