### PR TITLE
Add missing package needed because of newly-enabled test

### DIFF
--- a/tf2_sensor_msgs/package.xml
+++ b/tf2_sensor_msgs/package.xml
@@ -31,6 +31,7 @@
   <exec_depend>tf2_ros_py</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>rclcpp</test_depend>


### PR DESCRIPTION
A recent commit: https://github.com/ros2/geometry2/commit/6242f01eddae5187ca8bc6e4a0f8792ad9d0aade

enabled a pytest without also adding the test dependency to the package.xml.

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>