### PR TITLE
Make tf2_py Use FindPython3

### DIFF
--- a/tf2_py/CMakeLists.txt
+++ b/tf2_py/CMakeLists.txt
@@ -27,6 +27,7 @@ find_package(tf2 REQUIRED)
 
 find_package(python_cmake_module REQUIRED)
 find_package(PythonExtra REQUIRED)
+find_package(Python3 REQUIRED COMPONENTS Development)
 
 set(_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
 
@@ -36,33 +37,20 @@ endif()
 
 ament_python_install_package(${PROJECT_NAME})
 
-function(set_properties _targetname _build_type)
-  set_target_properties(${_targetname} PROPERTIES
-    PREFIX ""
-    LIBRARY_OUTPUT_DIRECTORY${_build_type} "${CMAKE_CURRENT_BINARY_DIR}/test_${PROJECT_NAME}"
-    RUNTIME_OUTPUT_DIRECTORY${_build_type} "${CMAKE_CURRENT_BINARY_DIR}/test_${PROJECT_NAME}"
-    OUTPUT_NAME "_${_targetname}${PythonExtra_EXTENSION_SUFFIX}"
-    SUFFIX "${PythonExtra_EXTENSION_EXTENSION}")
-endfunction()
+python3_add_library(_tf2_py src/tf2_py.cpp)
 
-add_library(${PROJECT_NAME} SHARED src/tf2_py.cpp)
+set_target_properties(_tf2_py PROPERTIES
+  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_${PROJECT_NAME}"
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_${PROJECT_NAME}"
+)
 
-set_properties(${PROJECT_NAME} "")
-if(WIN32)
-  set_properties(${PROJECT_NAME} "_DEBUG")
-  set_properties(${PROJECT_NAME} "_MINSIZEREL")
-  set_properties(${PROJECT_NAME} "_RELEASE")
-  set_properties(${PROJECT_NAME} "_RELWITHDEBINFO")
-endif()
-
-ament_target_dependencies(${PROJECT_NAME}
-  "geometry_msgs"
-  "tf2"
-  "PythonExtra"
+target_link_libraries(_tf2_py PRIVATE
+  ${geometry_msgs_TARGETS}
+  tf2::tf2
 )
 
 install(TARGETS
-  ${PROJECT_NAME}
+  _tf2_py
   DESTINATION ${PYTHON_INSTALL_DIR}/${PROJECT_NAME}
 )
 

--- a/tf2_py/CMakeLists.txt
+++ b/tf2_py/CMakeLists.txt
@@ -38,6 +38,11 @@ ament_python_install_package(${PROJECT_NAME})
 
 python3_add_library(_tf2_py src/tf2_py.cpp)
 
+if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+  # python3_add_library should really take care of this for us, but it doesn't
+  set_property(TARGET _tf2_py PROPERTY SUFFIX "_d.pyd")
+endif()
+
 # Set output directories to import module from the build directory
 # Use a no-op generator expression so multi-config generators don't append an
 # extra directory like Release/ or Debug/ and break the Python import.

--- a/tf2_py/CMakeLists.txt
+++ b/tf2_py/CMakeLists.txt
@@ -20,20 +20,19 @@ if(CMAKE_COMPILER_IS_GNUCXX)
   add_compile_options(-Wno-cast-function-type)
 endif()
 
+# Figure out Python3 debug/release before anything else can find_package it
+if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+  find_package(python_cmake_module REQUIRED)
+  find_package(PythonExtra REQUIRED)
+  # Force FindPython3 to use the debug interpretter where ROS 2 expects it
+  set(Python3_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
+endif()
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(tf2 REQUIRED)
-
-find_package(python_cmake_module REQUIRED)
-find_package(PythonExtra REQUIRED)
-find_package(Python3 REQUIRED COMPONENTS Development)
-
-set(_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
-
-if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
-  set(PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
-endif()
 
 ament_python_install_package(${PROJECT_NAME})
 
@@ -67,14 +66,11 @@ if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
 
   ament_add_pytest_test(tf2_py_test test
-    PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}"
     APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}
   )
 
   # Create importable location in build directory
   file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/test_tf2_py/__init__.py" "")
 endif()
-
-set(PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}")
 
 ament_package()

--- a/tf2_py/CMakeLists.txt
+++ b/tf2_py/CMakeLists.txt
@@ -38,9 +38,12 @@ ament_python_install_package(${PROJECT_NAME})
 
 python3_add_library(_tf2_py src/tf2_py.cpp)
 
+# Set output directories to import module from the build directory
+# Use a no-op generator expression so multi-config generators don't append an
+# extra directory like Release/ or Debug/ and break the Python import.
 set_target_properties(_tf2_py PROPERTIES
-  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_${PROJECT_NAME}"
-  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_${PROJECT_NAME}"
+  LIBRARY_OUTPUT_DIRECTORY "$<1:${CMAKE_CURRENT_BINARY_DIR}/test_${PROJECT_NAME}>"
+  RUNTIME_OUTPUT_DIRECTORY "$<1:${CMAKE_CURRENT_BINARY_DIR}/test_${PROJECT_NAME}>"
 )
 
 target_link_libraries(_tf2_py PRIVATE


### PR DESCRIPTION
Split from #493 

This makes tf2_py use FindPython3 and its CMake function `python3_add_library`. I split this because smaller PRs are easier to review, and I want to see how it does on Windows debug.