### PR TITLE
add torque due to force offset

### DIFF
--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.hpp
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.hpp
@@ -1184,6 +1184,12 @@ void doTransform(
 {
   doTransform(t_in.force, t_out.force, transform);
   doTransform(t_in.torque, t_out.torque, transform);
+  // add additional torque created by translating the force
+  Vector3 offset = {transform.transform.translation.x, transform.transform.translation.y, transform.transform.translation.z};
+  auto added_torque = offset.cross({t_out.force.x, t_out.force.y, t_out.force.z});
+  t_out.torque.x += added_torque.getX();
+  t_out.torque.y += added_torque.getY();
+  t_out.torque.z += added_torque.getZ();
 }
 
 /** \brief Apply a geometry_msgs TransformStamped to an geometry_msgs WrenchStamped type.

--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.hpp
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.hpp
@@ -1186,7 +1186,7 @@ void doTransform(
   doTransform(t_in.torque, t_out.torque, transform);
   // add additional torque created by translating the force
   Vector3 offset = {transform.transform.translation.x, transform.transform.translation.y,
-                     transform.transform.translation.z};
+                    transform.transform.translation.z};
   auto added_torque = offset.cross({t_out.force.x, t_out.force.y, t_out.force.z});
   t_out.torque.x += added_torque.getX();
   t_out.torque.y += added_torque.getY();

--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.hpp
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.hpp
@@ -1186,7 +1186,7 @@ void doTransform(
   doTransform(t_in.torque, t_out.torque, transform);
   // add additional torque created by translating the force
   Vector3 offset = {transform.transform.translation.x, transform.transform.translation.y,
-                    transform.transform.translation.z};
+    transform.transform.translation.z};
   auto added_torque = offset.cross({t_out.force.x, t_out.force.y, t_out.force.z});
   t_out.torque.x += added_torque.getX();
   t_out.torque.y += added_torque.getY();

--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.hpp
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.hpp
@@ -1185,7 +1185,8 @@ void doTransform(
   doTransform(t_in.force, t_out.force, transform);
   doTransform(t_in.torque, t_out.torque, transform);
   // add additional torque created by translating the force
-  Vector3 offset = {transform.transform.translation.x, transform.transform.translation.y, transform.transform.translation.z};
+  Vector3 offset = {transform.transform.translation.x, transform.transform.translation.y,
+                     transform.transform.translation.z};
   auto added_torque = offset.cross({t_out.force.x, t_out.force.y, t_out.force.z});
   t_out.torque.x += added_torque.getX();
   t_out.torque.y += added_torque.getY();

--- a/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
+++ b/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
@@ -549,9 +549,9 @@ TEST(TfGeometry, Wrench)
   v1.torque.z = 3;
 
   geometry_msgs::msg::TransformStamped trafo;
-  trafo.transform.translation.x = -1;
-  trafo.transform.translation.y = 2;
-  trafo.transform.translation.z = -3;
+  trafo.transform.translation.x = 0;
+  trafo.transform.translation.y = -2;
+  trafo.transform.translation.z = 0;
   trafo.transform.rotation = tf2::toMsg(tf2::Quaternion(tf2::Vector3(0, 0, 1), -M_PI / 2.0));
 
   tf2::doTransform(v1, res, trafo);
@@ -559,9 +559,9 @@ TEST(TfGeometry, Wrench)
   EXPECT_NEAR(res.force.y, -2, EPS);
   EXPECT_NEAR(res.force.z, 3, EPS);
 
-  EXPECT_NEAR(res.torque.x, 1, EPS);
+  EXPECT_NEAR(res.torque.x, -5, EPS);
   EXPECT_NEAR(res.torque.y, -2, EPS);
-  EXPECT_NEAR(res.torque.z, 3, EPS);
+  EXPECT_NEAR(res.torque.z, 5, EPS);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
Currently, the `doTransform` function in `tf2_geometry_msgs.hpp` transforms wrenches by applying pure rotation to the force and torque parts separately. However, this does not correspond to transforming a force vector because the transnational component is ignored. So perhaps the function can be renamed `doRotation` or something to that effect. See https://core.ac.uk/download/pdf/154240607.pdf for a reference on transforming force vectors. I made the needed change so `doTransform` now applies a transformation to the given wrench according the method described in the reference I linked.     