### PR TITLE
[tf2_ros/tf2_monitor] Calculate hz for each tf

### DIFF
--- a/tf2_ros/src/tf2_monitor.cpp
+++ b/tf2_ros/src/tf2_monitor.cpp
@@ -182,7 +182,7 @@ public:
     average_delay /= it->second.size();
     double frequency_out = static_cast<double>(it4->second.size()) /
       std::max(0.00000001, (it4->second.back() - it4->second.front()));
-    ss << "Frame: " << it->first << ", published by " << frame_authority << " " << frequency_out << 
+    ss << "Frame: " << it->first << ", published by " << frame_authority << " " << frequency_out <<
     " Hz, Average Delay: " << average_delay << " Max Delay: " << max_delay << std::endl;
     return ss.str();
   }

--- a/tf2_ros/src/tf2_monitor.cpp
+++ b/tf2_ros/src/tf2_monitor.cpp
@@ -183,7 +183,7 @@ public:
     double frequency_out = static_cast<double>(it4->second.size()) /
       std::max(0.00000001, (it4->second.back() - it4->second.front()));
     ss << "Frame: " << it->first << ", published by " << frame_authority << " " << frequency_out <<
-    " Hz, Average Delay: " << average_delay << " Max Delay: " << max_delay << std::endl;
+      " Hz, Average Delay: " << average_delay << " Max Delay: " << max_delay << std::endl;
     return ss.str();
   }
 

--- a/tf2_ros/src/tf2_monitor.cpp
+++ b/tf2_ros/src/tf2_monitor.cpp
@@ -179,8 +179,6 @@ public:
       max_delay = std::max(max_delay, it->second[i]);
     }
     average_delay /= it->second.size();
-    // ss << "Frame: " << it->first << ", published by " << frame_authority << ", Average Delay: " <<
-    //   average_delay << ", Max Delay: " << max_delay << std::endl;
     double frequency_out = static_cast<double>(it4->second.size()) /
       std::max(0.00000001, (it4->second.back() - it4->second.front()));
     ss << "Frame: " << it->first << ", published by " << frame_authority << " " << frequency_out << 

--- a/tf2_ros/src/tf2_monitor.cpp
+++ b/tf2_ros/src/tf2_monitor.cpp
@@ -87,7 +87,8 @@ public:
         message.transforms[i].child_frame_id);
       if (it == delay_map.end()) {
         delay_map[message.transforms[i].child_frame_id] = std::vector<double>(1, offset);
-        frequency_map[message.transforms[i].child_frame_id] = std::vector<double>(1, clock_->now().seconds());
+        frequency_map[message.transforms[i].child_frame_id] = std::vector<double>(
+          1, clock_->now().seconds());
       } else {
         it->second.push_back(offset);
         it4->second.push_back(clock_->now().seconds());

--- a/tf2_ros/src/tf2_monitor.cpp
+++ b/tf2_ros/src/tf2_monitor.cpp
@@ -55,6 +55,7 @@ public:
   std::vector<std::string> chain_;
   std::map<std::string, std::string> frame_authority_map;
   std::map<std::string, std::vector<double>> delay_map;
+  std::map<std::string, std::vector<double>> frequency_map;
   std::map<std::string, std::vector<double>> authority_map;
   std::map<std::string, std::vector<double>> authority_frequency_map;
 
@@ -82,12 +83,17 @@ public:
 
       std::map<std::string, std::vector<double>>::iterator it = delay_map.find(
         message.transforms[i].child_frame_id);
+      std::map<std::string, std::vector<double>>::iterator it4 = frequency_map.find(
+        message.transforms[i].child_frame_id);
       if (it == delay_map.end()) {
         delay_map[message.transforms[i].child_frame_id] = std::vector<double>(1, offset);
+        frequency_map[message.transforms[i].child_frame_id] = std::vector<double>(1, clock_->now().seconds());
       } else {
         it->second.push_back(offset);
+        it4->second.push_back(clock_->now().seconds());
         if (it->second.size() > 1000) {
           it->second.erase(it->second.begin());
+          it4->second.erase(it4->second.begin());
         }
       }
     }
@@ -162,6 +168,7 @@ public:
 
   std::string outputFrameInfo(
     const std::map<std::string, std::vector<double>>::iterator & it,
+    const std::map<std::string, std::vector<double>>::iterator & it4,
     const std::string & frame_authority)
   {
     std::stringstream ss;
@@ -172,8 +179,12 @@ public:
       max_delay = std::max(max_delay, it->second[i]);
     }
     average_delay /= it->second.size();
-    ss << "Frame: " << it->first << ", published by " << frame_authority << ", Average Delay: " <<
-      average_delay << ", Max Delay: " << max_delay << std::endl;
+    // ss << "Frame: " << it->first << ", published by " << frame_authority << ", Average Delay: " <<
+    //   average_delay << ", Max Delay: " << max_delay << std::endl;
+    double frequency_out = static_cast<double>(it4->second.size()) /
+      std::max(0.00000001, (it4->second.back() - it4->second.front()));
+    ss << "Frame: " << it->first << ", published by " << frame_authority << " " << frequency_out << 
+    " Hz, Average Delay: " << average_delay << " Max Delay: " << max_delay << std::endl;
     return ss.str();
   }
 
@@ -226,17 +237,18 @@ public:
         std::unique_lock<std::mutex> lock(map_mutex_);
         std::cout << std::endl << "Frames:" << std::endl;
         std::map<std::string, std::vector<double>>::iterator it = delay_map.begin();
-        for ( ; it != delay_map.end(); ++it) {
+        std::map<std::string, std::vector<double>>::iterator it4 = frequency_map.begin();
+        for ( ; it != delay_map.end(); ++it, ++it4) {
           if (using_specific_chain_) {
             for (size_t i = 0; i < chain_.size(); i++) {
               if (it->first != chain_[i]) {
                 continue;
               }
 
-              std::cout << outputFrameInfo(it, frame_authority_map[it->first]);
+              std::cout << outputFrameInfo(it, it4, frame_authority_map[it->first]);
             }
           } else {
-            std::cout << outputFrameInfo(it, frame_authority_map[it->first]);
+            std::cout << outputFrameInfo(it, it4, frame_authority_map[it->first]);
           }
         }
         std::cerr << std::endl << "All Broadcasters:" << std::endl;


### PR DESCRIPTION
Related to https://github.com/ros2/geometry2/issues/528

Currently, `tf2_monitor` in `tf2_ros` outputs some timestamp information for all the tfs from frameA to frameB. While the output shows delay information of the message timestamp, it does not show nor calculate the frequency of the messages. 

Before
```
RESULTS: for map to base_link                                                                                                                                 
Chain is: map -> base_link                                                                                                                                    
Net delay     avg = 1.98796e+06: max = 3.04946e+06                                                                                                            
                                                                                                                                                              
Frames:                                                                                                                                                       
Frame: base_link, published by <no authority available>, Average Delay: 3.04946e+06, Max Delay: 3.04946e+06                                                   
                                                                                                                                                              
All Broadcasters:                                                                                                                                             
Node: <no authority available> 65.1009 Hz, Average Delay: 3.04946e+06 Max Delay: 3.04946e+06    
```

After:
```
RESULTS: for map to base_link                                                                                                                                 
Chain is: map -> base_link                                                                                                                                    
Net delay     avg = 1.74212e+06: max = 3.05576e+06                                                                                                            
                                                                                                                                                              
Frames:                                                                                                                                                       
Frame: base_link, published by <no authority available> 50.0496 Hz, Average Delay: 3.05576e+06 Max Delay: 3.05576e+06                                         
                                                                                                                                                              
All Broadcasters:                                                                                                                                             
Node: <no authority available> 65.0861 Hz, Average Delay: 3.05576e+06 Max Delay: 3.05576e+06  
```