### PR TITLE
Export a tf2_geometry_msgs::tf2_geometry_msgs target

### DIFF
--- a/tf2_geometry_msgs/CMakeLists.txt
+++ b/tf2_geometry_msgs/CMakeLists.txt
@@ -9,14 +9,10 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -Wnon-virtual-dtor -Woverloaded-virtual)
 endif()
 
-find_package(ament_cmake_auto REQUIRED)
-set(required_dependencies
-  "geometry_msgs"
-  "orocos_kdl"
-  "tf2"
-  "tf2_ros"
-)
-ament_auto_find_build_dependencies(REQUIRED ${required_dependencies})
+find_package(geometry_msgs REQUIRED)
+find_package(orocos_kdl REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_ros REQUIRED)
 
 # TODO(ros2/geometry2#110) Port python once PyKDL becomes usable in ROS 2
 # ament_python_install_package(${PROJECT_NAME}
@@ -26,6 +22,16 @@ ament_auto_find_build_dependencies(REQUIRED ${required_dependencies})
 # install(PROGRAMS scripts/test.py
 #    DESTINATION lib/${PROJECT_NAME}
 # )
+
+add_library(${PROJECT_NAME} INTERFACE)
+target_include_directories(${PROJECT_NAME} INTERFACE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>")
+target_link_libraries(${PROJECT_NAME} INTERFACE
+  ${geometry_msgs_TARGETS}
+  orocos-kdl
+  tf2::tf2
+  tf2_ros::tf2_ros)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -42,27 +48,20 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_tf2_geometry_msgs test/test_tf2_geometry_msgs.cpp)
   if(TARGET test_tf2_geometry_msgs)
-    target_include_directories(test_tf2_geometry_msgs PUBLIC include)
-    ament_target_dependencies(test_tf2_geometry_msgs
-      "geometry_msgs"
-      "orocos_kdl"
-      "rclcpp"
-      "tf2"
-      "tf2_ros"
-    )
+    target_link_libraries(test_tf2_geometry_msgs
+      ${PROJECT_NAME}
+      rclcpp::rclcpp)
   endif()
 endif()
 
-add_library(${PROJECT_NAME} INTERFACE)
-target_include_directories(${PROJECT_NAME} INTERFACE $<INSTALL_INTERFACE:include>)
-ament_target_dependencies(${PROJECT_NAME} INTERFACE ${required_dependencies})
+install(TARGETS ${PROJECT_NAME} EXPORT export_${PROJECT_NAME})
+install(DIRECTORY include/ DESTINATION include)
 
-install(
-  TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
-  INCLUDES DESTINATION include
-)
+ament_export_targets(export_${PROJECT_NAME})
+ament_export_dependencies(
+  "geometry_msgs"
+  "orocos_kdl"
+  "tf2"
+  "tf2_ros")
 
-ament_export_targets(${PROJECT_NAME})
-ament_export_dependencies(${required_dependencies})
-
-ament_auto_package()
+ament_package()

--- a/tf2_geometry_msgs/CMakeLists.txt
+++ b/tf2_geometry_msgs/CMakeLists.txt
@@ -50,7 +50,10 @@ if(BUILD_TESTING)
   if(TARGET test_tf2_geometry_msgs)
     target_link_libraries(test_tf2_geometry_msgs
       ${PROJECT_NAME}
-      rclcpp::rclcpp)
+      rclcpp::rclcpp
+      # Used, but not linked to test ${PROJECT_NAME}'s exports:
+      #   tf2_ros::tf2_ros
+    )
   endif()
 endif()
 

--- a/tf2_geometry_msgs/package.xml
+++ b/tf2_geometry_msgs/package.xml
@@ -11,7 +11,7 @@
   <author email="tfoote@osrfoundation.org">Tully Foote</author>
   <author>Wim Meeussen</author>
 
-  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>geometry_msgs</depend>
   <depend>orocos_kdl</depend>


### PR DESCRIPTION
Split from #493

This makes tf2_geometry_msgs use more modern CMake. It now exports a `tf2_geometry_msgs::tf2_geometry_msgs` target so downstream projects can use modern CMake, and avoids `ament_target_dependencies()` (ament/ament_cmake#292).