### PR TITLE
[tf2] Output canTransform msg only on state change

### DIFF
--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -113,8 +113,13 @@ CompactFrameID BufferCore::validateFrameId(
     return 0;
   }
 
+  // Only check that a frame is non-existent once a frame was found
+  static bool init_state = true;
   CompactFrameID id = lookupFrameNumber(frame_id);
-  if (id == 0) {
+  if (id != 0) {
+    init_state = false;
+  }
+  if (!init_state && id == 0) {
     fillOrWarnMessageForInvalidFrame(
       function_name_arg, frame_id, error_msg, "frame does not exist");
   }


### PR DESCRIPTION
The "frame does not exist" error message in `BufferCore::validateFrameId`
is noisy and not warranted if a frame never existed to begin with, so
that message is only outputted once a state change has occurred - i.e.
any frame was found.

Fixes https://github.com/ros2/geometry2/issues/358.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>
