### PR TITLE
Bugfix: SetEuler/SetRPY implementations were differing 

### DIFF
--- a/tf2/include/tf2/LinearMath/Quaternion.h
+++ b/tf2/include/tf2/LinearMath/Quaternion.h
@@ -75,10 +75,10 @@ public:
 		tf2Scalar sinPitch = tf2Sin(halfPitch);
 		tf2Scalar cosRoll = tf2Cos(halfRoll);
 		tf2Scalar sinRoll = tf2Sin(halfRoll);
-		setValue(cosRoll * sinPitch * cosYaw + sinRoll * cosPitch * sinYaw,
-			cosRoll * cosPitch * sinYaw - sinRoll * sinPitch * cosYaw,
-			sinRoll * cosPitch * cosYaw - cosRoll * sinPitch * sinYaw,
-			cosRoll * cosPitch * cosYaw + sinRoll * sinPitch * sinYaw);
+		setValue(sinRoll * cosPitch * cosYaw - cosRoll * sinPitch * sinYaw,
+                cosRoll * sinPitch * cosYaw + sinRoll * cosPitch * sinYaw,
+                cosRoll * cosPitch * sinYaw - sinRoll * sinPitch * cosYaw,
+                cosRoll * cosPitch * cosYaw + sinRoll * sinPitch * sinYaw);
 	}
   /**@brief Set the quaternion using fixed axis RPY
    * @param roll Angle around X 
@@ -97,9 +97,9 @@ public:
 		tf2Scalar cosRoll = tf2Cos(halfRoll);
 		tf2Scalar sinRoll = tf2Sin(halfRoll);
 		setValue(sinRoll * cosPitch * cosYaw - cosRoll * sinPitch * sinYaw, //x
-                         cosRoll * sinPitch * cosYaw + sinRoll * cosPitch * sinYaw, //y
-                         cosRoll * cosPitch * sinYaw - sinRoll * sinPitch * cosYaw, //z
-                         cosRoll * cosPitch * cosYaw + sinRoll * sinPitch * sinYaw); //formerly yzx
+                cosRoll * sinPitch * cosYaw + sinRoll * cosPitch * sinYaw, //y
+                cosRoll * cosPitch * sinYaw - sinRoll * sinPitch * cosYaw, //z
+                cosRoll * cosPitch * cosYaw + sinRoll * sinPitch * sinYaw); //formerly yzx
 	}
   /**@brief Add two quaternions
    * @param q The quaternion to add to this one */

--- a/tf2/test/cache_unittest.cpp
+++ b/tf2/test/cache_unittest.cpp
@@ -267,8 +267,8 @@ TEST(TimeCache, SetRPYEqualsSetEuler)
     pitch = 1.0 * get_rand();
     roll = 1.0 * get_rand();
 
-    q1.setEuler(yaw, pitch, roll); // YPR
-    q2.setRPY(roll, pitch, yaw); // RPY
+    q1.setEuler(yaw, pitch, roll);
+    q2.setRPY(roll, pitch, yaw);
 
     EXPECT_NEAR(q1.x(), q2.x(), 1e-5);
     EXPECT_NEAR(q1.y(), q2.y(), 1e-5);

--- a/tf2/test/cache_unittest.cpp
+++ b/tf2/test/cache_unittest.cpp
@@ -254,6 +254,29 @@ TEST(Bullet, Slerp)
   }
 }
 
+TEST(TimeCache, SetRPYEqualsSetEuler)
+{
+  uint64_t runs = 100;
+  seed_rand();
+
+  tf2::Quaternion q1, q2;
+  double yaw, pitch, roll;
+
+  for (uint64_t i = 0; i < runs; i++) {
+    yaw = 1.0 * get_rand();
+    pitch = 1.0 * get_rand();
+    roll = 1.0 * get_rand();
+
+    q1.setEuler(yaw, pitch, roll); // YPR
+    q2.setRPY(roll, pitch, yaw); // RPY
+
+    EXPECT_NEAR(q1.x(), q2.x(), 1e-5);
+    EXPECT_NEAR(q1.y(), q2.y(), 1e-5);
+    EXPECT_NEAR(q1.z(), q2.z(), 1e-5);
+    EXPECT_NEAR(q1.w(), q2.w(), 1e-5);
+  }
+}
+
 TEST(TimeCache, AngularInterpolation)
 {
   uint64_t runs = 100;


### PR DESCRIPTION
Hi there, small bug fix along with a unit test.

SetEuler takes yaw, pitch, roll as parameters in that order, SetRPY takes roll, pitch, yaw in that order. They should produce the same Quaternion when passed the same yaw/pitch/roll in the right respective order, but it doesn't. 
The explanation is simple: SetEuler and SetRPY don't have the same implementation even though they should (the order changes but the way to calculate the Quaternions stay the same).

In the current implementation, the unit test I added was failing, now it's not.