### PR TITLE
Adding shared pointer definition to tf2 buffer

### DIFF
--- a/tf2_ros/include/tf2_ros/buffer.h
+++ b/tf2_ros/include/tf2_ros/buffer.h
@@ -63,6 +63,7 @@ class Buffer : public BufferInterface, public AsyncBufferInterface, public tf2::
 public:
   using tf2::BufferCore::lookupTransform;
   using tf2::BufferCore::canTransform;
+  using SharedPtr = std::shared_ptr<tf2_ros::Buffer>;
 
   /** \brief  Constructor for a Buffer object
    * \param clock A clock to use for time and sleeping


### PR DESCRIPTION
So we can have semantics like `tf2_ros::Buffer::SharedPtr` like we have for many other items in ROS 2, rather than `shared_ptr<tf2_ros::Buffer>` semantics. 