### PR TITLE
Drop PyKDL dependency in tf2_geometry_msgs (backport #509 to galactic)

### DIFF
--- a/tf2_geometry_msgs/CMakeLists.txt
+++ b/tf2_geometry_msgs/CMakeLists.txt
@@ -24,13 +24,10 @@ ament_python_install_package(${PROJECT_NAME}
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(rclcpp REQUIRED)
-<<<<<<< HEAD
-=======
 
   find_package(ament_cmake_pytest REQUIRED)
   ament_add_pytest_test(test_tf2_geometry_msgs_py test/test_tf2_geometry_msgs.py)
 
->>>>>>> 6b18a400 (Drop PyKDL dependency in tf2_geometry_msgs (#509))
   ament_add_gtest(test_tf2_geometry_msgs test/test_tf2_geometry_msgs.cpp)
   if(TARGET test_tf2_geometry_msgs)
     target_include_directories(test_tf2_geometry_msgs PUBLIC include)

--- a/tf2_geometry_msgs/CMakeLists.txt
+++ b/tf2_geometry_msgs/CMakeLists.txt
@@ -18,18 +18,19 @@ set(required_dependencies
 )
 ament_auto_find_build_dependencies(REQUIRED ${required_dependencies})
 
-# TODO(ros2/geometry2#110) Port python once PyKDL becomes usable in ROS 2
-# ament_python_install_package(${PROJECT_NAME}
-#      PACKAGE_DIR src/${PROJECT_NAME})
-
-# TODO(ros2/geometry2#110) Port python once PyKDL becomes usable in ROS 2
-# install(PROGRAMS scripts/test.py
-#    DESTINATION lib/${PROJECT_NAME}
-# )
+ament_python_install_package(${PROJECT_NAME}
+  PACKAGE_DIR src/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(rclcpp REQUIRED)
+<<<<<<< HEAD
+=======
+
+  find_package(ament_cmake_pytest REQUIRED)
+  ament_add_pytest_test(test_tf2_geometry_msgs_py test/test_tf2_geometry_msgs.py)
+
+>>>>>>> 6b18a400 (Drop PyKDL dependency in tf2_geometry_msgs (#509))
   ament_add_gtest(test_tf2_geometry_msgs test/test_tf2_geometry_msgs.cpp)
   if(TARGET test_tf2_geometry_msgs)
     target_include_directories(test_tf2_geometry_msgs PUBLIC include)

--- a/tf2_geometry_msgs/package.xml
+++ b/tf2_geometry_msgs/package.xml
@@ -22,12 +22,9 @@
   <exec_depend>tf2_ros_py</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
-<<<<<<< HEAD
-=======
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
->>>>>>> 6b18a400 (Drop PyKDL dependency in tf2_geometry_msgs (#509))
   <test_depend>rclcpp</test_depend>
 
   <export>

--- a/tf2_geometry_msgs/package.xml
+++ b/tf2_geometry_msgs/package.xml
@@ -18,15 +18,16 @@
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
 
-  <!-- python support not yet ported
-  <build_depend>python_orocos_kdl</build_depend>
-
-  <exec_depend>python_orocos_kdl</exec_depend>
-  -->
-
+  <exec_depend>python3-numpy</exec_depend>
   <exec_depend>tf2_ros_py</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
+<<<<<<< HEAD
+=======
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+>>>>>>> 6b18a400 (Drop PyKDL dependency in tf2_geometry_msgs (#509))
   <test_depend>rclcpp</test_depend>
 
   <export>

--- a/tf2_geometry_msgs/pytest.ini
+++ b/tf2_geometry_msgs/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2

--- a/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
+++ b/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
@@ -27,8 +27,17 @@
 
 # author: Wim Meeussen
 
+<<<<<<< HEAD
 from geometry_msgs.msg import PoseStamped, Vector3Stamped, PointStamped, PoseWithCovarianceStamped
 import PyKDL
+=======
+from typing import Iterable, Optional, Tuple
+
+from geometry_msgs.msg import (PointStamped, Pose, PoseStamped,
+                               PoseWithCovarianceStamped, TransformStamped,
+                               Vector3Stamped)
+import numpy as np
+>>>>>>> 6b18a400 (Drop PyKDL dependency in tf2_geometry_msgs (#509))
 import tf2_ros
 
 def to_msg_msg(msg):
@@ -45,6 +54,7 @@ tf2_ros.ConvertRegistration().add_from_msg(Vector3Stamped, from_msg_msg)
 tf2_ros.ConvertRegistration().add_from_msg(PoseStamped, from_msg_msg)
 tf2_ros.ConvertRegistration().add_from_msg(PointStamped, from_msg_msg)
 
+<<<<<<< HEAD
 def transform_to_kdl(t):
     return PyKDL.Frame(PyKDL.Rotation.Quaternion(t.transform.rotation.x, t.transform.rotation.y,
                                                  t.transform.rotation.z, t.transform.rotation.w),
@@ -56,29 +66,287 @@ def transform_to_kdl(t):
 # PointStamped
 def do_transform_point(point, transform):
     p = transform_to_kdl(transform) * PyKDL.Vector(point.point.x, point.point.y, point.point.z)
+=======
+
+def transform_covariance(cov_in, transform):
+    """
+    Apply a given transform to a covariance matrix.
+
+    :param cov_in: Covariance matrix
+    :param transform: The transform that will be applies
+    :returns: The transformed covariance matrix
+    """
+    # Converting the Quaternion to a Rotation Matrix first
+    # Taken from: https://automaticaddison.com/how-to-convert-a-quaternion-to-a-rotation-matrix/
+    q0 = transform.transform.rotation.w
+    q1 = transform.transform.rotation.x
+    q2 = transform.transform.rotation.y
+    q3 = transform.transform.rotation.z
+
+    # First row of the rotation matrix
+    r00 = 2 * (q0 * q0 + q1 * q1) - 1
+    r01 = 2 * (q1 * q2 - q0 * q3)
+    r02 = 2 * (q1 * q3 + q0 * q2)
+
+    # Second row of the rotation matrix
+    r10 = 2 * (q1 * q2 + q0 * q3)
+    r11 = 2 * (q0 * q0 + q2 * q2) - 1
+    r12 = 2 * (q2 * q3 - q0 * q1)
+
+    # Third row of the rotation matrix
+    r20 = 2 * (q1 * q3 - q0 * q2)
+    r21 = 2 * (q2 * q3 + q0 * q1)
+    r22 = 2 * (q0 * q0 + q3 * q3) - 1
+
+    # Code reference: https://github.com/ros2/geometry2/pull/430
+    # Mathematical Reference:
+    # A. L. Garcia, “Linear Transformations of Random Vectors,” in Probability,
+    # Statistics, and Random Processes For Electrical Engineering, 3rd ed.,
+    # Pearson Prentice Hall, 2008, pp. 320–322.
+
+    R = np.array([[r00, r01, r02],
+                  [r10, r11, r12],
+                  [r20, r21, r22]])
+
+    R_transpose = np.transpose(R)
+
+    cov_11 = np.array([cov_in[:3], cov_in[6:9], cov_in[12:15]])
+    cov_12 = np.array([cov_in[3:6], cov_in[9:12], cov_in[15:18]])
+    cov_21 = np.array([cov_in[18:21], cov_in[24:27], cov_in[30:33]])
+    cov_22 = np.array([cov_in[21:24], cov_in[27:30], cov_in[33:]])
+
+    # And we perform the transform
+    result_11 = R @ cov_11 @ R_transpose
+    result_12 = R @ cov_12 @ R_transpose
+    result_21 = R @ cov_21 @ R_transpose
+    result_22 = R @ cov_22 @ R_transpose
+
+    cov_out = PoseWithCovarianceStamped()
+
+    cov_out.pose.covariance[0] = result_11[0][0]
+    cov_out.pose.covariance[1] = result_11[0][1]
+    cov_out.pose.covariance[2] = result_11[0][2]
+    cov_out.pose.covariance[6] = result_11[1][0]
+    cov_out.pose.covariance[7] = result_11[1][1]
+    cov_out.pose.covariance[8] = result_11[1][2]
+    cov_out.pose.covariance[12] = result_11[2][0]
+    cov_out.pose.covariance[13] = result_11[2][1]
+    cov_out.pose.covariance[14] = result_11[2][2]
+
+    cov_out.pose.covariance[3] = result_12[0][0]
+    cov_out.pose.covariance[4] = result_12[0][1]
+    cov_out.pose.covariance[5] = result_12[0][2]
+    cov_out.pose.covariance[9] = result_12[1][0]
+    cov_out.pose.covariance[10] = result_12[1][1]
+    cov_out.pose.covariance[11] = result_12[1][2]
+    cov_out.pose.covariance[15] = result_12[2][0]
+    cov_out.pose.covariance[16] = result_12[2][1]
+    cov_out.pose.covariance[17] = result_12[2][2]
+
+    cov_out.pose.covariance[18] = result_21[0][0]
+    cov_out.pose.covariance[19] = result_21[0][1]
+    cov_out.pose.covariance[20] = result_21[0][2]
+    cov_out.pose.covariance[24] = result_21[1][0]
+    cov_out.pose.covariance[25] = result_21[1][1]
+    cov_out.pose.covariance[26] = result_21[1][2]
+    cov_out.pose.covariance[30] = result_21[2][0]
+    cov_out.pose.covariance[31] = result_21[2][1]
+    cov_out.pose.covariance[32] = result_21[2][2]
+
+    cov_out.pose.covariance[21] = result_22[0][0]
+    cov_out.pose.covariance[22] = result_22[0][1]
+    cov_out.pose.covariance[23] = result_22[0][2]
+    cov_out.pose.covariance[27] = result_22[1][0]
+    cov_out.pose.covariance[28] = result_22[1][1]
+    cov_out.pose.covariance[29] = result_22[1][2]
+    cov_out.pose.covariance[33] = result_22[2][0]
+    cov_out.pose.covariance[34] = result_22[2][1]
+    cov_out.pose.covariance[35] = result_22[2][2]
+
+    return cov_out.pose.covariance
+
+
+def _build_affine(
+        rotation: Optional[Iterable] = None,
+        translation: Optional[Iterable] = None) -> np.ndarray:
+    """
+    Build an affine matrix from a quaternion and a translation.
+
+    :param rotation: The quaternion as [w, x, y, z]
+    :param translation: The translation as [x, y, z]
+    :returns: The quaternion and the translation array
+    """
+    affine = np.eye(4)
+    if rotation is not None:
+        affine[:3, :3] = _get_mat_from_quat(np.asarray(rotation))
+    if translation is not None:
+        affine[:3, 3] = np.asarray(translation)
+    return affine
+
+
+def _transform_to_affine(transform: TransformStamped) -> np.ndarray:
+    """
+    Convert a `TransformStamped` to a affine matrix.
+
+    :param transform: The transform that should be converted
+    :returns: The affine transform
+    """
+    transform = transform.transform
+    transform_rotation_matrix = [
+        transform.rotation.w,
+        transform.rotation.x,
+        transform.rotation.y,
+        transform.rotation.z
+    ]
+    transform_translation = [
+        transform.translation.x,
+        transform.translation.y,
+        transform.translation.z
+    ]
+    return _build_affine(transform_rotation_matrix, transform_translation)
+
+
+def _get_mat_from_quat(quaternion: np.ndarray) -> np.ndarray:
+    """
+    Convert a quaternion to a rotation matrix.
+
+    This method is based on quat2mat from https://github.com
+    f185e866ecccb66c545559bc9f2e19cb5025e0ab/transforms3d/quaternions.py#L101 ,
+    since that library is not available via rosdep.
+
+    :param quaternion: A numpy array containing the w, x, y, and z components of the quaternion
+    :returns: The rotation matrix
+    """
+    Nq = np.sum(np.square(quaternion))
+    if Nq < np.finfo(np.float64).eps:
+        return np.eye(3)
+
+    XYZ = quaternion[1:] * 2.0 / Nq
+    wXYZ = XYZ * quaternion[0]
+    xXYZ = XYZ * quaternion[1]
+    yYZ = XYZ[1:] * quaternion[2]
+    zZ = XYZ[2] * quaternion[3]
+
+    return np.array(
+        [[1.0-(yYZ[0]+zZ), xXYZ[1]-wXYZ[2], xXYZ[2]+wXYZ[1]],
+         [xXYZ[1]+wXYZ[2], 1.0-(xXYZ[0]+zZ), yYZ[1]-wXYZ[0]],
+         [xXYZ[2]-wXYZ[1], yYZ[1]+wXYZ[0], 1.0-(xXYZ[0]+yYZ[0])]])
+
+
+def _get_quat_from_mat(rot_mat: np.ndarray) -> np.ndarray:
+    """
+    Convert a rotation matrix to a quaternion.
+
+    This method is a copy of mat2quat from https://github.com
+    f185e866ecccb66c545559bc9f2e19cb5025e0ab/transforms3d/quaternions.py#L150 ,
+    since that library is not available via rosdep.
+
+    Method from
+    Bar-Itzhack, Itzhack Y. (2000), "New method for extracting the
+    quaternion from a rotation matrix", AIAA Journal of Guidance,
+    Control and Dynamics 23(6):1085-1087 (Engineering Note), ISSN
+    0731-5090
+
+    :param rot_mat: A roatation matrix
+    :returns: An quaternion
+    """
+    # Decompose rotation matrix
+    Qxx, Qyx, Qzx, Qxy, Qyy, Qzy, Qxz, Qyz, Qzz = rot_mat.flat
+    # Create matrix
+    K = np.array([
+        [Qxx - Qyy - Qzz, 0,               0,               0],
+        [Qyx + Qxy,       Qyy - Qxx - Qzz, 0,               0],
+        [Qzx + Qxz,       Qzy + Qyz,       Qzz - Qxx - Qyy, 0],
+        [Qyz - Qzy,       Qzx - Qxz,       Qxy - Qyx,       Qxx + Qyy + Qzz]]
+    ) / 3.0
+    vals, vecs = np.linalg.eigh(K)
+    # Select largest eigenvector and reorder to w,x,y,z
+    q = vecs[[3, 0, 1, 2], np.argmax(vals)]
+    # Invert quaternion if w is negative (results in positive w)
+    if q[0] < 0:
+        q *= -1
+    return q
+
+
+def _decompose_affine(affine: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Decompose an affine transformation into a quaternion and the translation.
+
+    :param affine: The affine transformation matrix
+    :returns: The quaternion and the translation array
+    """
+    return _get_quat_from_mat(affine[:3, :3]), affine[:3, 3]
+
+
+# PointStamped
+def do_transform_point(
+        point: PointStamped,
+        transform: TransformStamped) -> PointStamped:
+    """
+    Transform a `PointStamped` using a given `TransformStamped`.
+
+    :param point: The point
+    :param transform: The transform
+    :returns: The transformed point
+    """
+    _, point = _decompose_affine(
+        np.matmul(
+            _transform_to_affine(transform),
+            _build_affine(translation=[
+                point.point.x,
+                point.point.y,
+                point.point.z
+            ])))
+
+>>>>>>> 6b18a400 (Drop PyKDL dependency in tf2_geometry_msgs (#509))
     res = PointStamped()
-    res.point.x = p[0]
-    res.point.y = p[1]
-    res.point.z = p[2]
+    res.point.x = point[0]
+    res.point.y = point[1]
+    res.point.z = point[2]
     res.header = transform.header
     return res
 tf2_ros.TransformRegistration().add(PointStamped, do_transform_point)
 
 
 # Vector3Stamped
+<<<<<<< HEAD
 def do_transform_vector3(vector3, transform):
     transform.transform.translation.x = 0.0;
     transform.transform.translation.y = 0.0;
     transform.transform.translation.z = 0.0;
     p = transform_to_kdl(transform) * PyKDL.Vector(vector3.vector.x, vector3.vector.y, vector3.vector.z)
+=======
+def do_transform_vector3(
+        vector3: Vector3Stamped,
+        transform: TransformStamped) -> Vector3Stamped:
+    """
+    Transform a `Vector3Stamped` using a given `TransformStamped`.
+
+    :param vector3: The vector3
+    :param transform: The transform
+    :returns: The transformed vector3
+    """
+    transform.transform.translation.x = 0.0
+    transform.transform.translation.y = 0.0
+    transform.transform.translation.z = 0.0
+    _, point = _decompose_affine(
+        np.matmul(
+            _transform_to_affine(transform),
+            _build_affine(translation=[
+                vector3.vector.x,
+                vector3.vector.y,
+                vector3.vector.z
+            ])))
+>>>>>>> 6b18a400 (Drop PyKDL dependency in tf2_geometry_msgs (#509))
     res = Vector3Stamped()
-    res.vector.x = p[0]
-    res.vector.y = p[1]
-    res.vector.z = p[2]
+    res.vector.x = point[0]
+    res.vector.y = point[1]
+    res.vector.z = point[2]
     res.header = transform.header
     return res
 tf2_ros.TransformRegistration().add(Vector3Stamped, do_transform_vector3)
 
+<<<<<<< HEAD
 # PoseStamped
 def do_transform_pose(pose, transform):
     f = transform_to_kdl(transform) * PyKDL.Frame(PyKDL.Rotation.Quaternion(pose.pose.orientation.x, pose.pose.orientation.y,
@@ -92,8 +360,69 @@ def do_transform_pose(pose, transform):
     res.header = transform.header
     return res
 tf2_ros.TransformRegistration().add(PoseStamped, do_transform_pose)
+=======
+
+# Pose
+def do_transform_pose(
+        pose: Pose,
+        transform: TransformStamped) -> Pose:
+    """
+    Transform a `Pose` using a given `TransformStamped`.
+
+    This method is used to share the tranformation done in
+    `do_transform_pose_stamped()` and `do_transform_pose_with_covariance_stamped()`
+
+    :param pose: The pose
+    :param transform: The transform
+    :returns: The transformed pose
+    """
+    quaternion, point = _decompose_affine(
+        np.matmul(
+            _transform_to_affine(transform),
+            _build_affine(
+                translation=[
+                    pose.position.x,
+                    pose.position.y,
+                    pose.position.z
+                ],
+                rotation=[
+                    pose.orientation.w,
+                    pose.orientation.x,
+                    pose.orientation.y,
+                    pose.orientation.z])))
+    res = Pose()
+    res.position.x = point[0]
+    res.position.y = point[1]
+    res.position.z = point[2]
+    res.orientation.w = quaternion[0]
+    res.orientation.x = quaternion[1]
+    res.orientation.y = quaternion[2]
+    res.orientation.z = quaternion[3]
+    return res
+
+
+# PoseStamped
+def do_transform_pose_stamped(
+        pose: PoseStamped,
+        transform: TransformStamped) -> PoseStamped:
+    """
+    Transform a `PoseStamped` using a given `TransformStamped`.
+
+    :param pose: The stamped pose
+    :param transform: The transform
+    :returns: The transformed pose stamped
+    """
+    res = PoseStamped()
+    res.pose = do_transform_pose(pose.pose, transform)
+    res.header = transform.header
+    return res
+
+
+tf2_ros.TransformRegistration().add(PoseStamped, do_transform_pose_stamped)
+>>>>>>> 6b18a400 (Drop PyKDL dependency in tf2_geometry_msgs (#509))
 
 # PoseWithCovarianceStamped
+<<<<<<< HEAD
 def do_transform_pose_with_covariance_stamped(pose, transform):
     f = transform_to_kdl(transform) * PyKDL.Frame(PyKDL.Rotation.Quaternion(pose.pose.pose.orientation.x, pose.pose.pose.orientation.y,
                                                                           pose.pose.pose.orientation.z, pose.pose.pose.orientation.w),
@@ -104,6 +433,21 @@ def do_transform_pose_with_covariance_stamped(pose, transform):
     res.pose.pose.position.z = f.p[2]
     (res.pose.pose.orientation.x, res.pose.pose.orientation.y, res.pose.pose.orientation.z, res.pose.pose.orientation.w) = f.M.GetQuaternion()
     res.pose.covariance = pose.pose.covariance
+=======
+def do_transform_pose_with_covariance_stamped(
+        pose: PoseWithCovarianceStamped,
+        transform: TransformStamped) -> PoseWithCovarianceStamped:
+    """
+    Transform a `PoseWithCovarianceStamped` using a given `TransformStamped`.
+
+    :param pose: The pose with covariance stamped
+    :param transform: The transform
+    :returns: The transformed pose with covariance stamped
+    """
+    res = PoseWithCovarianceStamped()
+    res.pose.pose = do_transform_pose(pose.pose.pose, transform)
+    res.pose.covariance = transform_covariance(pose.pose.covariance, transform)
+>>>>>>> 6b18a400 (Drop PyKDL dependency in tf2_geometry_msgs (#509))
     res.header = transform.header
     return res
 tf2_ros.TransformRegistration().add(PoseWithCovarianceStamped, do_transform_pose_with_covariance_stamped)

--- a/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
+++ b/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
@@ -27,17 +27,12 @@
 
 # author: Wim Meeussen
 
-<<<<<<< HEAD
-from geometry_msgs.msg import PoseStamped, Vector3Stamped, PointStamped, PoseWithCovarianceStamped
-import PyKDL
-=======
 from typing import Iterable, Optional, Tuple
 
 from geometry_msgs.msg import (PointStamped, Pose, PoseStamped,
                                PoseWithCovarianceStamped, TransformStamped,
                                Vector3Stamped)
 import numpy as np
->>>>>>> 6b18a400 (Drop PyKDL dependency in tf2_geometry_msgs (#509))
 import tf2_ros
 
 def to_msg_msg(msg):
@@ -54,19 +49,6 @@ tf2_ros.ConvertRegistration().add_from_msg(Vector3Stamped, from_msg_msg)
 tf2_ros.ConvertRegistration().add_from_msg(PoseStamped, from_msg_msg)
 tf2_ros.ConvertRegistration().add_from_msg(PointStamped, from_msg_msg)
 
-<<<<<<< HEAD
-def transform_to_kdl(t):
-    return PyKDL.Frame(PyKDL.Rotation.Quaternion(t.transform.rotation.x, t.transform.rotation.y,
-                                                 t.transform.rotation.z, t.transform.rotation.w),
-                       PyKDL.Vector(t.transform.translation.x,
-                                    t.transform.translation.y,
-                                    t.transform.translation.z))
-
-
-# PointStamped
-def do_transform_point(point, transform):
-    p = transform_to_kdl(transform) * PyKDL.Vector(point.point.x, point.point.y, point.point.z)
-=======
 
 def transform_covariance(cov_in, transform):
     """
@@ -298,7 +280,6 @@ def do_transform_point(
                 point.point.z
             ])))
 
->>>>>>> 6b18a400 (Drop PyKDL dependency in tf2_geometry_msgs (#509))
     res = PointStamped()
     res.point.x = point[0]
     res.point.y = point[1]
@@ -309,13 +290,6 @@ tf2_ros.TransformRegistration().add(PointStamped, do_transform_point)
 
 
 # Vector3Stamped
-<<<<<<< HEAD
-def do_transform_vector3(vector3, transform):
-    transform.transform.translation.x = 0.0;
-    transform.transform.translation.y = 0.0;
-    transform.transform.translation.z = 0.0;
-    p = transform_to_kdl(transform) * PyKDL.Vector(vector3.vector.x, vector3.vector.y, vector3.vector.z)
-=======
 def do_transform_vector3(
         vector3: Vector3Stamped,
         transform: TransformStamped) -> Vector3Stamped:
@@ -337,7 +311,6 @@ def do_transform_vector3(
                 vector3.vector.y,
                 vector3.vector.z
             ])))
->>>>>>> 6b18a400 (Drop PyKDL dependency in tf2_geometry_msgs (#509))
     res = Vector3Stamped()
     res.vector.x = point[0]
     res.vector.y = point[1]
@@ -346,21 +319,6 @@ def do_transform_vector3(
     return res
 tf2_ros.TransformRegistration().add(Vector3Stamped, do_transform_vector3)
 
-<<<<<<< HEAD
-# PoseStamped
-def do_transform_pose(pose, transform):
-    f = transform_to_kdl(transform) * PyKDL.Frame(PyKDL.Rotation.Quaternion(pose.pose.orientation.x, pose.pose.orientation.y,
-                                                                          pose.pose.orientation.z, pose.pose.orientation.w),
-                                                PyKDL.Vector(pose.pose.position.x, pose.pose.position.y, pose.pose.position.z))
-    res = PoseStamped()
-    res.pose.position.x = f.p[0]
-    res.pose.position.y = f.p[1]
-    res.pose.position.z = f.p[2]
-    (res.pose.orientation.x, res.pose.orientation.y, res.pose.orientation.z, res.pose.orientation.w) = f.M.GetQuaternion()
-    res.header = transform.header
-    return res
-tf2_ros.TransformRegistration().add(PoseStamped, do_transform_pose)
-=======
 
 # Pose
 def do_transform_pose(
@@ -419,21 +377,8 @@ def do_transform_pose_stamped(
 
 
 tf2_ros.TransformRegistration().add(PoseStamped, do_transform_pose_stamped)
->>>>>>> 6b18a400 (Drop PyKDL dependency in tf2_geometry_msgs (#509))
 
 # PoseWithCovarianceStamped
-<<<<<<< HEAD
-def do_transform_pose_with_covariance_stamped(pose, transform):
-    f = transform_to_kdl(transform) * PyKDL.Frame(PyKDL.Rotation.Quaternion(pose.pose.pose.orientation.x, pose.pose.pose.orientation.y,
-                                                                          pose.pose.pose.orientation.z, pose.pose.pose.orientation.w),
-                                                PyKDL.Vector(pose.pose.pose.position.x, pose.pose.pose.position.y, pose.pose.pose.position.z))
-    res = PoseWithCovarianceStamped()
-    res.pose.pose.position.x = f.p[0]
-    res.pose.pose.position.y = f.p[1]
-    res.pose.pose.position.z = f.p[2]
-    (res.pose.pose.orientation.x, res.pose.pose.orientation.y, res.pose.pose.orientation.z, res.pose.pose.orientation.w) = f.M.GetQuaternion()
-    res.pose.covariance = pose.pose.covariance
-=======
 def do_transform_pose_with_covariance_stamped(
         pose: PoseWithCovarianceStamped,
         transform: TransformStamped) -> PoseWithCovarianceStamped:
@@ -447,7 +392,6 @@ def do_transform_pose_with_covariance_stamped(
     res = PoseWithCovarianceStamped()
     res.pose.pose = do_transform_pose(pose.pose.pose, transform)
     res.pose.covariance = transform_covariance(pose.pose.covariance, transform)
->>>>>>> 6b18a400 (Drop PyKDL dependency in tf2_geometry_msgs (#509))
     res.header = transform.header
     return res
 tf2_ros.TransformRegistration().add(PoseWithCovarianceStamped, do_transform_pose_with_covariance_stamped)

--- a/tf2_geometry_msgs/test/test_tf2_geometry_msgs.py
+++ b/tf2_geometry_msgs/test/test_tf2_geometry_msgs.py
@@ -1,4 +1,35 @@
+<<<<<<< HEAD:tf2_geometry_msgs/scripts/test.py
 #!/usr/bin/env python3
+=======
+# Copyright 2008 Willow Garage, Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the Willow Garage, Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+>>>>>>> 6b18a400 (Drop PyKDL dependency in tf2_geometry_msgs (#509)):tf2_geometry_msgs/test/test_tf2_geometry_msgs.py
 
 import unittest
 import rclpy
@@ -66,7 +97,6 @@ class GeometryMsgs(unittest.TestCase):
         self.assertEqual(out.pose.pose.position.x, 0)
         self.assertEqual(out.pose.pose.position.y, -2)
         self.assertEqual(out.pose.pose.position.z, -3)
-        self.assertEqual(out.pose.covariance, v.pose.covariance)
 
         # Translation shouldn't affect Vector3
         t = TransformStamped()
@@ -100,6 +130,50 @@ class GeometryMsgs(unittest.TestCase):
         self.assertEqual(out.vector.y, 0)
         self.assertEqual(out.vector.z, 0)
 
+<<<<<<< HEAD:tf2_geometry_msgs/scripts/test.py
+=======
+        # Testing for pose and covariance transform
+        t = TransformStamped()
+        t.transform.translation.x = 1.0
+        t.transform.translation.y = 2.0
+        t.transform.translation.z = 3.0
+        t.transform.rotation = Quaternion(w=0.0, x=1.0, y=0.0, z=0.0)
+
+        v = PoseWithCovarianceStamped()
+        v.header.stamp = rclpy.time.Time(seconds=2.0).to_msg()
+        v.header.frame_id = 'a'
+        v.pose.covariance = (
+          1.0, 2.0, 3.0, 4.0, 5.0, 6.0,
+          1.0, 2.0, 3.0, 4.0, 5.0, 6.0,
+          1.0, 2.0, 3.0, 4.0, 5.0, 6.0,
+          1.0, 2.0, 3.0, 4.0, 5.0, 6.0,
+          1.0, 2.0, 3.0, 4.0, 5.0, 6.0,
+          1.0, 2.0, 3.0, 4.0, 5.0, 6.0
+        )
+        v.pose.pose.position.x = 1.0
+        v.pose.pose.position.y = 2.0
+        v.pose.pose.position.z = 3.0
+        v.pose.pose.orientation = Quaternion(w=0.0, x=1.0, y=0.0, z=0.0)
+
+        out = tf2_geometry_msgs.do_transform_pose_with_covariance_stamped(v, t)
+        expected_covariance = np.array([
+          1.0, -2.0, -3.0, 4.0, -5.0, -6.0,
+          -1.0, 2.0, 3.0, -4.0, 5.0, 6.0,
+          -1.0, 2.0, 3.0, -4.0, 5.0, 6.0,
+          1.0, -2.0, -3.0, 4.0, -5.0, -6.0,
+          -1.0, 2.0, 3.0, -4.0, 5.0, 6.0,
+          -1.0, 2.0, 3.0, -4.0, 5.0, 6.0
+        ])
+        self.assertEqual(out.pose.pose.position.x, 2)
+        self.assertEqual(out.pose.pose.position.y, 0)
+        self.assertEqual(out.pose.pose.position.z, 0)
+        self.assertEqual(out.pose.pose.orientation.x, 0)
+        self.assertEqual(out.pose.pose.orientation.y, 0)
+        self.assertEqual(out.pose.pose.orientation.z, 0)
+        self.assertEqual(out.pose.pose.orientation.w, 1)
+        self.assertTrue(np.array_equal(out.pose.covariance, expected_covariance))
+
+
+>>>>>>> 6b18a400 (Drop PyKDL dependency in tf2_geometry_msgs (#509)):tf2_geometry_msgs/test/test_tf2_geometry_msgs.py
 if __name__ == '__main__':
     rclpy.init(args=None)
-    unittest.main()

--- a/tf2_geometry_msgs/test/test_tf2_geometry_msgs.py
+++ b/tf2_geometry_msgs/test/test_tf2_geometry_msgs.py
@@ -1,6 +1,3 @@
-<<<<<<< HEAD:tf2_geometry_msgs/scripts/test.py
-#!/usr/bin/env python3
-=======
 # Copyright 2008 Willow Garage, Inc.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -29,14 +26,13 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
->>>>>>> 6b18a400 (Drop PyKDL dependency in tf2_geometry_msgs (#509)):tf2_geometry_msgs/test/test_tf2_geometry_msgs.py
-
 import unittest
 import rclpy
-import PyKDL
+import numpy as np
 import tf2_ros
 import tf2_geometry_msgs
 from geometry_msgs.msg import TransformStamped, PointStamped, Vector3Stamped, PoseStamped, PoseWithCovarianceStamped, Quaternion
+
 
 class GeometryMsgs(unittest.TestCase):
     def test_transform(self):
@@ -130,8 +126,6 @@ class GeometryMsgs(unittest.TestCase):
         self.assertEqual(out.vector.y, 0)
         self.assertEqual(out.vector.z, 0)
 
-<<<<<<< HEAD:tf2_geometry_msgs/scripts/test.py
-=======
         # Testing for pose and covariance transform
         t = TransformStamped()
         t.transform.translation.x = 1.0
@@ -174,6 +168,5 @@ class GeometryMsgs(unittest.TestCase):
         self.assertTrue(np.array_equal(out.pose.covariance, expected_covariance))
 
 
->>>>>>> 6b18a400 (Drop PyKDL dependency in tf2_geometry_msgs (#509)):tf2_geometry_msgs/test/test_tf2_geometry_msgs.py
 if __name__ == '__main__':
     rclpy.init(args=None)

--- a/tf2_ros_py/package.xml
+++ b/tf2_ros_py/package.xml
@@ -14,6 +14,7 @@
 
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rclpy</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>tf2_msgs</exec_depend>
   <exec_depend>tf2_py</exec_depend>


### PR DESCRIPTION
This PR supersedes #531, fixing merge conflicts to backport `tf2_geometry_msgs` python support into the galactic branch.

I can run `colcon build && source install/setup.bash && colcon test` in a Docker container with Foxy installed with no errors.