### PR TITLE
Added additional flag to fix race condition in TransformListener

### DIFF
--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -36,6 +36,7 @@
 #include <tf2/time.h>
 #include <tf2_ros/visibility_control.h>
 
+#include <atomic>
 #include <tf2_msgs/msg/tf_message.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -45,6 +46,7 @@
 #include <memory>
 #include <thread>
 #include <utility>
+#include <atomic>
 
 
 namespace tf2_ros
@@ -155,6 +157,7 @@ private:
   using thread_ptr =
     std::unique_ptr<std::thread, std::function<void (std::thread *)>>;
   thread_ptr dedicated_listener_thread_;
+  std::atomic_bool keep_running_;
 
   rclcpp::Node::SharedPtr optional_default_node_ = nullptr;
   rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr message_subscription_tf_;

--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -36,7 +36,6 @@
 #include <tf2/time.h>
 #include <tf2_ros/visibility_control.h>
 
-#include <atomic>
 #include <tf2_msgs/msg/tf_message.hpp>
 #include <rclcpp/rclcpp.hpp>
 

--- a/tf2_ros/src/transform_listener.cpp
+++ b/tf2_ros/src/transform_listener.cpp
@@ -73,17 +73,18 @@ void TransformListener::initThread(
   // see: http://stackoverflow.com/a/27389714/671658
   // I (wjwwood) chose to use the lamda rather than the static cast solution.
   auto run_func =
-    [executor, &keep_running =keep_running_](rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface) {
+    [executor,
+      & keep_running =
+      keep_running_](rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface) {
       executor->add_node(node_base_interface);
-      while(keep_running.load())
-      {
+      while (keep_running.load()) {
         executor->spin_once();
       }
       executor->remove_node(node_base_interface);
     };
   dedicated_listener_thread_ = thread_ptr(
     new std::thread(run_func, node_base_interface),
-    [executor, &keep_running = keep_running_](std::thread * t) {
+    [executor, & keep_running = keep_running_](std::thread * t) {
       keep_running.store(false);
       executor->cancel();
       t->join();

--- a/tf2_ros/src/transform_listener.cpp
+++ b/tf2_ros/src/transform_listener.cpp
@@ -67,19 +67,24 @@ void TransformListener::initThread(
 {
   auto executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
 
+  keep_running_ = true;
   // This lambda is required because `std::thread` cannot infer the correct
   // rclcpp::spin, since there are more than one versions of it (overloaded).
   // see: http://stackoverflow.com/a/27389714/671658
   // I (wjwwood) chose to use the lamda rather than the static cast solution.
   auto run_func =
-    [executor](rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface) {
+    [executor, &keep_running =keep_running_](rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface) {
       executor->add_node(node_base_interface);
-      executor->spin();
+      while(keep_running.load())
+      {
+        executor->spin_once();
+      }
       executor->remove_node(node_base_interface);
     };
   dedicated_listener_thread_ = thread_ptr(
     new std::thread(run_func, node_base_interface),
-    [executor](std::thread * t) {
+    [executor, &keep_running = keep_running_](std::thread * t) {
+      keep_running.store(false);
       executor->cancel();
       t->join();
       delete t;

--- a/tf2_ros/test/test_transform_listener.cpp
+++ b/tf2_ros/test/test_transform_listener.cpp
@@ -77,6 +77,14 @@ TEST(tf2_test_transform_listener, transform_listener_as_member)
   custom_node->init_tf_listener();
 }
 
+TEST(tf2_test_transform_listener, transform_listener_should_destroy_correctly)
+{
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+  tf2_ros::Buffer buffer(clock);
+  tf2_ros::TransformListener tfl(buffer, true);
+  (void) tfl;
+}
+
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Fixed race condition in TransformListener which happens when TransformListener destructor is called before dedicated thread reaches `executor->spin()`

The issue is reported [here](https://github.com/ros2/geometry2/issues/517)

The alternative solution is to add thread-safe executor:
```cpp
class SingleTreadedThreadSafeExecutor : public rclcpp::executors::SingleThreadedExecutor{
public:
  SingleTreadedThreadSafeExecutor() : is_terminated_(false)
  {

  }

  void spin_thread_safe(){
    if (spinning.exchange(true)) {
      throw std::runtime_error("spin() called while already spinning");
    }
    RCLCPP_SCOPE_EXIT(this->spinning.store(false); );
    while (rclcpp::ok(this->context_) && !is_terminated_ && spinning.load()) {
      rclcpp::AnyExecutable any_executable;
      if (get_next_executable(any_executable)) {
        execute_any_executable(any_executable);
      }
    }
  }
  void shutdown(){
    is_terminated_ = true;
    this->cancel();
  }

protected:
  std::atomic_bool is_terminated_;
};


void TransformListener::initThread(
  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface)
{
  auto executor = std::make_shared<SingleTreadedThreadSafeExecutor>();

  // This lambda is required because `std::thread` cannot infer the correct
  // rclcpp::spin, since there are more than one versions of it (overloaded).
  // see: http://stackoverflow.com/a/27389714/671658
  // I (wjwwood) chose to use the lamda rather than the static cast solution.
  auto run_func =
    [executor](rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface) {
      executor->add_node(node_base_interface);
      executor->spin();
      executor->remove_node(node_base_interface);
    };
  dedicated_listener_thread_ = thread_ptr(
    new std::thread(run_func, node_base_interface),
    [executor](std::thread * t) {
      executor->shutdown();
      t->join();
      delete t;
      // TODO(tfoote) reenable callback queue processing
      // tf_message_callback_queue_.callAvailable(ros::WallDuration(0.01));
    });
  // Tell the buffer we have a dedicated thread to enable timeouts
  buffer_.setUsingDedicatedThread(true);
}
```