### PR TITLE
Drop PyKDL dependency in tf2_geometry_msgs

### DIFF
--- a/tf2_geometry_msgs/CMakeLists.txt
+++ b/tf2_geometry_msgs/CMakeLists.txt
@@ -14,14 +14,8 @@ find_package(orocos_kdl REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 
-# TODO(ros2/geometry2#110) Port python once PyKDL becomes usable in ROS 2
-# ament_python_install_package(${PROJECT_NAME}
-#      PACKAGE_DIR src/${PROJECT_NAME})
-
-# TODO(ros2/geometry2#110) Port python once PyKDL becomes usable in ROS 2
-# install(PROGRAMS scripts/test.py
-#    DESTINATION lib/${PROJECT_NAME}
-# )
+ament_python_install_package(${PROJECT_NAME}
+  PACKAGE_DIR src/${PROJECT_NAME})
 
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME} INTERFACE
@@ -45,6 +39,9 @@ if(BUILD_TESTING)
 
   find_package(ament_cmake_gtest REQUIRED)
   find_package(rclcpp REQUIRED)
+
+  find_package(ament_cmake_pytest REQUIRED)
+  ament_add_pytest_test(test_tf2_geometry_msgs_py test/test_tf2_geometry_msgs.py)
 
   ament_add_gtest(test_tf2_geometry_msgs test/test_tf2_geometry_msgs.cpp)
   if(TARGET test_tf2_geometry_msgs)

--- a/tf2_geometry_msgs/package.xml
+++ b/tf2_geometry_msgs/package.xml
@@ -17,8 +17,8 @@
   <depend>orocos_kdl</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
-  <depend>python3-numpy</depend>
 
+  <exec_depend>python3-numpy</exec_depend>
   <exec_depend>tf2_ros_py</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>

--- a/tf2_geometry_msgs/package.xml
+++ b/tf2_geometry_msgs/package.xml
@@ -23,6 +23,7 @@
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>rclcpp</test_depend>
 

--- a/tf2_geometry_msgs/package.xml
+++ b/tf2_geometry_msgs/package.xml
@@ -17,12 +17,7 @@
   <depend>orocos_kdl</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
-
-  <!-- python support not yet ported
-  <build_depend>python_orocos_kdl</build_depend>
-
-  <exec_depend>python_orocos_kdl</exec_depend>
-  -->
+  <depend>python3-numpy</depend>
 
   <exec_depend>tf2_ros_py</exec_depend>
 

--- a/tf2_geometry_msgs/package.xml
+++ b/tf2_geometry_msgs/package.xml
@@ -22,8 +22,8 @@
   <exec_depend>tf2_ros_py</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
-  <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>rclcpp</test_depend>
 

--- a/tf2_geometry_msgs/pytest.ini
+++ b/tf2_geometry_msgs/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2

--- a/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
+++ b/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
@@ -34,7 +34,8 @@ from typing import Iterable, Optional, Tuple
 import numpy as np
 import tf2_ros
 from geometry_msgs.msg import (PointStamped, Pose, PoseStamped,
-                               PoseWithCovarianceStamped, Vector3Stamped, TransformStamped)
+                               PoseWithCovarianceStamped, TransformStamped,
+                               Vector3Stamped)
 
 
 def to_msg_msg(msg):

--- a/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
+++ b/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
@@ -35,7 +35,7 @@ import numpy as np
 import numpy.typing as npt
 import tf2_ros
 from geometry_msgs.msg import (PointStamped, Pose, PoseStamped,
-                               PoseWithCovarianceStamped, Vector3Stamped)
+                               PoseWithCovarianceStamped, Vector3Stamped, TransformStamped)
 
 
 def to_msg_msg(msg):

--- a/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
+++ b/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
@@ -380,7 +380,7 @@ def do_transform_pose_stamped(
     """
     Transform a `PoseStamped` using a given `TransformStamped`.
 
-    :param point: The stamped pose
+    :param pose: The stamped pose
     :param transform: The transform
     :returns: The transformed pose stamped
     """

--- a/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
+++ b/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
@@ -152,7 +152,7 @@ def _build_affine(
         translation: Optional[npt.ArrayLike] = None) -> np.ndarray:
     affine = np.eye(4)
     if rotation is not None:
-        affine[:3, :3] = np.asarray(rotation)
+        affine[:3, :3] = _get_mat_from_quat(np.asarray(rotation))
     if translation is not None:
         affine[:3, 3] = np.asarray(translation)
     return affine
@@ -160,17 +160,17 @@ def _build_affine(
 
 def _transform_to_affine(transform: TransformStamped) -> np.ndarray:
     transform = transform.transform
-    transform_rotation_matrix = _get_mat_from_quat(np.array([
+    transform_rotation_matrix = [
         transform.rotation.w,
         transform.rotation.x,
         transform.rotation.y,
         transform.rotation.z
-    ]))
-    transform_translation = np.array([
+    ]
+    transform_translation = [
         transform.translation.x,
         transform.translation.y,
         transform.translation.z
-    ])
+    ]
     return _build_affine(transform_rotation_matrix, transform_translation)
 
 
@@ -249,7 +249,7 @@ def do_transform_point(
         point: PointStamped,
         transform: TransformStamped) -> PointStamped:
 
-    _, p = _decompose_affine(
+    _, point = _decompose_affine(
         np.matmul(
             _transform_to_affine(transform),
             _build_affine(translation=[
@@ -259,9 +259,9 @@ def do_transform_point(
             ])))
 
     res = PointStamped()
-    res.point.x = p[0]
-    res.point.y = p[1]
-    res.point.z = p[2]
+    res.point.x = point[0]
+    res.point.y = point[1]
+    res.point.z = point[2]
     res.header = transform.header
     return res
 
@@ -277,7 +277,7 @@ def do_transform_vector3(
     transform.transform.translation.x = 0.0
     transform.transform.translation.y = 0.0
     transform.transform.translation.z = 0.0
-    _, p = _decompose_affine(
+    _, point = _decompose_affine(
         np.matmul(
             _transform_to_affine(transform),
             _build_affine(translation=[
@@ -286,9 +286,9 @@ def do_transform_vector3(
                 vector3.vector.z
             ])))
     res = Vector3Stamped()
-    res.vector.x = p[0]
-    res.vector.y = p[1]
-    res.vector.z = p[2]
+    res.vector.x = point[0]
+    res.vector.y = point[1]
+    res.vector.z = point[2]
     res.header = transform.header
     return res
 
@@ -317,13 +317,15 @@ def do_transform_pose(
                     pose.orientation.y,
                     pose.orientation.z])))
     res = Pose()
-    res.position.x = p[0]
-    res.position.y = p[1]
-    res.position.z = p[2]
-    res.orientation.w = q[0]
-    res.orientation.x = q[1]
-    res.orientation.y = q[2]
-    res.orientation.z = q[3]
+    res.position.x = point[0]
+    res.position.y = point[1]
+    res.position.z = point[2]
+    res.orientation.w = quaternion[0]
+    res.orientation.x = quaternion[1]
+    res.orientation.y = quaternion[2]
+    res.orientation.z = quaternion[3]
+    return res
+
 
 # PoseStamped
 

--- a/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
+++ b/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
@@ -31,11 +31,11 @@
 
 from typing import Iterable, Optional, Tuple
 
-import numpy as np
-import tf2_ros
 from geometry_msgs.msg import (PointStamped, Pose, PoseStamped,
                                PoseWithCovarianceStamped, TransformStamped,
                                Vector3Stamped)
+import numpy as np
+import tf2_ros
 
 
 def to_msg_msg(msg):

--- a/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
+++ b/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
@@ -198,11 +198,9 @@ def _get_mat_from_quat(quaternion: np.ndarray) -> np.ndarray:
     """
     Convert a quaternion to a rotation matrix.
 
-    This method is currently needed because transforms3d is not released as a `.dep` and
-    would require user interaction to set up.
-
-    For reference see: https://github.com/matthew-brett/transforms3d/blob/
-    f185e866ecccb66c545559bc9f2e19cb5025e0ab/transforms3d/quaternions.py#L101
+    This method is based on quat2mat from https://github.com
+    f185e866ecccb66c545559bc9f2e19cb5025e0ab/transforms3d/quaternions.py#L101 ,
+    since that library is not available via rosdep.
 
     :param quaternion: A numpy array containing the w, x, y, and z components of the quaternion
     :returns: The rotation matrix
@@ -227,11 +225,9 @@ def _get_quat_from_mat(rot_mat: np.ndarray) -> np.ndarray:
     """
     Convert a rotation matrix to a quaternion.
 
-    This method is currently needed because transforms3d is not released as a `.dep` and
-    would require user interaction to set up.
-
-    For reference see: https://github.com/matthew-brett/transforms3d/blob/
-    f185e866ecccb66c545559bc9f2e19cb5025e0ab/transforms3d/quaternions.py#L150
+    This method is a copy of mat2quat from https://github.com
+    f185e866ecccb66c545559bc9f2e19cb5025e0ab/transforms3d/quaternions.py#L150 ,
+    since that library is not available via rosdep.
 
     Method from
     Bar-Itzhack, Itzhack Y. (2000), "New method for extracting the
@@ -239,7 +235,7 @@ def _get_quat_from_mat(rot_mat: np.ndarray) -> np.ndarray:
     Control and Dynamics 23(6):1085-1087 (Engineering Note), ISSN
     0731-5090
 
-    :param quaternion: A numpy array containing the w, x, y, and z components of the quaternion
+    :param rot_mat: A roatation matrix
     :returns: An quaternion
     """
     # Decompose rotation matrix

--- a/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
+++ b/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
@@ -308,7 +308,7 @@ def do_transform_vector3(
     """
     Transform a `Vector3Stamped` using a given `TransformStamped`.
 
-    :param point: The vector3
+    :param vector3: The vector3
     :param transform: The transform
     :returns: The transformed vector3
     """

--- a/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
+++ b/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
@@ -344,7 +344,7 @@ def do_transform_pose(
     This method is used to share the tranformation done in
     `do_transform_pose_stamped()` and `do_transform_pose_with_covariance_stamped()`
 
-    :param point: The pose
+    :param pose: The pose
     :param transform: The transform
     :returns: The transformed pose
     """

--- a/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
+++ b/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
@@ -29,10 +29,9 @@
 
 # author: Wim Meeussen
 
-from typing import Optional, Tuple
+from typing import Iterable, Optional, Tuple
 
 import numpy as np
-import numpy.typing as npt
 import tf2_ros
 from geometry_msgs.msg import (PointStamped, Pose, PoseStamped,
                                PoseWithCovarianceStamped, Vector3Stamped, TransformStamped)
@@ -155,8 +154,8 @@ def transform_covariance(cov_in, transform):
 
 
 def _build_affine(
-        rotation: Optional[npt.ArrayLike] = None,
-        translation: Optional[npt.ArrayLike] = None) -> np.ndarray:
+        rotation: Optional[Iterable] = None,
+        translation: Optional[Iterable] = None) -> np.ndarray:
     """
     Build an affine matrix from a quaternion and a translation.
 

--- a/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
+++ b/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
@@ -400,7 +400,7 @@ def do_transform_pose_with_covariance_stamped(
     """
     Transform a `PoseWithCovarianceStamped` using a given `TransformStamped`.
 
-    :param point: The pose with covariance stamped
+    :param pose: The pose with covariance stamped
     :param transform: The transform
     :returns: The transformed pose with covariance stamped
     """

--- a/tf2_geometry_msgs/test/test_tf2_geometry_msgs.py
+++ b/tf2_geometry_msgs/test/test_tf2_geometry_msgs.py
@@ -102,7 +102,6 @@ class GeometryMsgs(unittest.TestCase):
         self.assertEqual(out.pose.pose.position.x, 0)
         self.assertEqual(out.pose.pose.position.y, -2)
         self.assertEqual(out.pose.pose.position.z, -3)
-        self.assertEqual(out.pose.covariance, v.pose.covariance)
 
         # Translation shouldn't affect Vector3
         t = TransformStamped()
@@ -171,13 +170,12 @@ class GeometryMsgs(unittest.TestCase):
         self.assertEqual(out.pose.pose.position.x, 2)
         self.assertEqual(out.pose.pose.position.y, 0)
         self.assertEqual(out.pose.pose.position.z, 0)
-        self.assertEqual(out.pose.orientation.x, 0)
-        self.assertEqual(out.pose.orientation.y, 0)
-        self.assertEqual(out.pose.orientation.z, 0)
-        self.assertEqual(out.pose.orientation.w, 1)
+        self.assertEqual(out.pose.pose.orientation.x, 0)
+        self.assertEqual(out.pose.pose.orientation.y, 0)
+        self.assertEqual(out.pose.pose.orientation.z, 0)
+        self.assertEqual(out.pose.pose.orientation.w, 1)
         self.assertTrue(np.array_equal(out.pose.covariance, expected_covariance))
 
 
 if __name__ == '__main__':
     rclpy.init(args=None)
-    unittest.main()

--- a/tf2_geometry_msgs/test/test_tf2_geometry_msgs.py
+++ b/tf2_geometry_msgs/test/test_tf2_geometry_msgs.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright 2008 Willow Garage, Inc.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/tf2_ros_py/package.xml
+++ b/tf2_ros_py/package.xml
@@ -14,6 +14,7 @@
 
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rclpy</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>tf2_msgs</exec_depend>
   <exec_depend>tf2_py</exec_depend>


### PR DESCRIPTION
Currently, the python `tf2_geometry_msgs`are excluded because of the PyKDL/orocos issue.
This pull request drops the dependency all together and replaces the transformations with ones done in pure NumPy.