### PR TITLE
clear relative callback of Buffer if MessageFilter is destroyed

### DIFF
--- a/tf2_ros/include/tf2_ros/async_buffer_interface.h
+++ b/tf2_ros/include/tf2_ros/async_buffer_interface.h
@@ -47,7 +47,7 @@ namespace tf2_ros
 
 class TransformStampedFuture : public std::shared_future<geometry_msgs::msg::TransformStamped>
 {
-  typedef std::shared_future<geometry_msgs::msg::TransformStamped> _Base_type;
+  using _Base_type = std::shared_future<geometry_msgs::msg::TransformStamped>;
 
 public:
   /// Constructor

--- a/tf2_ros/include/tf2_ros/async_buffer_interface.h
+++ b/tf2_ros/include/tf2_ros/async_buffer_interface.h
@@ -47,21 +47,21 @@ namespace tf2_ros
 
 class TransformStampedFuture : public std::shared_future<geometry_msgs::msg::TransformStamped>
 {
-  using _Base_type = std::shared_future<geometry_msgs::msg::TransformStamped>;
+  using BaseType = std::shared_future<geometry_msgs::msg::TransformStamped>;
 
 public:
   /// Constructor
-  explicit TransformStampedFuture(_Base_type && future) noexcept
-  : _Base_type(std::move(future)) {}
+  explicit TransformStampedFuture(BaseType && future) noexcept
+  : BaseType(std::move(future)) {}
 
   /// Copy constructor
   TransformStampedFuture(const TransformStampedFuture & ts_future) noexcept
-  : _Base_type(ts_future),
+  : BaseType(ts_future),
     handle_(ts_future.handle_) {}
 
   /// Move constructor
   TransformStampedFuture(TransformStampedFuture && ts_future) noexcept
-  : _Base_type(std::move(ts_future)),
+  : BaseType(std::move(ts_future)),
     handle_(std::move(ts_future.handle_)) {}
 
   void setHandle(const tf2::TransformableRequestHandle handle)

--- a/tf2_ros/include/tf2_ros/buffer.h
+++ b/tf2_ros/include/tf2_ros/buffer.h
@@ -252,6 +252,14 @@ public:
       callback);
   }
 
+  /**
+   * \brief Cancel the future to make sure the callback of requested transform is clean.
+   * \sa cancel(TransformStampedFuture& ts_future);
+   */
+  TF2_ROS_PUBLIC
+  void
+  cancel(const TransformStampedFuture & ts_future) override;
+
   TF2_ROS_PUBLIC
   inline void
   setCreateTimerInterface(CreateTimerInterface::SharedPtr create_timer_interface)

--- a/tf2_ros/include/tf2_ros/buffer.h
+++ b/tf2_ros/include/tf2_ros/buffer.h
@@ -254,7 +254,7 @@ public:
 
   /**
    * \brief Cancel the future to make sure the callback of requested transform is clean.
-   * \sa cancel(TransformStampedFuture& ts_future);
+   * \param ts_future The future to the requested transform.
    */
   TF2_ROS_PUBLIC
   void

--- a/tf2_ros/include/tf2_ros/buffer_interface.h
+++ b/tf2_ros/include/tf2_ros/buffer_interface.h
@@ -49,8 +49,6 @@
 
 namespace tf2_ros
 {
-using TransformStampedFuture = std::shared_future<geometry_msgs::msg::TransformStamped>;
-using TransformReadyCallback = std::function<void (const TransformStampedFuture &)>;
 
 inline builtin_interfaces::msg::Time toMsg(const tf2::TimePoint & t)
 {

--- a/tf2_ros/include/tf2_ros/message_filter.h
+++ b/tf2_ros/include/tf2_ros/message_filter.h
@@ -439,9 +439,11 @@ public:
         buffer_timeout_,
         std::bind(&MessageFilter::transformReadyCallback, this, std::placeholders::_1, handle));
 
+      // If handle of future is 0 or 0xffffffffffffffffULL, waitForTransform have already called
+      // the callback.
       if (0 != future.getHandle() || 0xffffffffffffffffULL != future.getHandle()) {
         std::unique_lock<std::mutex> lock(ts_futures_mutex_);
-        ts_futures_.insert({handle, future});
+        ts_futures_.insert({handle, std::move(future)});
       }
     }
   }

--- a/tf2_ros/include/tf2_ros/message_filter.h
+++ b/tf2_ros/include/tf2_ros/message_filter.h
@@ -44,6 +44,7 @@
 #include <tuple>
 #include <type_traits>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "message_filters/connection.h"

--- a/tf2_ros/include/tf2_ros/message_filter.h
+++ b/tf2_ros/include/tf2_ros/message_filter.h
@@ -43,6 +43,7 @@
 #include <string>
 #include <tuple>
 #include <type_traits>
+#include <unordered_map>
 #include <vector>
 
 #include "message_filters/connection.h"
@@ -335,6 +336,14 @@ public:
    */
   void clear()
   {
+    {
+      std::unique_lock<std::mutex> lock(ts_futures_mutex_);
+      for (auto & kv : ts_futures_) {
+        buffer_.cancel(kv.second);
+      }
+      ts_futures_.clear();
+    }
+
     std::unique_lock<std::mutex> unique_lock(messages_mutex_);
 
     TF2_ROS_MESSAGEFILTER_DEBUG("%s", "Cleared");
@@ -423,12 +432,17 @@ public:
       const auto & handle = std::get<0>(param);
       const auto & stamp = std::get<1>(param);
       const auto & target_frame = std::get<2>(param);
-      buffer_.waitForTransform(
+      tf2_ros::TransformStampedFuture future = buffer_.waitForTransform(
         target_frame,
         frame_id,
         stamp,
         buffer_timeout_,
         std::bind(&MessageFilter::transformReadyCallback, this, std::placeholders::_1, handle));
+
+      if (0 != future.getHandle() || 0xffffffffffffffffULL != future.getHandle()) {
+        std::unique_lock<std::mutex> lock(ts_futures_mutex_);
+        ts_futures_.insert({handle, future});
+      }
     }
   }
 
@@ -484,6 +498,14 @@ private:
 
     MEvent saved_event;
     bool event_found = false;
+
+    {
+      std::unique_lock<std::mutex> lock(ts_futures_mutex_);
+      auto iter = ts_futures_.find(handle);
+      if (iter != ts_futures_.end()) {
+        ts_futures_.erase(iter);
+      }
+    }
 
     {
       // We will be accessing and mutating messages now, require unique lock
@@ -748,6 +770,13 @@ private:
 
   // Timeout duration when calling the buffer method 'waitForTransform'
   tf2::Duration buffer_timeout_;
+
+  ///< The mutex used for locking TransformStampedFuture map operations
+  std::mutex ts_futures_mutex_;
+
+  ///< Store the TransformStampedFuture returned by 'waitForTransform',
+  // to clear the callback in the Buffer if MessageFiltered object is destroyed.
+  std::unordered_map<uint64_t, tf2_ros::TransformStampedFuture> ts_futures_;
 };
 }  // namespace tf2_ros
 

--- a/tf2_ros/src/buffer.cpp
+++ b/tf2_ros/src/buffer.cpp
@@ -240,6 +240,7 @@ Buffer::waitForTransform(
     };
 
   auto handle = addTransformableRequest(cb, target_frame, source_frame, time);
+  future.setHandle(handle);
   if (0 == handle) {
     // Immediately transformable
     geometry_msgs::msg::TransformStamped msg_stamped = lookupTransform(
@@ -264,6 +265,18 @@ Buffer::waitForTransform(
     timer_to_request_map_[timer_handle] = handle;
   }
   return future;
+}
+
+void
+Buffer::cancel(const TransformStampedFuture & ts_future)
+{
+  cancelTransformableRequest(ts_future.getHandle());
+
+  std::lock_guard<std::mutex> lock(timer_to_request_map_mutex_);
+  auto iter = timer_to_request_map_.find(ts_future.getHandle());
+  if (iter != timer_to_request_map_.end()) {
+    timer_to_request_map_.erase(iter);
+  }
 }
 
 void


### PR DESCRIPTION
to fix https://github.com/ros2/rviz/issues/703

Signed-off-by: Chen Lihui <lihui.chen@sony.com>