### PR TITLE
Using shared data structures to pass along fields needed in timer callback

### DIFF
--- a/tf2/include/tf2/buffer_core.h
+++ b/tf2/include/tf2/buffer_core.h
@@ -429,6 +429,8 @@ private:
     const TimePoint & time, std::string * error_msg) const;
 
 protected:
+  // This data structure contains members and functions needed in multi-threaded operations,
+  // and should be shared with callback functions or lambdas to prevent use-after-free scenarios.
   struct TransformableData
   {
     M_TransformableCallback transformable_callbacks_;

--- a/tf2/include/tf2/buffer_core.h
+++ b/tf2/include/tf2/buffer_core.h
@@ -218,10 +218,6 @@ public:
     const std::string & target_frame,
     const std::string & source_frame,
     TimePoint time);
-  /// \brief Internal use only
-  TF2_PUBLIC
-  void cancelTransformableRequest(TransformableRequestHandle handle);
-
 
   // Tell the buffer that there are multiple threads servicing it.
   // This is useful for derived classes to know if they can block or not.
@@ -329,9 +325,6 @@ private:
 
   typedef std::unordered_map<TransformableCallbackHandle,
       TransformableCallback> M_TransformableCallback;
-  M_TransformableCallback transformable_callbacks_;
-  uint32_t transformable_callbacks_counter_;
-  std::mutex transformable_callbacks_mutex_;
 
   struct TransformableRequest
   {
@@ -344,9 +337,6 @@ private:
     std::string source_string;
   };
   typedef std::vector<TransformableRequest> V_TransformableRequest;
-  V_TransformableRequest transformable_requests_;
-  std::mutex transformable_requests_mutex_;
-  uint64_t transformable_requests_counter_;
 
   bool using_dedicated_thread_;
 
@@ -437,6 +427,24 @@ private:
   bool canTransformInternal(
     CompactFrameID target_id, CompactFrameID source_id,
     const TimePoint & time, std::string * error_msg) const;
+
+protected:
+  struct TransformableData
+  {
+    M_TransformableCallback transformable_callbacks_;
+    uint32_t transformable_callbacks_counter_;
+    std::mutex transformable_callbacks_mutex_;
+
+    V_TransformableRequest transformable_requests_;
+    std::mutex transformable_requests_mutex_;
+    uint64_t transformable_requests_counter_;
+
+    /// \brief Internal use only
+    TF2_PUBLIC
+    void cancelTransformableRequest(TransformableRequestHandle handle);
+  };
+
+  std::shared_ptr<TransformableData> transformable_data_;
 };
 }  // namespace tf2
 

--- a/tf2_ros/include/tf2_ros/buffer.h
+++ b/tf2_ros/include/tf2_ros/buffer.h
@@ -260,6 +260,8 @@ public:
   }
 
 private:
+  // This data structure contains members and functions needed in multi-threaded operations,
+  // and should be shared with callback functions or lambdas to prevent use-after-free scenarios.
   struct TimerCallbackData
   {
     /// \brief Interface for creating timers

--- a/tf2_ros/test/test_buffer.cpp
+++ b/tf2_ros/test/test_buffer.cpp
@@ -295,6 +295,41 @@ TEST(test_buffer, wait_for_transform_race)
   EXPECT_FALSE(callback_timeout);
 }
 
+TEST(test_buffer, wait_for_transform_buffer_destructed_race)
+{
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+  bool callback_timeout = false;
+  tf2_ros::TransformStampedFuture future;
+
+  {
+    tf2_ros::Buffer buffer(clock);
+    // Silence error about dedicated thread's being necessary
+    buffer.setUsingDedicatedThread(true);
+    auto mock_create_timer = std::make_shared<MockCreateTimer>();
+    buffer.setCreateTimerInterface(mock_create_timer);
+
+    rclcpp::Time rclcpp_time = clock->now();
+    tf2::TimePoint tf2_time(std::chrono::nanoseconds(rclcpp_time.nanoseconds()));
+
+    future = buffer.waitForTransform(
+      "foo",
+      "bar",
+      tf2_time, tf2::durationFromSec(1.0),
+      [&callback_timeout](const tf2_ros::TransformStampedFuture & future)
+      {
+        try {
+          // We don't expect this throw, even though a timeout will occur
+          future.get();
+        } catch (...) {
+          callback_timeout = true;
+        }
+      });
+  }
+
+  auto status = future.wait_for(std::chrono::seconds(1));
+  EXPECT_EQ(status, std::future_status::timeout);
+}
+
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

# Bug fix

Fixes https://github.com/ros2/geometry2/issues/460

This race condition is fixed by passing shared data structures holding required the required fields in the timer callback. This ensures all the fields do not get destructed before the callback is executed. This is a much cleaner solution than https://github.com/ros2/geometry2/pull/479, as it doesn't break API.

This test, https://github.com/aaronchongth/geometry2/blob/aaron/buffer-shared-data/tf2_ros/test/test_buffer.cpp#L298-L331, was added to recreate the issue faced in https://github.com/ros2/geometry2/issues/460.