### PR TITLE
Fix invalid timer handle exception

### DIFF
--- a/tf2_ros/src/buffer.cpp
+++ b/tf2_ros/src/buffer.cpp
@@ -302,9 +302,9 @@ Buffer::timerCallback(
     timer_is_valid = (timer_to_request_map_.end() != timer_and_request_it);
     if (timer_is_valid) {
       request_handle = timer_and_request_it->second;
+      timer_to_request_map_.erase(timer_handle);
+      timer_interface_->remove(timer_handle);
     }
-    timer_to_request_map_.erase(timer_handle);
-    timer_interface_->remove(timer_handle);
   }
 
   if (timer_is_valid) {

--- a/tf2_ros/test/test_buffer.cpp
+++ b/tf2_ros/test/test_buffer.cpp
@@ -111,7 +111,9 @@ public:
     tf2_ros::TimerCallbackType callback) override
   {
     auto timer_handle_index = next_timer_handle_index_++;
-    auto timer_callback = std::bind(&MockCreateTimerROS::timerCallback, this, timer_handle_index, callback);
+    auto timer_callback = std::bind(
+      &MockCreateTimerROS::timerCallback, this, timer_handle_index,
+      callback);
     timer_to_callback_map_[timer_handle_index] = timer_callback;
     return tf2_ros::CreateTimerROS::createTimer(clock, period, callback);
   }
@@ -119,8 +121,7 @@ public:
   void
   execute_timers()
   {
-    for (const auto & elem : timer_to_callback_map_)
-    {
+    for (const auto & elem : timer_to_callback_map_) {
       elem.second(elem.first);
     }
   }
@@ -387,9 +388,10 @@ TEST(test_buffer, wait_for_transform_race)
 TEST(test_buffer, timer_ros_wait_for_transform_race)
 {
   int argc = 1;
-  char const *const argv[] ={"timer_ros_wait_for_transform_race"};
+  char const * const argv[] = {"timer_ros_wait_for_transform_race"};
   rclcpp::init(argc, argv);
-  std::shared_ptr<rclcpp::Node> rclcpp_node_ = std::make_shared<rclcpp::Node>("timer_ros_wait_for_transform_race");
+  std::shared_ptr<rclcpp::Node> rclcpp_node_ = std::make_shared<rclcpp::Node>(
+    "timer_ros_wait_for_transform_race");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
   tf2_ros::Buffer buffer(clock);

--- a/tf2_ros/test/test_buffer.cpp
+++ b/tf2_ros/test/test_buffer.cpp
@@ -430,7 +430,7 @@ TEST(test_buffer, timer_ros_wait_for_transform_race)
   EXPECT_TRUE(buffer.setTransform(transform, "unittest"));
 
   // Fake a time out (race with setTransform above)
-  mock_create_timer_ros->execute_timers();
+  EXPECT_NO_THROW(mock_create_timer_ros->execute_timers());
 
   EXPECT_TRUE(buffer.canTransform("bar", "foo", tf2_time));
   EXPECT_TRUE(buffer.canTransform("bar", "foo", rclcpp_time));

--- a/tf2_ros/test/test_buffer.cpp
+++ b/tf2_ros/test/test_buffer.cpp
@@ -384,6 +384,61 @@ TEST(test_buffer, wait_for_transform_race)
   EXPECT_FALSE(callback_timeout);
 }
 
+TEST(test_buffer, timer_ros_wait_for_transform_race)
+{
+  int argc = 1;
+  char const *const argv[] ={"timer_ros_wait_for_transform_race"};
+  rclcpp::init(argc, argv);
+  std::shared_ptr<rclcpp::Node> rclcpp_node_ = std::make_shared<rclcpp::Node>("timer_ros_wait_for_transform_race");
+
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+  tf2_ros::Buffer buffer(clock);
+  // Silence error about dedicated thread's being necessary
+  buffer.setUsingDedicatedThread(true);
+  auto mock_create_timer_ros = std::make_shared<MockCreateTimerROS>(
+    rclcpp_node_->get_node_base_interface(),
+    rclcpp_node_->get_node_timers_interface());
+  buffer.setCreateTimerInterface(mock_create_timer_ros);
+
+  rclcpp::Time rclcpp_time = clock->now();
+  tf2::TimePoint tf2_time(std::chrono::nanoseconds(rclcpp_time.nanoseconds()));
+
+  bool callback_timeout = false;
+  auto future = buffer.waitForTransform(
+    "foo",
+    "bar",
+    tf2_time, tf2::durationFromSec(1.0),
+    [&callback_timeout](const tf2_ros::TransformStampedFuture & future)
+    {
+      try {
+        // We don't expect this throw, even though a timeout will occur
+        future.get();
+      } catch (...) {
+        callback_timeout = true;
+      }
+    });
+
+  auto status = future.wait_for(std::chrono::milliseconds(1));
+  EXPECT_EQ(status, std::future_status::timeout);
+
+  // Set the valid transform during the timeout
+  geometry_msgs::msg::TransformStamped transform;
+  transform.header.frame_id = "foo";
+  transform.header.stamp = builtin_interfaces::msg::Time(rclcpp_time);
+  transform.child_frame_id = "bar";
+  transform.transform.rotation.w = 1.0;
+  EXPECT_TRUE(buffer.setTransform(transform, "unittest"));
+
+  // Fake a time out (race with setTransform above)
+  mock_create_timer_ros->execute_timers();
+
+  EXPECT_TRUE(buffer.canTransform("bar", "foo", tf2_time));
+  EXPECT_TRUE(buffer.canTransform("bar", "foo", rclcpp_time));
+  status = future.wait_for(std::chrono::milliseconds(1));
+  EXPECT_EQ(status, std::future_status::ready);
+  EXPECT_FALSE(callback_timeout);
+}
+
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
- This PR try to fix invalid timer handle exception caused by removing handle repeatedly.
- This issue is found when using [Nav2 ](https://github.com/ros-planning/navigation2)and set a small `transform_tolerance` for `local_costmap` and `global_costmap`.
- Specific error messages are as follows:
  ```
  [server-9] [planner_server-4] terminate called after throwing an instance of 'tf2_ros::InvalidTimerHandleException'
  [server-9] [planner_server-4]   what():  Invalid timer handle in remove()
  ```
- We found this exception is thrown from https://github.com/ros2/geometry2/blob/16562cee8694c11f1f82b2bdbde2814fca1c7954/tf2_ros/src/create_timer_ros.cpp#L93
- If adding more messages for debug, we found that there is a high probability that handle will be removed repeatedly.
  ```
  [server-9] [planner_server-4] [INFO] [1636089969.121297887] [tf2_buffer]: [cliff] remove@217, it->first=286, this->timer_interface_=0x55eee89ff140
  [server-9] [planner_server-4] [INFO] [1636089969.126648738] [tf2_buffer]: [cliff] remove@286, timer_handle=286, timer_interface_=0x55eee89ff140
  [server-9] [planner_server-4] terminate called after throwing an instance of 'tf2_ros::InvalidTimerHandleException'
  [server-9] [planner_server-4]   what():  Invalid timer handle in remove()
  ```
- Therefore, we have made a change to ensure that `timer_handle` only can be removed when it can be found in `timer_to_request_map_`