### PR TITLE
Enable TFListener to get Authority

### DIFF
--- a/test_tf2/CMakeLists.txt
+++ b/test_tf2/CMakeLists.txt
@@ -123,6 +123,12 @@ if(TARGET test_tf2_bullet)
     tf2::tf2)
 endif()
 
+ament_add_gtest(test_transform_listener test/test_transform_listener.cpp)
+if(TARGET test_transform_listener)
+  target_link_libraries(test_transform_listener
+    tf2_ros::tf2_ros)
+endif()
+
 # TODO(ahcorde): enable once python part of tf2_geometry_msgs is working
 # add_launch_test(test/test_buffer_client.launch.py)
 

--- a/test_tf2/test/test_transform_listener.cpp
+++ b/test_tf2/test/test_transform_listener.cpp
@@ -1,0 +1,92 @@
+/*********************************************************************
+*
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2022, Open Source Robotics Foundation, Inc.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of Willow Garage, Inc. nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+#include <gtest/gtest.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+
+#include <chrono>
+#include <thread>
+
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <tf2_msgs/msg/tf_message.hpp>
+#include <tf2_ros/qos.hpp>
+
+
+TEST(transform_listener, authority_present)
+{
+  const std::string pub_namespace = "/tflistnertest/ns";
+  const std::string pub_node_name = "sentinel_node_name";
+  auto pub_node = std::make_shared<rclcpp::Node>(pub_node_name, pub_namespace);
+  auto listener_node = std::make_shared<rclcpp::Node>("listener");
+
+  auto pub = rclcpp::create_publisher<tf2_msgs::msg::TFMessage>(
+    pub_node, "/tf", tf2_ros::DynamicBroadcasterQoS());
+
+  
+  auto buffer = tf2_ros::Buffer(listener_node->get_clock());
+  auto listener = tf2_ros::TransformListener(buffer, listener_node);
+
+  // Wait for pub/sub to match
+  while(pub->get_subscription_count() == 0) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+
+  auto msg = tf2_msgs::msg::TFMessage();
+  auto tf_stamped = geometry_msgs::msg::TransformStamped();
+  tf_stamped.header.frame_id = "parent";
+  tf_stamped.child_frame_id = "child";
+  tf_stamped.header.stamp = pub_node->get_clock()->now();
+  msg.transforms.push_back(tf_stamped);
+
+  pub->publish(msg);
+
+  // Wait for sub to get message
+  while(!buffer.canTransform("parent", "child", tf2::TimePointZero)) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  
+  const std::string as_yaml = buffer.allFramesAsYAML();
+  EXPECT_TRUE(as_yaml.find(pub_node_name) != std::string::npos) << as_yaml;
+  EXPECT_TRUE(as_yaml.find(pub_namespace) != std::string::npos) << as_yaml;
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tf2_ros/test/node_wrapper.hpp
+++ b/tf2_ros/test/node_wrapper.hpp
@@ -55,6 +55,9 @@ public:
   rclcpp::node_interfaces::NodeParametersInterface::SharedPtr
   get_node_parameters_interface() {return this->node->get_node_parameters_interface();}
 
+  rclcpp::node_interfaces::NodeGraphInterface::SharedPtr
+  get_node_graph_interface() {return this->node->get_node_graph_interface();}
+
 private:
   rclcpp::Node::SharedPtr node;
 };


### PR DESCRIPTION
This enables the `TFListener` to get the authority, that is the name of the node containing the publisher who published the transform.


This [doesn't enable `tf2_monitor` to get the authority](https://github.com/ros2/geometry2/blob/2687a3543bf61481b06dcf37839c7e92bed85d2e/tf2_ros/src/tf2_monitor.cpp#L71-L72). I didn't see a good API to get the data there, so I left it unresolved.