### PR TITLE
[tf2_tools] Add `graphviz` as a runtime dependency

### DIFF
--- a/tf2_tools/package.xml
+++ b/tf2_tools/package.xml
@@ -19,6 +19,7 @@
   <build_depend>tf2</build_depend>
   <build_depend>tf2_ros</build_depend>
 
+  <exec_depend>graphviz</exec_depend>
   <exec_depend>tf2_msgs</exec_depend>
   <exec_depend>tf2</exec_depend>
   <exec_depend>tf2_ros</exec_depend>


### PR DESCRIPTION
This PR is an alternative to backporting #351 since that requires
`tf2_ros_py`, among other difficulties.

Without this runtime dependency, the subprocess used to invoke the `dot`
utility that ships with `graphviz` silently dies, and a `frames.pdf`
file is not generated.

Closes #482.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>