### PR TITLE
Fix Buffer destruct race condition  

### DIFF
--- a/test_tf2/test/test_buffer_server.cpp
+++ b/test_tf2/test/test_buffer_server.cpp
@@ -47,9 +47,9 @@ int main(int argc, char** argv)
   auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock);
-  tf2_ros::TransformListener tfl(buffer, node, false);
-  std::unique_ptr<tf2_ros::BufferServer> server = std::make_unique<tf2_ros::BufferServer>(buffer, node, "tf_action");
+  std::shared_ptr<tf2_ros::Buffer> buffer = tf2_ros::Buffer::make(clock);
+  tf2_ros::TransformListener tfl(*buffer, node, false);
+  std::unique_ptr<tf2_ros::BufferServer> server = std::make_unique<tf2_ros::BufferServer>(*buffer, node, "tf_action");
 
   rclcpp::spin(node);
 }

--- a/test_tf2/test/test_static_publisher.cpp
+++ b/test_tf2/test/test_static_publisher.cpp
@@ -53,8 +53,9 @@ TEST(StaticTransformPublisher, a_b_different_times)
   auto node = rclcpp::Node::make_shared("StaticTransformPublisher_a_b_different_times_test");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer mB(clock);
-  tf2_ros::TransformListener tfl(mB, node, false);
+  std::shared_ptr<tf2_ros::Buffer> mB = tf2_ros::Buffer::make(clock);
+  ASSERT_NE(nullptr, mB);
+  tf2_ros::TransformListener tfl(*mB, node, false);
 
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(node);
@@ -64,7 +65,7 @@ TEST(StaticTransformPublisher, a_b_different_times)
 
   int attempts = 0;
 
-  while (!mB.canTransform("a", "b", tf2::timeFromSec(0))) {
+  while (!mB->canTransform("a", "b", tf2::timeFromSec(0))) {
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
     attempts++;
     if (attempts > MAX_ATTEMPTS) {
@@ -72,9 +73,9 @@ TEST(StaticTransformPublisher, a_b_different_times)
     }
   }
 
-  EXPECT_TRUE(mB.canTransform("a", "b", tf2::timeFromSec(0)));
-  EXPECT_TRUE(mB.canTransform("a", "b", tf2::timeFromSec(100)));
-  EXPECT_TRUE(mB.canTransform("a", "b", tf2::timeFromSec(1000)));
+  EXPECT_TRUE(mB->canTransform("a", "b", tf2::timeFromSec(0)));
+  EXPECT_TRUE(mB->canTransform("a", "b", tf2::timeFromSec(100)));
+  EXPECT_TRUE(mB->canTransform("a", "b", tf2::timeFromSec(1000)));
 
   executor.cancel();
   spin_thread.join();
@@ -86,8 +87,9 @@ TEST(StaticTransformPublisher, a_c_different_times)
   auto node = rclcpp::Node::make_shared("StaticTransformPublisher_a_c_different_times_test");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer mB(clock);
-  tf2_ros::TransformListener tfl(mB, node, false);
+  std::shared_ptr<tf2_ros::Buffer> mB = tf2_ros::Buffer::make(clock);
+  ASSERT_NE(nullptr, mB);
+  tf2_ros::TransformListener tfl(*mB, node, false);
 
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(node);
@@ -96,7 +98,7 @@ TEST(StaticTransformPublisher, a_c_different_times)
     std::bind(&rclcpp::executors::SingleThreadedExecutor::spin, &executor));
 
   int attempts = 0;
-  while (!mB.canTransform("a", "c", tf2::timeFromSec(0))) {
+  while (!mB->canTransform("a", "c", tf2::timeFromSec(0))) {
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
     attempts++;
     if (attempts > MAX_ATTEMPTS) {
@@ -104,9 +106,9 @@ TEST(StaticTransformPublisher, a_c_different_times)
     }
   }
 
-  EXPECT_TRUE(mB.canTransform("a", "c", tf2::timeFromSec(0)));
-  EXPECT_TRUE(mB.canTransform("a", "c", tf2::timeFromSec(10)));
-  EXPECT_TRUE(mB.canTransform("a", "c", tf2::timeFromSec(1000)));
+  EXPECT_TRUE(mB->canTransform("a", "c", tf2::timeFromSec(0)));
+  EXPECT_TRUE(mB->canTransform("a", "c", tf2::timeFromSec(10)));
+  EXPECT_TRUE(mB->canTransform("a", "c", tf2::timeFromSec(1000)));
 
   executor.cancel();
   spin_thread.join();
@@ -118,8 +120,9 @@ TEST(StaticTransformPublisher, a_d_different_times)
   auto node = rclcpp::Node::make_shared("StaticTransformPublisher_a_d_different_times_test");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer mB(clock);
-  tf2_ros::TransformListener tfl(mB, node, false);
+  std::shared_ptr<tf2_ros::Buffer> mB = tf2_ros::Buffer::make(clock);
+  ASSERT_NE(nullptr, mB);
+  tf2_ros::TransformListener tfl(*mB, node, false);
 
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(node);
@@ -129,7 +132,7 @@ TEST(StaticTransformPublisher, a_d_different_times)
 
   int attempts = 0;
 
-  while (!mB.canTransform("a", "c", tf2::timeFromSec(0))) {
+  while (!mB->canTransform("a", "c", tf2::timeFromSec(0))) {
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
     attempts++;
     if (attempts > MAX_ATTEMPTS) {
@@ -144,18 +147,18 @@ TEST(StaticTransformPublisher, a_d_different_times)
   ts.child_frame_id = "d";
 
   // make sure listener has populated
-  EXPECT_TRUE(mB.canTransform("a", "c", tf2::timeFromSec(0)));
-  EXPECT_TRUE(mB.canTransform("a", "c", tf2::timeFromSec(100)));
-  EXPECT_TRUE(mB.canTransform("a", "c", tf2::timeFromSec(1000)));
+  EXPECT_TRUE(mB->canTransform("a", "c", tf2::timeFromSec(0)));
+  EXPECT_TRUE(mB->canTransform("a", "c", tf2::timeFromSec(100)));
+  EXPECT_TRUE(mB->canTransform("a", "c", tf2::timeFromSec(1000)));
 
-  mB.setTransform(ts, "authority");
+  mB->setTransform(ts, "authority");
   //printf("%s\n", mB.allFramesAsString().c_str());
-  EXPECT_TRUE(mB.canTransform("c", "d", tf2::timeFromSec(10)));
+  EXPECT_TRUE(mB->canTransform("c", "d", tf2::timeFromSec(10)));
 
-  EXPECT_TRUE(mB.canTransform("a", "d", tf2::timeFromSec(0)));
-  EXPECT_FALSE(mB.canTransform("a", "d", tf2::timeFromSec(1)));
-  EXPECT_TRUE(mB.canTransform("a", "d", tf2::timeFromSec(10)));
-  EXPECT_FALSE(mB.canTransform("a", "d", tf2::timeFromSec(1000)));
+  EXPECT_TRUE(mB->canTransform("a", "d", tf2::timeFromSec(0)));
+  EXPECT_FALSE(mB->canTransform("a", "d", tf2::timeFromSec(1)));
+  EXPECT_TRUE(mB->canTransform("a", "d", tf2::timeFromSec(10)));
+  EXPECT_FALSE(mB->canTransform("a", "d", tf2::timeFromSec(1000)));
 
   executor.cancel();
   spin_thread.join();
@@ -167,8 +170,9 @@ TEST(StaticTransformPublisher, multiple_parent_test)
   auto node = rclcpp::Node::make_shared("StaticTransformPublisher_a_d_different_times_test");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer mB(clock);
-  tf2_ros::TransformListener tfl(mB, node, false);
+  std::shared_ptr<tf2_ros::Buffer> mB = tf2_ros::Buffer::make(clock);
+  ASSERT_NE(nullptr, mB);
+  tf2_ros::TransformListener tfl(*mB, node, false);
 
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(node);
@@ -178,7 +182,7 @@ TEST(StaticTransformPublisher, multiple_parent_test)
 
   int attempts = 0;
 
-  while (!mB.canTransform("a", "b", tf2::timeFromSec(0))) {
+  while (!mB->canTransform("a", "b", tf2::timeFromSec(0))) {
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
     attempts++;
     if (attempts > MAX_ATTEMPTS) {
@@ -198,9 +202,9 @@ TEST(StaticTransformPublisher, multiple_parent_test)
   std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
   // make sure listener has populated
-  EXPECT_TRUE(mB.canTransform("a", "d", tf2::timeFromSec(0)));
-  EXPECT_TRUE(mB.canTransform("a", "d", tf2::timeFromSec(100)));
-  EXPECT_TRUE(mB.canTransform("a", "d", tf2::timeFromSec(1000)));
+  EXPECT_TRUE(mB->canTransform("a", "d", tf2::timeFromSec(0)));
+  EXPECT_TRUE(mB->canTransform("a", "d", tf2::timeFromSec(100)));
+  EXPECT_TRUE(mB->canTransform("a", "d", tf2::timeFromSec(1000)));
 
   // Publish new transform with child 'd', should replace old one in static tf
   ts.header.frame_id = "new_parent";
@@ -212,10 +216,10 @@ TEST(StaticTransformPublisher, multiple_parent_test)
 
   std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
-  EXPECT_TRUE(mB.canTransform("new_parent", "d", tf2::timeFromSec(0)));
-  EXPECT_TRUE(mB.canTransform("new_parent", "other_child", tf2::timeFromSec(0)));
-  EXPECT_TRUE(mB.canTransform("new_parent", "other_child2", tf2::timeFromSec(0)));
-  EXPECT_FALSE(mB.canTransform("a", "d", tf2::timeFromSec(0)));
+  EXPECT_TRUE(mB->canTransform("new_parent", "d", tf2::timeFromSec(0)));
+  EXPECT_TRUE(mB->canTransform("new_parent", "other_child", tf2::timeFromSec(0)));
+  EXPECT_TRUE(mB->canTransform("new_parent", "other_child2", tf2::timeFromSec(0)));
+  EXPECT_FALSE(mB->canTransform("a", "d", tf2::timeFromSec(0)));
 
   executor.cancel();
   spin_thread.join();

--- a/test_tf2/test/test_tf2_bullet.cpp
+++ b/test_tf2/test/test_tf2_bullet.cpp
@@ -35,7 +35,7 @@
 #include <gtest/gtest.h>
 #include <tf2/convert.h>
 
-std::unique_ptr<tf2_ros::Buffer> tf_buffer = nullptr;
+std::shared_ptr<tf2_ros::Buffer> tf_buffer = nullptr;
 static const double EPS = 1e-3;
 
 TEST(TfBullet, Transform)
@@ -81,7 +81,7 @@ int main(int argc, char **argv){
   auto node = rclcpp::Node::make_shared("test_tf2_bullet");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf_buffer = std::make_unique<tf2_ros::Buffer>(clock);
+  tf_buffer = tf2_ros::Buffer::make(clock);
 
   // populate buffer
   geometry_msgs::msg::TransformStamped t;

--- a/tf2_eigen/test/tf2_eigen-test.cpp
+++ b/tf2_eigen/test/tf2_eigen-test.cpp
@@ -149,7 +149,7 @@ struct EigenBufferTransform : public ::testing::Test
   static void SetUpTestSuite()
   {
     rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-    tf_buffer = std::make_unique<tf2_ros::Buffer>(clock);
+    tf_buffer = tf2_ros::Buffer::make(clock);
     tf_buffer->setUsingDedicatedThread(true);
 
     // populate buffer
@@ -173,11 +173,11 @@ struct EigenBufferTransform : public ::testing::Test
   ::testing::AssertionResult doTestEigenQuaternion(
     const Eigen::Quaterniond & parameter, const Eigen::Quaterniond & expected);
 
-  static std::unique_ptr<tf2_ros::Buffer> tf_buffer;
+  static std::shared_ptr<tf2_ros::Buffer> tf_buffer;
   static constexpr double EPS = 1e-3;
 };
 
-std::unique_ptr<tf2_ros::Buffer> EigenBufferTransform::tf_buffer;
+std::shared_ptr<tf2_ros::Buffer> EigenBufferTransform::tf_buffer;
 
 template<int mode>
 void EigenBufferTransform::testEigenTransform()

--- a/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
+++ b/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
@@ -46,7 +46,7 @@
 #include <memory>
 #include <string>
 
-std::unique_ptr<tf2_ros::Buffer> tf_buffer = nullptr;
+std::shared_ptr<tf2_ros::Buffer> tf_buffer = nullptr;
 static const double EPS = 1e-3;
 
 geometry_msgs::msg::TransformStamped generate_stamped_transform()
@@ -544,7 +544,7 @@ int main(int argc, char ** argv)
   testing::InitGoogleTest(&argc, argv);
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf_buffer = std::make_unique<tf2_ros::Buffer>(clock);
+  tf_buffer = tf2_ros::Buffer::make(clock);
   tf_buffer->setUsingDedicatedThread(true);
 
   // populate buffer

--- a/tf2_kdl/test/test_tf2_kdl.cpp
+++ b/tf2_kdl/test/test_tf2_kdl.cpp
@@ -45,7 +45,7 @@
 #include "tf2_ros/buffer.h"
 #include <tf2/convert.h>
 
-std::unique_ptr<tf2_ros::Buffer> tf_buffer;
+std::shared_ptr<tf2_ros::Buffer> tf_buffer;
 static const double EPS = 1e-3;
 
 TEST(TfKDL, Frame)
@@ -218,7 +218,7 @@ int main(int argc, char **argv){
   testing::InitGoogleTest(&argc, argv);
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf_buffer = std::make_unique<tf2_ros::Buffer>(clock);
+  tf_buffer = tf2_ros::Buffer::make(clock);
 
   // populate buffer
   geometry_msgs::msg::TransformStamped t;

--- a/tf2_ros/include/tf2_ros/buffer.h
+++ b/tf2_ros/include/tf2_ros/buffer.h
@@ -58,21 +58,35 @@ namespace tf2_ros
  * Stores known frames and offers a ROS service, "tf_frames", which responds to client requests
  * with a response containing a tf2_msgs::FrameGraph representing the relationship of known frames.
  */
-class Buffer : public BufferInterface, public AsyncBufferInterface, public tf2::BufferCore
+class Buffer : public BufferInterface, public AsyncBufferInterface, public tf2::BufferCore,
+  public std::enable_shared_from_this<Buffer>
 {
 public:
   using tf2::BufferCore::lookupTransform;
   using tf2::BufferCore::canTransform;
 
-  /** \brief  Constructor for a Buffer object
+  /** \brief Factory function to create a shared Buffer object.
    * \param clock A clock to use for time and sleeping
    * \param cache_time How long to keep a history of transforms
    * \param node If passed advertise the view_frames service that exposes debugging information from the buffer
    */
-  TF2_ROS_PUBLIC Buffer(
+  TF2_ROS_PUBLIC
+  static
+  std::shared_ptr<Buffer> make(
     rclcpp::Clock::SharedPtr clock,
     tf2::Duration cache_time = tf2::Duration(tf2::BUFFER_CORE_DEFAULT_CACHE_TIME),
     rclcpp::Node::SharedPtr node = rclcpp::Node::SharedPtr());
+
+  // /** \brief  Constructor for a Buffer object
+  //  * \param clock A clock to use for time and sleeping
+  //  * \param cache_time How long to keep a history of transforms
+  //  * \param node If passed advertise the view_frames service that exposes debugging
+  //  information from the buffer
+  //  */
+  // TF2_ROS_PUBLIC Buffer(
+  //   rclcpp::Clock::SharedPtr clock,
+  //   tf2::Duration cache_time = tf2::Duration(tf2::BUFFER_CORE_DEFAULT_CACHE_TIME),
+  //   rclcpp::Node::SharedPtr node = rclcpp::Node::SharedPtr());
 
   /** \brief Get the transform between two frames by frame ID.
    * \param target_frame The frame to which data should be transformed
@@ -260,6 +274,11 @@ public:
   }
 
 private:
+  Buffer(
+    rclcpp::Clock::SharedPtr clock,
+    tf2::Duration cache_time = tf2::Duration(tf2::BUFFER_CORE_DEFAULT_CACHE_TIME),
+    rclcpp::Node::SharedPtr node = rclcpp::Node::SharedPtr());
+
   void timerCallback(
     const TimerHandle & timer_handle,
     std::shared_ptr<std::promise<geometry_msgs::msg::TransformStamped>> promise,

--- a/tf2_ros/include/tf2_ros/buffer.h
+++ b/tf2_ros/include/tf2_ros/buffer.h
@@ -77,17 +77,6 @@ public:
     tf2::Duration cache_time = tf2::Duration(tf2::BUFFER_CORE_DEFAULT_CACHE_TIME),
     rclcpp::Node::SharedPtr node = rclcpp::Node::SharedPtr());
 
-  // /** \brief  Constructor for a Buffer object
-  //  * \param clock A clock to use for time and sleeping
-  //  * \param cache_time How long to keep a history of transforms
-  //  * \param node If passed advertise the view_frames service that exposes debugging
-  //  information from the buffer
-  //  */
-  // TF2_ROS_PUBLIC Buffer(
-  //   rclcpp::Clock::SharedPtr clock,
-  //   tf2::Duration cache_time = tf2::Duration(tf2::BUFFER_CORE_DEFAULT_CACHE_TIME),
-  //   rclcpp::Node::SharedPtr node = rclcpp::Node::SharedPtr());
-
   /** \brief Get the transform between two frames by frame ID.
    * \param target_frame The frame to which data should be transformed
    * \param source_frame The frame where the data originated

--- a/tf2_ros/src/buffer.cpp
+++ b/tf2_ros/src/buffer.cpp
@@ -267,7 +267,6 @@ Buffer::waitForTransform(
     auto timer_handle = timer_interface_->createTimer(
       clock_,
       timeout,
-      // std::bind(&Buffer::timerCallback, this, std::placeholders::_1, promise, future, callback));
       [b = shared_from_this(), promise, future, callback](const TimerHandle & timer_handle)
       {
         b->timerCallback(timer_handle, promise, future, callback);

--- a/tf2_ros/src/buffer.cpp
+++ b/tf2_ros/src/buffer.cpp
@@ -43,6 +43,15 @@
 namespace tf2_ros
 {
 
+std::shared_ptr<Buffer> Buffer::make(
+  rclcpp::Clock::SharedPtr clock, tf2::Duration cache_time,
+  rclcpp::Node::SharedPtr node)
+{
+  // return std::make_shared<Buffer>(clock, cache_time, node);
+  std::shared_ptr<Buffer> buffer(new Buffer(clock, cache_time, node));
+  return buffer;
+}
+
 Buffer::Buffer(
   rclcpp::Clock::SharedPtr clock, tf2::Duration cache_time,
   rclcpp::Node::SharedPtr node)
@@ -258,7 +267,11 @@ Buffer::waitForTransform(
     auto timer_handle = timer_interface_->createTimer(
       clock_,
       timeout,
-      std::bind(&Buffer::timerCallback, this, std::placeholders::_1, promise, future, callback));
+      // std::bind(&Buffer::timerCallback, this, std::placeholders::_1, promise, future, callback));
+      [b = shared_from_this(), promise, future, callback](const TimerHandle & timer_handle)
+      {
+        b->timerCallback(timer_handle, promise, future, callback);
+      });
 
     // Save association between timer and request handle
     timer_to_request_map_[timer_handle] = handle;

--- a/tf2_ros/src/buffer_server_main.cpp
+++ b/tf2_ros/src/buffer_server_main.cpp
@@ -49,9 +49,15 @@ int main(int argc, char ** argv)
   auto node = std::make_shared<rclcpp::Node>("tf_buffer");
   double buffer_size = node->declare_parameter("buffer_size", 120.0);
 
-  tf2_ros::Buffer buffer(node->get_clock(), tf2::durationFromSec(buffer_size));
-  tf2_ros::TransformListener listener(buffer);
-  tf2_ros::BufferServer buffer_server(buffer, node, "tf2_buffer_server");
+  std::shared_ptr<tf2_ros::Buffer> buffer = tf2_ros::Buffer::make(
+    node->get_clock(), tf2::durationFromSec(buffer_size));
+  if (!buffer) {
+    RCLCPP_ERROR(node->get_logger(), "Failed to create a tf2_ros::Buffer");
+    return 1;
+  }
+
+  tf2_ros::TransformListener listener(*buffer);
+  tf2_ros::BufferServer buffer_server(*buffer, node, "tf2_buffer_server");
 
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(node);

--- a/tf2_ros/src/tf2_echo.cpp
+++ b/tf2_ros/src/tf2_echo.cpp
@@ -45,13 +45,13 @@
 class echoListener
 {
 public:
-  tf2_ros::Buffer buffer_;
+  std::shared_ptr<tf2_ros::Buffer> buffer_;
   std::shared_ptr<tf2_ros::TransformListener> tfl_;
 
   explicit echoListener(rclcpp::Clock::SharedPtr clock)
-  : buffer_(clock)
   {
-    tfl_ = std::make_shared<tf2_ros::TransformListener>(buffer_);
+    buffer_ = tf2_ros::Buffer::make(clock);
+    tfl_ = std::make_shared<tf2_ros::TransformListener>(*buffer_);
   }
 
   ~echoListener()
@@ -117,7 +117,7 @@ int main(int argc, char ** argv)
 
   // Wait for the first transforms to become avaiable.
   std::string warning_msg;
-  while (rclcpp::ok() && !echoListener.buffer_.canTransform(
+  while (rclcpp::ok() && !echoListener.buffer_->canTransform(
       source_frameid, target_frameid, tf2::TimePoint(), &warning_msg))
   {
     RCLCPP_INFO_THROTTLE(
@@ -131,7 +131,7 @@ int main(int argc, char ** argv)
   while (rclcpp::ok()) {
     try {
       geometry_msgs::msg::TransformStamped echo_transform;
-      echo_transform = echoListener.buffer_.lookupTransform(
+      echo_transform = echoListener.buffer_->lookupTransform(
         source_frameid, target_frameid,
         tf2::TimePoint());
       std::cout.precision(3);
@@ -157,7 +157,7 @@ int main(int argc, char ** argv)
       std::cout << "Failure at " << clock->now().seconds() << std::endl;
       std::cout << "Exception thrown:" << ex.what() << std::endl;
       std::cout << "The current list of frames is:" << std::endl;
-      std::cout << echoListener.buffer_.allFramesAsString() << std::endl;
+      std::cout << echoListener.buffer_->allFramesAsString() << std::endl;
     }
     rate.sleep();
   }

--- a/tf2_ros/test/listener_unittest.cpp
+++ b/tf2_ros/test/listener_unittest.cpp
@@ -45,8 +45,9 @@ TEST(tf2_ros_test_listener, transform_listener)
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
 
-  tf2_ros::Buffer buffer(clock);
-  tf2_ros::TransformListener tfl(buffer, node, false);
+  std::shared_ptr<tf2_ros::Buffer> buffer = tf2_ros::Buffer::make(clock);
+  ASSERT_NE(nullptr, buffer);
+  tf2_ros::TransformListener tfl(*buffer, node, false);
 
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(node);
@@ -63,13 +64,13 @@ TEST(tf2_ros_test_listener, transform_listener)
   ts.transform.translation.y = 2;
   ts.transform.translation.z = 3;
 
-  buffer.setTransform(ts, "authority");
+  buffer->setTransform(ts, "authority");
 
   std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
-  EXPECT_TRUE(buffer.canTransform("a", "b", tf2::timeFromSec(0)));
+  EXPECT_TRUE(buffer->canTransform("a", "b", tf2::timeFromSec(0)));
 
-  geometry_msgs::msg::TransformStamped out_rootc = buffer.lookupTransform(
+  geometry_msgs::msg::TransformStamped out_rootc = buffer->lookupTransform(
     "a", "b",
     builtin_interfaces::msg::Time());
 

--- a/tf2_ros/test/message_filter_test.cpp
+++ b/tf2_ros/test/message_filter_test.cpp
@@ -56,29 +56,30 @@ TEST(tf2_ros_message_filter, construction_and_destruction)
 {
   auto node = rclcpp::Node::make_shared("test_message_filter_node");
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock);
+  std::shared_ptr<tf2_ros::Buffer> buffer = tf2_ros::Buffer::make(clock);
+  ASSERT_NE(nullptr, buffer);
 
   // Node constructor with defaults
   {
-    tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "map", 10, node);
+    tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(*buffer, "map", 10, node);
   }
 
   // Node constructor no defaults
   {
     tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(
-      buffer, "map", 10, node, std::chrono::milliseconds(100));
+      *buffer, "map", 10, node, std::chrono::milliseconds(100));
   }
 
   // Node interface constructor with defaults
   {
     tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(
-      buffer, "map", 10, node->get_node_logging_interface(), node->get_node_clock_interface());
+      *buffer, "map", 10, node->get_node_logging_interface(), node->get_node_clock_interface());
   }
 
   // Node interface constructor no defaults
   {
     tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(
-      buffer,
+      *buffer,
       "map",
       10,
       node->get_node_logging_interface(),
@@ -89,26 +90,27 @@ TEST(tf2_ros_message_filter, construction_and_destruction)
   message_filters::Subscriber<geometry_msgs::msg::PointStamped> sub;
   // Filter + node constructor with defaults
   {
-    tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(sub, buffer, "map", 10, node);
+    tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(sub, *buffer, "map", 10, node);
   }
 
   // Filter + node constructor no defaults
   {
     tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(
-      sub, buffer, "map", 10, node, std::chrono::hours(1));
+      sub, *buffer, "map", 10, node, std::chrono::hours(1));
   }
 
   // Filter + node interface constructor with defaults
   {
     tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(
-      sub, buffer, "map", 10, node->get_node_logging_interface(), node->get_node_clock_interface());
+      sub, *buffer, "map", 10, node->get_node_logging_interface(),
+      node->get_node_clock_interface());
   }
 
   // Filter + node interface constructor no defaults
   {
     tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(
       sub,
-      buffer,
+      *buffer,
       "map",
       10,
       node->get_node_logging_interface(),
@@ -129,10 +131,11 @@ TEST(tf2_ros_message_filter, multiple_frames_and_time_tolerance)
   sub.subscribe(node, "point");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock);
-  buffer.setCreateTimerInterface(create_timer_interface);
-  tf2_ros::TransformListener tfl(buffer);
-  tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "map", 10, node);
+  std::shared_ptr<tf2_ros::Buffer> buffer = tf2_ros::Buffer::make(clock);
+  ASSERT_NE(nullptr, buffer);
+  buffer->setCreateTimerInterface(create_timer_interface);
+  tf2_ros::TransformListener tfl(*buffer);
+  tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(*buffer, "map", 10, node);
   filter.connectInput(sub);
   filter.registerCallback(&filter_callback);
 

--- a/tf2_ros/test/test_buffer.cpp
+++ b/tf2_ros/test/test_buffer.cpp
@@ -299,6 +299,44 @@ TEST(test_buffer, wait_for_transform_race)
   EXPECT_FALSE(callback_timeout);
 }
 
+TEST(test_buffer, wait_for_transform_buffer_destructed_race)
+{
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+  bool callback_timeout = false;
+  tf2_ros::TransformStampedFuture future;
+
+  {
+    std::shared_ptr<tf2_ros::Buffer> buffer = tf2_ros::Buffer::make(clock);
+    ASSERT_NE(nullptr, buffer);
+    // Silence error about dedicated thread's being necessary
+    buffer->setUsingDedicatedThread(true);
+    auto mock_create_timer = std::make_shared<MockCreateTimer>();
+    buffer->setCreateTimerInterface(mock_create_timer);
+
+    rclcpp::Time rclcpp_time = clock->now();
+    tf2::TimePoint tf2_time(std::chrono::nanoseconds(rclcpp_time.nanoseconds()));
+
+    future = buffer->waitForTransform(
+      "foo",
+      "bar",
+      tf2_time, tf2::durationFromSec(1.0),
+      [&callback_timeout](const tf2_ros::TransformStampedFuture & future)
+      {
+        try {
+          // We don't expect this throw, even though a timeout will occur
+          future.get();
+        } catch (...) {
+          callback_timeout = true;
+        }
+      });
+
+    // Allow this instance of buffer to go out of scope and get destructed.
+  }
+
+  auto status = future.wait_for(std::chrono::milliseconds(1));
+  EXPECT_EQ(status, std::future_status::timeout);
+}
+
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/tf2_ros/test/test_buffer_server.cpp
+++ b/tf2_ros/test/test_buffer_server.cpp
@@ -122,7 +122,7 @@ protected:
   void SetUp()
   {
     node_ = std::make_shared<rclcpp::Node>("tf_buffer");
-    buffer_ = std::make_shared<tf2_ros::Buffer>(node_->get_clock());
+    buffer_ = tf2_ros::Buffer::make(node_->get_clock());
     server_ = std::make_unique<tf2_ros::BufferServer>(*buffer_, node_, ACTION_NAME);
     mock_client_ = std::make_shared<MockBufferClient>();
 

--- a/tf2_ros/test/test_transform_listener.cpp
+++ b/tf2_ros/test/test_transform_listener.cpp
@@ -45,8 +45,8 @@ public:
   void init_tf_listener()
   {
     rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-    tf2_ros::Buffer buffer(clock);
-    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(buffer, shared_from_this(), false);
+    std::shared_ptr<tf2_ros::Buffer> buffer = tf2_ros::Buffer::make(clock);
+    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*buffer, shared_from_this(), false);
   }
 
 private:
@@ -58,8 +58,9 @@ TEST(tf2_test_transform_listener, transform_listener_rclcpp_node)
   auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock);
-  tf2_ros::TransformListener tfl(buffer, node, false);
+  std::shared_ptr<tf2_ros::Buffer> buffer = tf2_ros::Buffer::make(clock);
+  ASSERT_NE(nullptr, buffer);
+  tf2_ros::TransformListener tfl(*buffer, node, false);
 }
 
 TEST(tf2_test_transform_listener, transform_listener_custom_rclcpp_node)
@@ -67,8 +68,9 @@ TEST(tf2_test_transform_listener, transform_listener_custom_rclcpp_node)
   auto node = std::make_shared<NodeWrapper>("tf2_ros_message_filter");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock);
-  tf2_ros::TransformListener tfl(buffer, node, false);
+  std::shared_ptr<tf2_ros::Buffer> buffer = tf2_ros::Buffer::make(clock);
+  ASSERT_NE(nullptr, buffer);
+  tf2_ros::TransformListener tfl(*buffer, node, false);
 }
 
 TEST(tf2_test_transform_listener, transform_listener_as_member)

--- a/tf2_ros/test/time_reset_test.cpp
+++ b/tf2_ros/test/time_reset_test.cpp
@@ -55,14 +55,15 @@ TEST(tf2_ros_time_reset_test, time_backwards)
     "transform_listener_backwards_reset");
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
 
-  tf2_ros::Buffer buffer(clock);
-  tf2_ros::TransformListener tfl(buffer);
+  std::shared_ptr<tf2_ros::Buffer> buffer = tf2_ros::Buffer::make(clock);
+  ASSERT_NE(nullptr, buffer);
+  tf2_ros::TransformListener tfl(*buffer);
   tf2_ros::TransformBroadcaster tfb(node_);
 
   auto clock_pub = node_->create_publisher<rosgraph_msgs::msg::Clock>("/clock", 1);
 
   // basic test
-  ASSERT_FALSE(buffer.canTransform("foo", "bar", rclcpp::Time(101, 0)));
+  ASSERT_FALSE(buffer->canTransform("foo", "bar", rclcpp::Time(101, 0)));
 
   // make sure endpoints have discovered each other
   spin_for_a_second(node_);
@@ -88,7 +89,7 @@ TEST(tf2_ros_time_reset_test, time_backwards)
   spin_for_a_second(node_);
 
   // verify it's been set
-  ASSERT_TRUE(buffer.canTransform("foo", "bar", rclcpp::Time(101, 0)));
+  ASSERT_TRUE(buffer->canTransform("foo", "bar", rclcpp::Time(101, 0)));
 
   // TODO(ahcorde): review this
   // c.clock.sec = 90;

--- a/tf2_sensor_msgs/test/test_tf2_sensor_msgs.cpp
+++ b/tf2_sensor_msgs/test/test_tf2_sensor_msgs.cpp
@@ -39,7 +39,7 @@
 
 #include <memory>
 
-std::unique_ptr<tf2_ros::Buffer> tf_buffer = nullptr;
+std::shared_ptr<tf2_ros::Buffer> tf_buffer = nullptr;
 static const double EPS = 1e-3;
 
 
@@ -87,7 +87,7 @@ int main(int argc, char ** argv)
   testing::InitGoogleTest(&argc, argv);
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf_buffer = std::make_unique<tf2_ros::Buffer>(clock);
+  tf_buffer = tf2_ros::Buffer::make(clock);
 
   // populate buffer
   geometry_msgs::msg::TransformStamped t;


### PR DESCRIPTION
# Bug fix

Fixes https://github.com/ros2/geometry2/issues/460

This race condition is fixed by passing a shared `Buffer` to the callback function used in `waitForTransform`, this ensures `Buffer` does not get destructed before the callback is executed. However this requires `Buffer` to be created as a shared pointer instead of calling the usual constructor.

This test, https://github.com/aaronchongth/geometry2/blob/aaron/buffer-make-fn/tf2_ros/test/test_buffer.cpp#L302-L338, was added to recreate the issue faced in https://github.com/ros2/geometry2/issues/460. I haven't managed to migrate downstream packages like Rviz2 to use this new constructor as of now.

To experience the issue, replace these 4 lines, https://github.com/aaronchongth/geometry2/blob/aaron/buffer-make-fn/tf2_ros/src/buffer.cpp#L270-L273, with the original `std::bind` call,

```
  std::bind(&Buffer::timerCallback, this, std::placeholders::_1, promise, future, callback));
```

Compile and run the test, this newly added test should fail,

```
rm -rf install/tf2_ros build tf2_ros
colcon build --packages-select tf2_ros

source install/setup.bash
./build/tf2_ros/test_buffer
```

Ideally there would be another solution which is both backward compatible, and solves this race condition at the same time. I will continue looking into it, for now do let me know if anyone has any suggestions or thoughts.