### PR TITLE
Be much more careful about cleanup in the tf2_ros_py tests.

### DIFF
--- a/tf2_ros_py/test/test_buffer.py
+++ b/tf2_ros_py/test/test_buffer.py
@@ -36,14 +36,6 @@ from geometry_msgs.msg import TransformStamped, PointStamped
 
 
 class TestBuffer(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        pass
-
-    @classmethod
-    def tearDownClass(cls):
-        pass
-
     def build_transform(self, target, source, rclpy_time):
         transform = TransformStamped()
         transform.header.frame_id = target

--- a/tf2_ros_py/test/test_listener_and_broadcaster.py
+++ b/tf2_ros_py/test/test_listener_and_broadcaster.py
@@ -73,6 +73,7 @@ class TestBroadcasterAndListener(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        cls.node.destroy_node()
         rclpy.shutdown()
 
     def setUp(self):

--- a/tf2_ros_py/tf2_ros/buffer_client.py
+++ b/tf2_ros_py/tf2_ros/buffer_client.py
@@ -273,3 +273,8 @@ class BufferClient(tf2_ros.BufferInterface):
             raise tf2.TransformException(result.error.error_string)
 
         return result.transform
+
+    def destroy(self) -> None:
+        """Cleanup resources associated with this BufferClient."""
+
+        self.action_client.destroy()


### PR DESCRIPTION
In certain circumstances on Windows, we were seeing crashes
while the tf2_ros_py tests were running.  After some investigation,
I found out that the tf2_ros_py buffer tests were not being
careful about when they cleaned up.  This lead to the crashes.

What this change does is to make the cleanup in the tf2_ros_py
tests very explicit, which fixes the crashes on Windows in
my testing.

Arguably, this change is deeply un-Pythonic.  Really the cleanup
should just happen naturally as part of the regular Python destruction.
There are a few reasons I think we should take this change anyway:

1. Throughout the rest of the ROS 2 core, the Python code is very
   careful to cleanup after itself, as is done here.  So I would
   say that the current problem is more of a design/low-level
   issue in rclpy than something here in tf2_ros_py
2. Cleaning up like this is arguably "more correct" than waiting
   for the Python garbage collector to do it.  That is, when
   we are no longer using an Action server or client, we really
   want it to be destructed ASAP, not eventually.
3. We need this change in order to change the default DDS vendor
   to Fast-RTPS.  This could be a bug in Fast-RTPS, though it
   is not totally clear to me where or how given the number of
   layers involved here (Python unittest -> tf2_ros_py -> rclpy
   -> rcl -> rmw -> rmw_fastrtps -> Fast-RTPS).

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

I believe this will unblock https://github.com/ros2/rmw/pull/315 and https://github.com/ros2/rmw_fastrtps/pull/571