### PR TITLE
Install includes to include/${PROJECT_NAME} and use modern CMake

### DIFF
--- a/test_tf2/CMakeLists.txt
+++ b/test_tf2/CMakeLists.txt
@@ -67,7 +67,7 @@ if(TARGET test_convert)
       # TODO(sloretz) require target to exist when https://github.com/ros2/choco-packages/issues/19 is addressed
       target_link_libraries(test_convert Eigen3::Eigen)
     else()
-      target_include_directories(test_convert ${Eigen3_INCLUDE_DIRS})
+      target_include_directories(test_convert PRIVATE ${Eigen3_INCLUDE_DIRS})
     endif()
 endif()
 

--- a/test_tf2/CMakeLists.txt
+++ b/test_tf2/CMakeLists.txt
@@ -57,29 +57,29 @@ endif()
 ament_add_gtest(test_convert test/test_convert.cpp)
 if(TARGET test_convert)
   target_link_libraries(test_convert
+    Eigen3::Eigen
     ${geometry_msgs_TARGETS}
     tf2::tf2
-    tf2_kdl::tf2_kdl
     tf2_bullet::tf2_bullet
     tf2_eigen::tf2_eigen
     ${tf2_geometry_msgs_TARGETS}
-    Eigen3::Eigen)
+    tf2_kdl::tf2_kdl)
 endif()
 
 ament_add_gtest(test_utils test/test_utils.cpp)
 if(TARGET test_utils)
   target_link_libraries(test_utils
     ${geometry_msgs_TARGETS}
-    ${tf2_geometry_msgs_TARGETS}
     tf2::tf2
+    ${tf2_geometry_msgs_TARGETS}
     tf2_kdl::tf2_kdl)
 endif()
 
 add_executable(test_buffer_server test/test_buffer_server.cpp)
 if(TARGET test_buffer_server)
   target_link_libraries(test_buffer_server
-    tf2_ros::tf2_ros
-    rclcpp::rclcpp)
+    rclcpp::rclcpp
+    tf2_ros::tf2_ros)
 endif()
 
 add_executable(test_buffer_client test/test_buffer_client.cpp)
@@ -108,9 +108,9 @@ endif()
 ament_add_gtest(test_tf2_bullet test/test_tf2_bullet.cpp)
 if(TARGET test_tf2_bullet)
   target_link_libraries(test_tf2_bullet
+    rclcpp::rclcpp
     tf2_bullet::tf2_bullet
     tf2_ros::tf2_ros
-    rclcpp::rclcpp
     tf2::tf2)
 endif()
 

--- a/test_tf2/CMakeLists.txt
+++ b/test_tf2/CMakeLists.txt
@@ -20,7 +20,6 @@ endif()
 
 find_package(ament_cmake_gtest REQUIRED)
 find_package(builtin_interfaces REQUIRED)
-find_package(eigen3_cmake_module REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(launch_testing_ament_cmake REQUIRED)
@@ -36,92 +35,83 @@ ament_find_gtest()
 
 ament_add_gtest(buffer_core_test test/buffer_core_test.cpp)
 if(TARGET buffer_core_test)
-  ament_target_dependencies(buffer_core_test
-    builtin_interfaces
-    geometry_msgs
-    rclcpp
-    tf2
-    tf2_geometry_msgs
-    tf2_ros
-  )
+  target_link_libraries(buffer_core_test
+    ${builtin_interfaces_TARGETS}
+    ${geometry_msgs_TARGETS}
+    rclcpp::rclcpp
+    tf2::tf2
+    ${tf2_geometry_msgs_TARGETS}
+    tf2_ros::tf2_ros)
 endif()
 
 ament_add_gtest(test_message_filter test/test_message_filter.cpp)
 if(TARGET test_message_filter)
-  ament_target_dependencies(test_message_filter
-    builtin_interfaces
-    geometry_msgs
-    rclcpp
-    tf2
-    tf2_ros
-  )
+  target_link_libraries(test_message_filter
+    ${builtin_interfaces_TARGETS}
+    ${geometry_msgs_TARGETS}
+    rclcpp::rclcpp
+    tf2::tf2
+    tf2_ros::tf2_ros)
 endif()
 
 ament_add_gtest(test_convert test/test_convert.cpp)
 if(TARGET test_convert)
-  ament_target_dependencies(test_convert
-    Eigen3
-    eigen3_cmake_module
-    tf2
-    tf2_bullet
-    tf2_eigen
-    tf2_geometry_msgs
-    tf2_kdl
-  )
+  target_link_libraries(test_convert
+    ${geometry_msgs_TARGETS}
+    tf2::tf2
+    tf2_kdl::tf2_kdl
+    tf2_bullet::tf2_bullet
+    tf2_eigen::tf2_eigen
+    ${tf2_geometry_msgs_TARGETS}
+    Eigen3::Eigen)
 endif()
 
 ament_add_gtest(test_utils test/test_utils.cpp)
 if(TARGET test_utils)
-  ament_target_dependencies(test_utils
-    geometry_msgs
-    tf2
-    tf2_geometry_msgs
-    tf2_kdl
-  )
+  target_link_libraries(test_utils
+    ${geometry_msgs_TARGETS}
+    ${tf2_geometry_msgs_TARGETS}
+    tf2::tf2
+    tf2_kdl::tf2_kdl)
 endif()
 
 add_executable(test_buffer_server test/test_buffer_server.cpp)
 if(TARGET test_buffer_server)
-  ament_target_dependencies(test_buffer_server
-    rclcpp
-    tf2_bullet
-    tf2_ros
-  )
+  target_link_libraries(test_buffer_server
+    tf2_ros::tf2_ros
+    rclcpp::rclcpp)
 endif()
 
 add_executable(test_buffer_client test/test_buffer_client.cpp)
 if(TARGET test_buffer_client)
-  ament_target_dependencies(test_buffer_client
-    rclcpp
-    tf2_bullet
-    tf2_geometry_msgs
-    tf2_kdl
-    tf2_ros
-  )
-  target_link_libraries(test_buffer_client ${GTEST_LIBRARIES})
+  target_link_libraries(test_buffer_client
+    ${GTEST_LIBRARIES}
+    rclcpp::rclcpp
+    tf2_bullet::tf2_bullet
+    ${tf2_geometry_msgs_TARGETS}
+    tf2_kdl::tf2_kdl
+    tf2_ros::tf2_ros)
   add_launch_test(test/buffer_client_tester.launch.py)
 endif()
 
 add_executable(test_static_publisher test/test_static_publisher.cpp)
 if(TARGET test_static_publisher)
-  ament_target_dependencies(test_static_publisher
-    geometry_msgs
-    rclcpp
-    tf2
-    tf2_ros
-  )
-  target_include_directories(test_static_publisher PRIVATE ${GTEST_INCLUDE_DIRS})
-  target_link_libraries(test_static_publisher ${GTEST_LIBRARIES})
+  target_link_libraries(test_static_publisher
+    ${GTEST_LIBRARIES}
+    ${geometry_msgs_TARGETS}
+    rclcpp::rclcpp
+    tf2::tf2
+    tf2_ros::tf2_ros)
   add_launch_test(test/static_publisher.launch.py)
 endif()
 
 ament_add_gtest(test_tf2_bullet test/test_tf2_bullet.cpp)
 if(TARGET test_tf2_bullet)
-  ament_target_dependencies(test_tf2_bullet
-      rclcpp
-      tf2_bullet
-      tf2_ros
-  )
+  target_link_libraries(test_tf2_bullet
+    tf2_bullet::tf2_bullet
+    tf2_ros::tf2_ros
+    rclcpp::rclcpp
+    tf2::tf2)
 endif()
 
 # TODO(ahcorde): enable once python part of tf2_geometry_msgs is working

--- a/test_tf2/CMakeLists.txt
+++ b/test_tf2/CMakeLists.txt
@@ -63,12 +63,12 @@ if(TARGET test_convert)
     tf2_eigen::tf2_eigen
     ${tf2_geometry_msgs_TARGETS}
     tf2_kdl::tf2_kdl)
-    if(TARGET Eigen3::Eigen)
-      # TODO(sloretz) require target to exist when https://github.com/ros2/choco-packages/issues/19 is addressed
-      target_link_libraries(test_convert Eigen3::Eigen)
-    else()
-      target_include_directories(test_convert PRIVATE ${Eigen3_INCLUDE_DIRS})
-    endif()
+  if(TARGET Eigen3::Eigen)
+    # TODO(sloretz) require target to exist when https://github.com/ros2/choco-packages/issues/19 is addressed
+    target_link_libraries(test_convert Eigen3::Eigen)
+  else()
+    target_include_directories(test_convert PRIVATE ${Eigen3_INCLUDE_DIRS})
+  endif()
 endif()
 
 ament_add_gtest(test_utils test/test_utils.cpp)

--- a/test_tf2/CMakeLists.txt
+++ b/test_tf2/CMakeLists.txt
@@ -57,13 +57,18 @@ endif()
 ament_add_gtest(test_convert test/test_convert.cpp)
 if(TARGET test_convert)
   target_link_libraries(test_convert
-    Eigen3::Eigen
     ${geometry_msgs_TARGETS}
     tf2::tf2
     tf2_bullet::tf2_bullet
     tf2_eigen::tf2_eigen
     ${tf2_geometry_msgs_TARGETS}
     tf2_kdl::tf2_kdl)
+    if(TARGET Eigen3::Eigen)
+      # TODO(sloretz) require target to exist when https://github.com/ros2/choco-packages/issues/19 is addressed
+      target_link_libraries(test_convert Eigen3::Eigen)
+    else()
+      target_include_directories(test_convert ${Eigen3_INCLUDE_DIRS})
+    endif()
 endif()
 
 ament_add_gtest(test_utils test/test_utils.cpp)

--- a/test_tf2/package.xml
+++ b/test_tf2/package.xml
@@ -12,7 +12,6 @@
   <author>Eitan Marder-Eppstein</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
   <build_depend>eigen</build_depend>
 

--- a/tf2/CMakeLists.txt
+++ b/tf2/CMakeLists.txt
@@ -100,5 +100,11 @@ endif()
 
 ament_export_dependencies(console_bridge geometry_msgs rcutils rosidl_runtime_cpp)
 
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
+ament_export_libraries(tf2)
+
+# Export modern CMake targets
 ament_export_targets(export_tf2)
+
 ament_package()

--- a/tf2/CMakeLists.txt
+++ b/tf2/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 find_package(ament_cmake)
 find_package(console_bridge_vendor REQUIRED) # Provides console_bridge 0.4.0 on platforms without it.
 find_package(console_bridge REQUIRED)
+find_package(builtin_interfaces REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rosidl_runtime_cpp REQUIRED)
@@ -24,9 +25,11 @@ add_library(tf2 SHARED src/cache.cpp src/buffer_core.cpp src/static_cache.cpp sr
 target_include_directories(tf2 PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
-target_link_libraries(tf2
+target_link_libraries(tf2 PUBLIC
+  ${geometry_msgs_TARGETS})
+target_link_libraries(tf2 PRIVATE
+  ${builtin_interfaces_TARGETS}
   console_bridge::console_bridge
-  ${geometry_msgs_TARGETS}
   rcutils::rcutils)
 
 # Causes the visibility macros to use dllexport rather than dllimport,
@@ -89,7 +92,12 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_simple_tf2_core test/simple_tf2_core.cpp)
   if(TARGET test_simple_tf2_core)
-    target_link_libraries(test_simple_tf2_core tf2)
+    target_link_libraries(test_simple_tf2_core
+      ${builtin_interfaces_TARGETS}
+      tf2
+      # Used, but not linked to test tf2's exports:
+      #   ${geometry_msgs_TARGETS}
+    )
   endif()
 
   ament_add_gtest(test_time test/test_time.cpp)

--- a/tf2/CMakeLists.txt
+++ b/tf2/CMakeLists.txt
@@ -23,25 +23,23 @@ find_package(rosidl_runtime_cpp REQUIRED)
 add_library(tf2 SHARED src/cache.cpp src/buffer_core.cpp src/static_cache.cpp src/time.cpp)
 target_include_directories(tf2 PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>")
-ament_target_dependencies(tf2
-  "console_bridge"
-  "geometry_msgs"
-  "rcutils"
-)
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(tf2
+  console_bridge::console_bridge
+  ${geometry_msgs_TARGETS}
+  rcutils::rcutils)
+
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
 target_compile_definitions(tf2 PRIVATE "TF2_BUILDING_DLL")
 
-install(TARGETS tf2 EXPORT tf2
+install(TARGETS tf2 EXPORT export_tf2
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
 )
 
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION include/${PROJECT_NAME}
-)
+install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 
 # Tests
 if(BUILD_TESTING)
@@ -92,9 +90,6 @@ if(BUILD_TESTING)
   ament_add_gtest(test_simple_tf2_core test/simple_tf2_core.cpp)
   if(TARGET test_simple_tf2_core)
     target_link_libraries(test_simple_tf2_core tf2)
-    ament_target_dependencies(test_simple_tf2_core
-      "geometry_msgs"
-    )
   endif()
 
   ament_add_gtest(test_time test/test_time.cpp)
@@ -104,7 +99,6 @@ if(BUILD_TESTING)
 endif()
 
 ament_export_dependencies(console_bridge geometry_msgs rcutils rosidl_runtime_cpp)
-ament_export_include_directories(include)
-ament_export_libraries(tf2)
-ament_export_targets(tf2)
+
+ament_export_targets(export_tf2)
 ament_package()

--- a/tf2/package.xml
+++ b/tf2/package.xml
@@ -23,6 +23,7 @@
   <build_depend>rosidl_runtime_cpp</build_depend>
   <build_export_depend>rosidl_runtime_cpp</build_export_depend>
 
+  <depend>builtin_interfaces</depend>
   <depend>console_bridge_vendor</depend>
   <depend>geometry_msgs</depend>
   <depend>libconsole-bridge-dev</depend>

--- a/tf2_bullet/CMakeLists.txt
+++ b/tf2_bullet/CMakeLists.txt
@@ -10,7 +10,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -Wnon-virtual-dtor -Woverloaded-virtual)
 endif()
 
-
 find_package(ament_cmake REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(tf2 REQUIRED)
@@ -21,7 +20,7 @@ include(bullet-extras.cmake)
 add_library(tf2_bullet INTERFACE)
 target_include_directories(tf2_bullet INTERFACE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>")
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 target_link_libraries(tf2_bullet INTERFACE
   tf2_bullet::Bullet
   tf2::tf2
@@ -30,9 +29,7 @@ target_link_libraries(tf2_bullet INTERFACE
 
 install(TARGETS tf2_bullet EXPORT export_tf2_bullet)
 
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION include/${PROJECT_NAME}
-)
+install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/tf2_bullet/CMakeLists.txt
+++ b/tf2_bullet/CMakeLists.txt
@@ -10,6 +10,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -Wnon-virtual-dtor -Woverloaded-virtual)
 endif()
 
+
 find_package(ament_cmake REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(tf2 REQUIRED)

--- a/tf2_eigen/CMakeLists.txt
+++ b/tf2_eigen/CMakeLists.txt
@@ -14,11 +14,20 @@ find_package(geometry_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 
-find_package(eigen3_cmake_module REQUIRED)
 find_package(Eigen3 REQUIRED)
 
-install(DIRECTORY include/${PROJECT_NAME}/
-        DESTINATION include/${PROJECT_NAME})
+add_library(tf2_eigen INTERFACE)
+target_link_libraries(tf2_eigen INTERFACE
+  Eigen3::Eigen
+  tf2::tf2
+  tf2_ros::tf2_ros)
+target_include_directories(tf2_eigen INTERFACE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+
+
+install(TARGETS tf2_eigen EXPORT export_tf2_eigen)
+install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_cmake_cppcheck REQUIRED)
@@ -35,20 +44,14 @@ if(BUILD_TESTING)
 
   ament_add_gtest(tf2_eigen-test test/tf2_eigen-test.cpp)
   if(TARGET tf2_eigen-test)
-    target_include_directories(tf2_eigen-test PUBLIC
-      include)
-    ament_target_dependencies(tf2_eigen-test
-      "tf2"
-      "tf2_ros")
-    target_include_directories(tf2_eigen-test PUBLIC
-      ${Eigen3_INCLUDE_DIRS})
+    target_link_libraries(tf2_eigen-test tf2_eigen)
   endif()
 endif()
 
-ament_export_include_directories(include)
 ament_export_dependencies(
-  eigen3_cmake_module
   Eigen3
   tf2
   tf2_ros)
+
+ament_export_targets(export_tf2_eigen)
 ament_package()

--- a/tf2_eigen/CMakeLists.txt
+++ b/tf2_eigen/CMakeLists.txt
@@ -52,5 +52,11 @@ ament_export_dependencies(
   tf2
   tf2_ros)
 
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
+ament_export_libraries(tf2_eigen)
+
+# Export modern CMake targets
 ament_export_targets(export_tf2_eigen)
+
 ament_package()

--- a/tf2_eigen/CMakeLists.txt
+++ b/tf2_eigen/CMakeLists.txt
@@ -18,13 +18,18 @@ find_package(Eigen3 REQUIRED)
 
 add_library(tf2_eigen INTERFACE)
 target_link_libraries(tf2_eigen INTERFACE
-  Eigen3::Eigen
   ${geometry_msgs_TARGETS}
   tf2::tf2
   tf2_ros::tf2_ros)
 target_include_directories(tf2_eigen INTERFACE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+if(TARGET Eigen3::Eigen)
+  # TODO(sloretz) require target to exist when https://github.com/ros2/choco-packages/issues/19 is addressed
+  target_link_libraries(tf2_eigen INTERFACE Eigen3::Eigen)
+else()
+  target_include_directories(tf2_eigen INTERFACE ${Eigen3_INCLUDE_DIRS})
+endif()
 
 install(TARGETS tf2_eigen EXPORT export_tf2_eigen)
 install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})

--- a/tf2_eigen/CMakeLists.txt
+++ b/tf2_eigen/CMakeLists.txt
@@ -25,7 +25,6 @@ target_include_directories(tf2_eigen INTERFACE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 
-
 install(TARGETS tf2_eigen EXPORT export_tf2_eigen)
 install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 

--- a/tf2_eigen/CMakeLists.txt
+++ b/tf2_eigen/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(Eigen3 REQUIRED)
 add_library(tf2_eigen INTERFACE)
 target_link_libraries(tf2_eigen INTERFACE
   Eigen3::Eigen
+  ${geometry_msgs_TARGETS}
   tf2::tf2
   tf2_ros::tf2_ros)
 target_include_directories(tf2_eigen INTERFACE
@@ -43,7 +44,14 @@ if(BUILD_TESTING)
 
   ament_add_gtest(tf2_eigen-test test/tf2_eigen-test.cpp)
   if(TARGET tf2_eigen-test)
-    target_link_libraries(tf2_eigen-test tf2_eigen)
+    target_link_libraries(tf2_eigen-test
+      tf2_eigen
+      # Used, but not linked to test tf2_eigen's exports:
+      #   Eigen3::Eigen
+      #   ${geometry_msgs_TARGETS}
+      #   tf2::tf2
+      #   tf2_ros::tf2_ros
+    )
   endif()
 endif()
 
@@ -54,7 +62,6 @@ ament_export_dependencies(
 
 # Export old-style CMake variables
 ament_export_include_directories("include/${PROJECT_NAME}")
-ament_export_libraries(tf2_eigen)
 
 # Export modern CMake targets
 ament_export_targets(export_tf2_eigen)

--- a/tf2_eigen/package.xml
+++ b/tf2_eigen/package.xml
@@ -10,9 +10,6 @@
   <author>Koji Terada</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>eigen3_cmake_module</buildtool_depend>
-
-  <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>
 
   <build_depend>eigen</build_depend>
 

--- a/tf2_eigen_kdl/CMakeLists.txt
+++ b/tf2_eigen_kdl/CMakeLists.txt
@@ -21,9 +21,14 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 target_link_libraries(${PROJECT_NAME} PUBLIC
-  Eigen3::Eigen
   orocos-kdl
   tf2::tf2)
+if(TARGET Eigen3::Eigen)
+  # TODO(sloretz) require target to exist when https://github.com/ros2/choco-packages/issues/19 is addressed
+  target_link_libraries(${PROJECT_NAME} PUBLIC Eigen3::Eigen)
+else()
+  target_include_directories(${PROJECT_NAME} PUBLIC ${Eigen3_INCLUDE_DIRS})
+endif()
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.

--- a/tf2_eigen_kdl/CMakeLists.txt
+++ b/tf2_eigen_kdl/CMakeLists.txt
@@ -10,7 +10,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
-find_package(eigen3_cmake_module REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(orocos_kdl REQUIRED)
 find_package(tf2 REQUIRED)
@@ -20,35 +19,30 @@ add_library(${PROJECT_NAME} SHARED
 )
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>")
-ament_target_dependencies(${PROJECT_NAME}
-  Eigen3
-  eigen3_cmake_module
-  orocos_kdl
-  tf2
-)
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  Eigen3::Eigen
+  orocos-kdl
+  tf2::tf2)
+
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
 target_compile_definitions(${PROJECT_NAME} PRIVATE "TF2_EIGEN_KDL_BUILDING_DLL")
 
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION include/${PROJECT_NAME})
+install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 
 install(TARGETS ${PROJECT_NAME}
-  EXPORT ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION lib)
 
-ament_export_include_directories(include)
 ament_export_dependencies(
-  eigen3_cmake_module
   Eigen3
   orocos_kdl
   tf2
 )
-ament_export_libraries(${PROJECT_NAME})
-ament_export_targets(${PROJECT_NAME})
+ament_export_targets(export_${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/tf2_eigen_kdl/CMakeLists.txt
+++ b/tf2_eigen_kdl/CMakeLists.txt
@@ -42,6 +42,12 @@ ament_export_dependencies(
   orocos_kdl
   tf2
 )
+
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
+ament_export_libraries(${PROJECT_NAME})
+
+# Export modern CMake targets
 ament_export_targets(export_${PROJECT_NAME})
 
 if(BUILD_TESTING)

--- a/tf2_eigen_kdl/package.xml
+++ b/tf2_eigen_kdl/package.xml
@@ -16,9 +16,6 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <buildtool_depend>eigen3_cmake_module</buildtool_depend>
-  <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>
-
   <build_depend>eigen</build_depend>
   <build_export_depend>eigen</build_export_depend>
 

--- a/tf2_geometry_msgs/CMakeLists.txt
+++ b/tf2_geometry_msgs/CMakeLists.txt
@@ -27,6 +27,16 @@ target_link_libraries(${PROJECT_NAME} INTERFACE
   tf2::tf2
   tf2_ros::tf2_ros)
 
+add_library(${PROJECT_NAME} INTERFACE)
+target_include_directories(${PROJECT_NAME} INTERFACE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${PROJECT_NAME} INTERFACE
+  ${geometry_msgs_TARGETS}
+  orocos-kdl
+  tf2::tf2
+  tf2_ros::tf2_ros)
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
 
@@ -55,7 +65,7 @@ if(BUILD_TESTING)
 endif()
 
 install(TARGETS ${PROJECT_NAME} EXPORT export_${PROJECT_NAME})
-install(DIRECTORY include/ DESTINATION include)
+install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 
 ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(

--- a/tf2_geometry_msgs/CMakeLists.txt
+++ b/tf2_geometry_msgs/CMakeLists.txt
@@ -20,16 +20,6 @@ ament_python_install_package(${PROJECT_NAME}
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME} INTERFACE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>")
-target_link_libraries(${PROJECT_NAME} INTERFACE
-  ${geometry_msgs_TARGETS}
-  orocos-kdl
-  tf2::tf2
-  tf2_ros::tf2_ros)
-
-add_library(${PROJECT_NAME} INTERFACE)
-target_include_directories(${PROJECT_NAME} INTERFACE
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 target_link_libraries(${PROJECT_NAME} INTERFACE
   ${geometry_msgs_TARGETS}

--- a/tf2_kdl/CMakeLists.txt
+++ b/tf2_kdl/CMakeLists.txt
@@ -52,6 +52,12 @@ if(BUILD_TESTING)
     ${tf2_msgs_TARGETS})
 endif()
 
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
+ament_export_libraries(tf2_kdl)
+
+# Export modern CMake targets
 ament_export_targets(export_tf2_kdl)
+
 ament_export_dependencies(builtin_interfaces geometry_msgs orocos_kdl tf2 tf2_ros)
 ament_package()

--- a/tf2_kdl/CMakeLists.txt
+++ b/tf2_kdl/CMakeLists.txt
@@ -20,9 +20,20 @@ find_package(tf2_ros REQUIRED)
 ament_python_install_package(${PROJECT_NAME}
      PACKAGE_DIR src/${PROJECT_NAME})
 
-install(DIRECTORY include/${PROJECT_NAME}/
-    DESTINATION include/${PROJECT_NAME}
-)
+add_library(tf2_kdl INTERFACE)
+target_link_libraries(tf2_kdl INTERFACE
+  ${builtin_interfaces_TARGETS}
+  ${geometry_msgs_TARGETS}
+  orocos-kdl
+  tf2::tf2
+  tf2_ros::tf2_ros)
+target_include_directories(tf2_kdl INTERFACE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+
+install(TARGETS tf2_kdl EXPORT export_tf2_kdl)
+
+install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 
 # TODO(ahcorde): Port python once https://github.com/ros2/orocos_kinematics_dynamics/pull/4 is merged
 # install(PROGRAMS scripts/test.py
@@ -35,18 +46,12 @@ if(BUILD_TESTING)
   find_package(tf2_msgs REQUIRED)
 
   ament_add_gtest(test_kdl test/test_tf2_kdl.cpp)
-  target_include_directories(test_kdl PUBLIC
-    include
-  )
-  ament_target_dependencies(test_kdl
-    builtin_interfaces
-    orocos_kdl
-    rclcpp
-    tf2
-    tf2_ros
-    tf2_msgs)
+  target_link_libraries(test_kdl
+    tf2_kdl
+    rclcpp::rclcpp
+    ${tf2_msgs_TARGETS})
 endif()
 
-ament_export_include_directories(include)
+ament_export_targets(export_tf2_kdl)
 ament_export_dependencies(builtin_interfaces geometry_msgs orocos_kdl tf2 tf2_ros)
 ament_package()

--- a/tf2_kdl/CMakeLists.txt
+++ b/tf2_kdl/CMakeLists.txt
@@ -49,12 +49,14 @@ if(BUILD_TESTING)
   target_link_libraries(test_kdl
     tf2_kdl
     rclcpp::rclcpp
-    ${tf2_msgs_TARGETS})
+    # Used, but not linked to test tf2_kdl's exports:
+    #   tf2::tf2
+    #   tf2_ros::tf2_ros
+  )
 endif()
 
 # Export old-style CMake variables
 ament_export_include_directories("include/${PROJECT_NAME}")
-ament_export_libraries(tf2_kdl)
 
 # Export modern CMake targets
 ament_export_targets(export_tf2_kdl)

--- a/tf2_ros/CMakeLists.txt
+++ b/tf2_ros/CMakeLists.txt
@@ -155,7 +155,13 @@ if(BUILD_TESTING)
 
 endif()
 
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
+ament_export_libraries(${PROJECT_NAME})
+
+# Export modern CMake targets
 ament_export_targets(export_${PROJECT_NAME})
+
 ament_export_dependencies(
   rcl_interfaces
   rclcpp_components

--- a/tf2_ros/CMakeLists.txt
+++ b/tf2_ros/CMakeLists.txt
@@ -48,15 +48,22 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE "TF2_ROS_BUILDING_DLL")
 add_executable(buffer_server src/buffer_server_main.cpp)
 target_link_libraries(buffer_server
   ${PROJECT_NAME}
+  rclcpp::rclcpp
 )
 
 add_library(static_transform_broadcaster_node SHARED
   src/static_transform_broadcaster_node.cpp
 )
 target_compile_definitions(static_transform_broadcaster_node PRIVATE "STATIC_TRANSFORM_BROADCASTER_BUILDING_DLL")
-target_link_libraries(static_transform_broadcaster_node
+target_include_directories(static_transform_broadcaster_node PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(static_transform_broadcaster_node PUBLIC
   ${PROJECT_NAME}
+  ${geometry_msgs_TARGETS}
   rclcpp::rclcpp
+  ${tf2_msgs_TARGETS})
+target_link_libraries(static_transform_broadcaster_node PRIVATE
   rclcpp_components::component)
 rclcpp_components_register_nodes(static_transform_broadcaster_node "tf2_ros::StaticTransformBroadcasterNode")
 

--- a/tf2_ros/CMakeLists.txt
+++ b/tf2_ros/CMakeLists.txt
@@ -56,6 +56,7 @@ add_library(static_transform_broadcaster_node SHARED
 target_compile_definitions(static_transform_broadcaster_node PRIVATE "STATIC_TRANSFORM_BROADCASTER_BUILDING_DLL")
 target_link_libraries(static_transform_broadcaster_node
   ${PROJECT_NAME}
+  rclcpp::rclcpp
   rclcpp_components::component)
 rclcpp_components_register_nodes(static_transform_broadcaster_node "tf2_ros::StaticTransformBroadcasterNode")
 
@@ -65,7 +66,9 @@ add_executable(static_transform_publisher
 )
 target_link_libraries(static_transform_publisher
   ${PROJECT_NAME}
+  rclcpp::rclcpp
   static_transform_broadcaster_node
+  tf2::tf2
 )
 
 add_executable(tf2_echo
@@ -73,6 +76,7 @@ add_executable(tf2_echo
 )
 target_link_libraries(tf2_echo
   ${PROJECT_NAME}
+  rclcpp::rclcpp
 )
 
 add_executable(tf2_monitor
@@ -80,6 +84,8 @@ add_executable(tf2_monitor
 )
 target_link_libraries(tf2_monitor
   ${PROJECT_NAME}
+  rclcpp::rclcpp
+  ${tf2_msgs_TARGETS}
 )
 
 # Install rules
@@ -114,6 +120,7 @@ if(BUILD_TESTING)
   find_package(ament_cmake_cpplint REQUIRED)
   find_package(ament_cmake_lint_cmake REQUIRED)
   find_package(ament_cmake_uncrustify REQUIRED)
+  find_package(rosgraph_msgs REQUIRED)
 
   ament_cppcheck(LANGUAGE "c++")
   ament_cpplint()
@@ -123,35 +130,78 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
 
   ament_add_gtest(test_buffer test/test_buffer.cpp)
-  target_link_libraries(test_buffer ${PROJECT_NAME})
+  target_link_libraries(test_buffer
+    ${PROJECT_NAME}
+    # Used, but not linked to test tf2_ros's exports:
+    #   rclcpp::rclcpp
+  )
 
   ament_add_gtest(test_buffer_server test/test_buffer_server.cpp)
-  target_link_libraries(test_buffer_server ${PROJECT_NAME})
+  target_link_libraries(test_buffer_server
+    ${PROJECT_NAME}
+    # Used, but not linked to test tf2_ros's exports:
+    #   rclcpp::rclcpp
+    #   rclcpp_action::rclcpp_action
+    #   ${tf2_msgs_TARGETS}
+  )
 
   ament_add_gtest(test_buffer_client test/test_buffer_client.cpp)
-  target_link_libraries(test_buffer_client ${PROJECT_NAME})
+  target_link_libraries(test_buffer_client
+    ${PROJECT_NAME}
+    # Used, but not linked to test tf2_ros's exports:
+    #   rclcpp::rclcpp
+    #   rclcpp_action::rclcpp_action
+    #   ${tf2_msgs_TARGETS}
+  )
 
   # Adds a tf2_ros message_filter unittest that uses
   # multiple target frames and a non-zero time tolerance
   ament_add_gtest(${PROJECT_NAME}_test_message_filter test/message_filter_test.cpp)
-  target_link_libraries(${PROJECT_NAME}_test_message_filter ${PROJECT_NAME})
+  target_link_libraries(${PROJECT_NAME}_test_message_filter
+    ${PROJECT_NAME}
+    # Used, but not linked to test tf2_ros's exports:
+    #   ${geometry_msgs_TARGETS}
+    #   message_filters::message_filters
+    #   rclcpp::rclcpp
+  )
 
   ament_add_gtest(${PROJECT_NAME}_test_transform_listener test/test_transform_listener.cpp)
-  target_link_libraries(${PROJECT_NAME}_test_transform_listener ${PROJECT_NAME})
+  target_link_libraries(${PROJECT_NAME}_test_transform_listener
+    ${PROJECT_NAME}
+    # Used, but not linked to test tf2_ros's exports:
+    #   rclcpp::rclcpp
+  )
 
   ament_add_gtest(${PROJECT_NAME}_test_static_transform_broadcaster test/test_static_transform_broadcaster.cpp)
-  target_link_libraries(${PROJECT_NAME}_test_static_transform_broadcaster ${PROJECT_NAME})
+  target_link_libraries(${PROJECT_NAME}_test_static_transform_broadcaster
+    ${PROJECT_NAME}
+    # Used, but not linked to test tf2_ros's exports:
+    #   rclcpp::rclcpp
+  )
 
   ament_add_gtest(${PROJECT_NAME}_test_transform_broadcaster test/test_transform_broadcaster.cpp)
-  target_link_libraries(${PROJECT_NAME}_test_transform_broadcaster ${PROJECT_NAME})
+  target_link_libraries(${PROJECT_NAME}_test_transform_broadcaster
+    ${PROJECT_NAME}
+    # Used, but not linked to test tf2_ros's exports:
+    #   rclcpp::rclcpp
+  )
 
   ament_add_gtest(${PROJECT_NAME}_test_time_reset test/time_reset_test.cpp)
   target_link_libraries(${PROJECT_NAME}_test_time_reset
     ${PROJECT_NAME}
-    ${rosgraph_msgs_TARGETS})
+    ${rosgraph_msgs_TARGETS}
+    # Used, but not linked to test tf2_ros's exports:
+    #   ${builtin_interfaces_TARGETS}
+    #   rclcpp::rclcpp
+  )
 
   ament_add_gtest(${PROJECT_NAME}_test_listener test/listener_unittest.cpp)
-  target_link_libraries(${PROJECT_NAME}_test_listener ${PROJECT_NAME})
+  target_link_libraries(${PROJECT_NAME}_test_listener
+    ${PROJECT_NAME}
+    # Used, but not linked to test tf2_ros's exports:
+    #   ${builtin_interfaces_TARGETS}
+    #   rclcpp::rclcpp
+  )
 
 endif()
 

--- a/tf2_ros/CMakeLists.txt
+++ b/tf2_ros/CMakeLists.txt
@@ -20,16 +20,6 @@ find_package(rclcpp_components REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_msgs REQUIRED)
 
-set(dependencies
-  builtin_interfaces
-  geometry_msgs
-  message_filters
-  rclcpp
-  rclcpp_action
-  tf2
-  tf2_msgs
-)
-
 # tf2_ros library
 add_library(${PROJECT_NAME} SHARED
   src/buffer.cpp
@@ -42,10 +32,15 @@ add_library(${PROJECT_NAME} SHARED
 )
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>")
-ament_target_dependencies(${PROJECT_NAME}
-  ${dependencies}
-)
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  ${builtin_interfaces_TARGETS}
+  ${geometry_msgs_TARGETS}
+  message_filters::message_filters
+  rclcpp::rclcpp
+  rclcpp_action::rclcpp_action
+  tf2::tf2
+  ${tf2_msgs_TARGETS})
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE "TF2_ROS_BUILDING_DLL")
 
@@ -54,24 +49,14 @@ add_executable(buffer_server src/buffer_server_main.cpp)
 target_link_libraries(buffer_server
   ${PROJECT_NAME}
 )
-ament_target_dependencies(buffer_server
-  ${dependencies}
-)
 
 add_library(static_transform_broadcaster_node SHARED
   src/static_transform_broadcaster_node.cpp
 )
 target_compile_definitions(static_transform_broadcaster_node PRIVATE "STATIC_TRANSFORM_BROADCASTER_BUILDING_DLL")
-target_include_directories(static_transform_broadcaster_node PUBLIC
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>")
-target_link_libraries(static_transform_broadcaster_node ${PROJECT_NAME})
-ament_target_dependencies(static_transform_broadcaster_node
-  "geometry_msgs"
-  "rclcpp"
-  "rclcpp_components"
-  "tf2_msgs"
-)
+target_link_libraries(static_transform_broadcaster_node
+  ${PROJECT_NAME}
+  rclcpp_components::component)
 rclcpp_components_register_nodes(static_transform_broadcaster_node "tf2_ros::StaticTransformBroadcasterNode")
 
 # static_transform_publisher
@@ -82,23 +67,12 @@ target_link_libraries(static_transform_publisher
   ${PROJECT_NAME}
   static_transform_broadcaster_node
 )
-ament_target_dependencies(static_transform_publisher
-  "geometry_msgs"
-  "rclcpp"
-  "tf2"
-  "tf2_msgs"
-)
 
 add_executable(tf2_echo
   src/tf2_echo.cpp
 )
 target_link_libraries(tf2_echo
   ${PROJECT_NAME}
-)
-ament_target_dependencies(tf2_echo
-  "geometry_msgs"
-  "rclcpp"
-  "tf2"
 )
 
 add_executable(tf2_monitor
@@ -107,20 +81,17 @@ add_executable(tf2_monitor
 target_link_libraries(tf2_monitor
   ${PROJECT_NAME}
 )
-ament_target_dependencies(tf2_monitor
-  ${dependencies}
-)
 
 # Install rules
 install(TARGETS ${PROJECT_NAME}
-  EXPORT ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
 )
 
 install(TARGETS static_transform_broadcaster_node
-  EXPORT static_transform_broadcaster_node
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -135,9 +106,7 @@ install(TARGETS
   DESTINATION lib/${PROJECT_NAME}
 )
 
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION include/${PROJECT_NAME}
-)
+install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 
 # Tests
 if(BUILD_TESTING)
@@ -154,73 +123,48 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
 
   ament_add_gtest(test_buffer test/test_buffer.cpp)
-  ament_target_dependencies(test_buffer
-    ${dependencies}
-  )
   target_link_libraries(test_buffer ${PROJECT_NAME})
 
   ament_add_gtest(test_buffer_server test/test_buffer_server.cpp)
-  ament_target_dependencies(test_buffer_server
-    ${dependencies}
-  )
   target_link_libraries(test_buffer_server ${PROJECT_NAME})
 
   ament_add_gtest(test_buffer_client test/test_buffer_client.cpp)
-  ament_target_dependencies(test_buffer_client
-    ${dependencies}
-  )
   target_link_libraries(test_buffer_client ${PROJECT_NAME})
 
   # Adds a tf2_ros message_filter unittest that uses
   # multiple target frames and a non-zero time tolerance
   ament_add_gtest(${PROJECT_NAME}_test_message_filter test/message_filter_test.cpp)
-  ament_target_dependencies(${PROJECT_NAME}_test_message_filter
-    ${dependencies}
-  )
   target_link_libraries(${PROJECT_NAME}_test_message_filter ${PROJECT_NAME})
 
   ament_add_gtest(${PROJECT_NAME}_test_transform_listener test/test_transform_listener.cpp)
-  ament_target_dependencies(${PROJECT_NAME}_test_transform_listener
-    ${dependencies}
-  )
   target_link_libraries(${PROJECT_NAME}_test_transform_listener ${PROJECT_NAME})
 
   ament_add_gtest(${PROJECT_NAME}_test_static_transform_broadcaster test/test_static_transform_broadcaster.cpp)
-  ament_target_dependencies(${PROJECT_NAME}_test_static_transform_broadcaster
-    rclcpp
-  )
   target_link_libraries(${PROJECT_NAME}_test_static_transform_broadcaster ${PROJECT_NAME})
 
   ament_add_gtest(${PROJECT_NAME}_test_transform_broadcaster test/test_transform_broadcaster.cpp)
-  ament_target_dependencies(${PROJECT_NAME}_test_transform_broadcaster
-    rclcpp
-  )
   target_link_libraries(${PROJECT_NAME}_test_transform_broadcaster ${PROJECT_NAME})
 
   ament_add_gtest(${PROJECT_NAME}_test_time_reset test/time_reset_test.cpp)
-  ament_target_dependencies(${PROJECT_NAME}_test_time_reset
-    ${dependencies}
-    rosgraph_msgs
-  )
-  target_link_libraries(${PROJECT_NAME}_test_time_reset ${PROJECT_NAME})
+  target_link_libraries(${PROJECT_NAME}_test_time_reset
+    ${PROJECT_NAME}
+    ${rosgraph_msgs_TARGETS})
 
   ament_add_gtest(${PROJECT_NAME}_test_listener test/listener_unittest.cpp)
-  ament_target_dependencies(${PROJECT_NAME}_test_listener
-    builtin_interfaces
-    geometry_msgs
-    rclcpp
-    tf2
-  )
   target_link_libraries(${PROJECT_NAME}_test_listener ${PROJECT_NAME})
 
 endif()
 
-ament_export_include_directories(include)
-ament_export_libraries(${PROJECT_NAME} static_transform_broadcaster_node)
-ament_export_targets(${PROJECT_NAME} static_transform_broadcaster_node)
+ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(
-  ${dependencies}
   rcl_interfaces
   rclcpp_components
+  builtin_interfaces
+  geometry_msgs
+  message_filters
+  rclcpp
+  rclcpp_action
+  tf2
+  tf2_msgs
 )
 ament_package()

--- a/tf2_ros/package.xml
+++ b/tf2_ros/package.xml
@@ -27,6 +27,7 @@
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>rosgraph_msgs</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Part of ros2/ros2#1150

This installs includes to `include/${PROJECT_NAME}` to mitigate include directory search order issues when overriding packages in desktop.

Part of ament/ament_cmake#365

This removes `ament_export_libraries` and `ament_export_include_directories` as they're redundant with the exported CMake targets in packages that I was already changing. I only updated packages that installed headers.

Part of ament/ament_cmake#292

This replaces `ament_target_dependencies()` calls with `target_link_libraries()` in packages that I was already changing. I only updated packages that installed headers.

This also removes the dependency on `eigen3_cmake_module` in packages that I was already changing. It's no longer necessary now that we can use modern CMake targets. I only updated packages that installed headers.

Requires ros2/rclcpp#1855 for the `rclcpp_components::component` target.