### PR TITLE
Workaround broken RHEL FindEigen3.cmake

### DIFF
--- a/tf2_eigen/CMakeLists.txt
+++ b/tf2_eigen/CMakeLists.txt
@@ -14,7 +14,11 @@ find_package(geometry_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 
-find_package(Eigen3 REQUIRED)
+# Work around broken find module in AlmaLinux/RHEL eigen3-devel from PowerTools repo
+find_package(Eigen3 QUIET NO_MODULE)
+if(NOT Eigen3_FOUND)
+  find_package(Eigen3 REQUIRED)
+endif()
 
 add_library(tf2_eigen INTERFACE)
 target_link_libraries(tf2_eigen INTERFACE


### PR DESCRIPTION
This works around a broken find module shipped in `eigen3-devel` from the PowerTools repo on AlmaLinux 8. The PR resovles this build failure.
https://ci.ros2.org/view/nightly/job/nightly_linux-rhel_debug/1095/

https://centos.pkgs.org/8/centos-powertools-x86_64/eigen3-devel-3.3.4-6.el8.noarch.rpm.html

The first problem is `eigen3-devel` has a patch to install a `FindEigen3.cmake` module at all. Eigen3 ships an `Eigen3Config.CMake` file, so the find module is unnecessary.

The second problem is the find module might have been able to find the `Eigen3Config.cmake`, except the it has a hard coded version it searches for: `2.91.0`. That's a different major version from the actual version of Eigen 3 that is shipped (`3.3.4`), so the `Eigen3ConfigVersion.cmake` file reports it as incompatible. 

The find module goes on to search for the eigen headers anyways, and it does find them, but it instead of using [the standard variable name `Eigen3_INCLUDE_DIRS`](https://cmake.org/cmake/help/latest/manual/cmake-developer.7.html#standard-variable-names), it puts the include directory into the variable `EIGEN3_INCLUDE_DIR` (note wrong case and no `S`).

This PR fixes it by first quietly finding `Eigen3` without considering find modules, and if that doesn't work it tries again with them.