### PR TITLE
Depend on orocos_kdl_vendor 

### DIFF
--- a/tf2_eigen_kdl/include/tf2_eigen_kdl/tf2_eigen_kdl.hpp
+++ b/tf2_eigen_kdl/include/tf2_eigen_kdl/tf2_eigen_kdl.hpp
@@ -37,8 +37,21 @@
 #ifndef TF2_EIGEN_KDL__TF2_EIGEN_KDL_HPP_
 #define TF2_EIGEN_KDL__TF2_EIGEN_KDL_HPP_
 
+// Version 3.4.0 of Eigen in Ubuntu 22.04 has a bug that causes -Wclass-memaccess warnings on
+// aarch64.  Upstream Eigen has already fixed this in
+// https://gitlab.com/libeigen/eigen/-/merge_requests/645 .  The Debian fix for this is in
+// https://salsa.debian.org/science-team/eigen3/-/merge_requests/1 .
+// However, it is not clear that that fix is going to make it into Ubuntu 22.04 before it
+// freezes, so disable the warning here.
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif
 #include <Eigen/Core>
 #include <Eigen/Geometry>
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 #include "kdl/frames.hpp"
 

--- a/tf2_eigen_kdl/package.xml
+++ b/tf2_eigen_kdl/package.xml
@@ -19,7 +19,7 @@
   <build_depend>eigen</build_depend>
   <build_export_depend>eigen</build_export_depend>
 
-  <depend>orocos_kdl</depend>
+  <depend>orocos_kdl_vendor</depend>
   <depend>tf2</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>

--- a/tf2_geometry_msgs/CMakeLists.txt
+++ b/tf2_geometry_msgs/CMakeLists.txt
@@ -20,7 +20,8 @@ ament_python_install_package(${PROJECT_NAME}
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME} INTERFACE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+  ${orocos_kdl_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME} INTERFACE
   ${geometry_msgs_TARGETS}
   orocos-kdl

--- a/tf2_geometry_msgs/package.xml
+++ b/tf2_geometry_msgs/package.xml
@@ -14,7 +14,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>geometry_msgs</depend>
-  <depend>orocos_kdl</depend>
+  <depend>orocos_kdl_vendor</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
 

--- a/tf2_kdl/CMakeLists.txt
+++ b/tf2_kdl/CMakeLists.txt
@@ -29,7 +29,8 @@ target_link_libraries(tf2_kdl INTERFACE
   tf2_ros::tf2_ros)
 target_include_directories(tf2_kdl INTERFACE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+  ${orocos_kdl_INCLUDE_DIRS})
 
 install(TARGETS tf2_kdl EXPORT export_tf2_kdl)
 
@@ -61,5 +62,6 @@ ament_export_include_directories("include/${PROJECT_NAME}")
 # Export modern CMake targets
 ament_export_targets(export_tf2_kdl)
 
-ament_export_dependencies(builtin_interfaces geometry_msgs orocos_kdl tf2 tf2_ros)
+ament_export_dependencies(builtin_interfaces geometry_msgs orocos_kdl_vendor tf2 tf2_ros)
+
 ament_package()

--- a/tf2_kdl/package.xml
+++ b/tf2_kdl/package.xml
@@ -15,7 +15,7 @@
 
   <depend>builtin_interfaces</depend>
   <depend>geometry_msgs</depend>
-  <depend>orocos_kdl</depend>
+  <depend>orocos_kdl_vendor</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
 


### PR DESCRIPTION
* Change package.xml dependency to the vendor package
* Add missing include directories for orocos_kdl
* Install tf2_kdl as a header-only target

Connects to https://github.com/ros2/ros2/pull/1208