### PR TITLE
Add in one more destroy call that was missed in testing.

### DIFF
--- a/tf2_ros_py/test/test_buffer_client.py
+++ b/tf2_ros_py/test/test_buffer_client.py
@@ -139,6 +139,8 @@ class TestBufferClient(unittest.TestCase):
         self.assertEqual(build_transform(
             'foo', 'bar', rclpy.time.Time().to_msg()), result)
 
+        buffer_client.destroy()
+
     def test_lookup_transform_fail(self):
         buffer_client = BufferClient(
             self.node, 'lookup_transform', check_frequency=10.0, timeout_padding=rclpy.duration.Duration(seconds=0.0))


### PR DESCRIPTION
This may fix some of the crashes on Windows.  Either way,
it doesn't hurt to have (and is more "correct" in our
current usage of rclpy).

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This is a follow-on from #499 , and may fix #503