### PR TITLE
Add an API to clear out cached static transforms.

### DIFF
--- a/tf2_ros/include/tf2_ros/static_transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/static_transform_broadcaster.h
@@ -81,6 +81,12 @@ public:
   TF2_ROS_PUBLIC
   void sendTransform(const std::vector<geometry_msgs::msg::TransformStamped> & transforms);
 
+  /** \brief Clear the memory of any previously sent transforms
+   * This can be used to "remove" transforms that are no longer valid
+   */
+  TF2_ROS_PUBLIC
+  void clearTransforms();
+
 private:
   /// Internal reference to ros::Node
   rclcpp::Publisher<tf2_msgs::msg::TFMessage>::SharedPtr publisher_;

--- a/tf2_ros/src/static_transform_broadcaster.cpp
+++ b/tf2_ros/src/static_transform_broadcaster.cpp
@@ -71,4 +71,9 @@ void StaticTransformBroadcaster::sendTransform(
   publisher_->publish(net_message_);
 }
 
+void StaticTransformBroadcaster::clearTransforms()
+{
+  net_message_.transforms.clear();
+}
+
 }  // namespace tf2_ros


### PR DESCRIPTION
When calling sendTransform() on the StaticTransformBroadcaster
class, all transforms are cached internally.  Subsequent calls
to sendTransform() will only add and republish those transforms
that are different from previously seen ones.  This works well
for code that wants to "build up" a list of static transforms
from a diverse set of sources.  (As a side note, there is a
bug in here where a second static transform between the same
two joints but with a different translation or rotation is
silently ignored.  That should probably produce an error.)

However, this caching becomes a problem if a node ever wants
to remove joints during runtime.  To facilitate this, add a
new clearTransforms() API that allows the caller to do this.
This has the potential to remove unrelated transforms, but
since it is an opt-in API, presumably the user knows what
they are doing.  The first user of this will be robot_state_publisher,
which knows it is getting all of its static transforms from
a single URDF file.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Still a draft because it needs further testing.