### PR TITLE
Allow to construct `TransformBroadcaster` and `TransformListener` from node interfaces

### DIFF
--- a/tf2_ros/include/tf2_ros/transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/transform_broadcaster.h
@@ -53,7 +53,7 @@ namespace tf2_ros
 class TransformBroadcaster
 {
 public:
-  /** \brief Node interface constructor */
+  /** \brief Node constructor */
   template<class NodeT, class AllocatorT = std::allocator<void>>
   TransformBroadcaster(
     NodeT && node,
@@ -67,9 +67,31 @@ public:
         rclcpp::QosPolicyKind::Reliability};
       return options;
     } ())
+  : TransformBroadcaster(
+      node->get_node_parameters_interface(),
+      node->get_node_topics_interface(),
+      qos,
+      options)
+  { }
+
+  /** \brief Node interfaces constructor */
+  template<class AllocatorT = std::allocator<void>>
+  TransformBroadcaster(
+    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & node_parameters,
+    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr & node_topics,
+    const rclcpp::QoS & qos = DynamicBroadcasterQoS(),
+    const rclcpp::PublisherOptionsWithAllocator<AllocatorT> & options = [] () {
+      rclcpp::PublisherOptionsWithAllocator<AllocatorT> options;
+      options.qos_overriding_options = rclcpp::QosOverridingOptions{
+        rclcpp::QosPolicyKind::Depth,
+        rclcpp::QosPolicyKind::Durability,
+        rclcpp::QosPolicyKind::History,
+        rclcpp::QosPolicyKind::Reliability};
+      return options;
+    } ())
   {
     publisher_ = rclcpp::create_publisher<tf2_msgs::msg::TFMessage>(
-      node, "/tf", qos, options);
+      node_parameters, node_topics, "/tf", qos, options);
   }
 
   /** \brief Send a TransformStamped message

--- a/tf2_ros/include/tf2_ros/transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/transform_broadcaster.h
@@ -77,8 +77,8 @@ public:
   /** \brief Node interfaces constructor */
   template<class AllocatorT = std::allocator<void>>
   TransformBroadcaster(
-    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & node_parameters,
-    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr & node_topics,
+    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
+    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics,
     const rclcpp::QoS & qos = DynamicBroadcasterQoS(),
     const rclcpp::PublisherOptionsWithAllocator<AllocatorT> & options = [] () {
       rclcpp::PublisherOptionsWithAllocator<AllocatorT> options;

--- a/tf2_ros/include/tf2_ros/transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/transform_broadcaster.h
@@ -67,7 +67,7 @@ public:
         rclcpp::QosPolicyKind::Reliability};
       return options;
     } ())
-  : TransformBroadcaster(
+    : TransformBroadcaster(
       node->get_node_parameters_interface(),
       node->get_node_topics_interface(),
       qos,

--- a/tf2_ros/include/tf2_ros/transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/transform_broadcaster.h
@@ -72,7 +72,7 @@ public:
       node->get_node_topics_interface(),
       qos,
       options)
-  { }
+  {}
 
   /** \brief Node interfaces constructor */
   template<class AllocatorT = std::allocator<void>>

--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -120,10 +120,10 @@ public:
   template<class AllocatorT = std::allocator<void>>
   TransformListener(
     tf2::BufferCore & buffer,
-    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr & node_base,
-    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr & node_logging,
-    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & node_parameters,
-    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr & node_topics,
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
+    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
+    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
+    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics,
     bool spin_thread = true,
     const rclcpp::QoS & qos = DynamicListenerQoS(),
     const rclcpp::QoS & static_qos = StaticListenerQoS(),
@@ -151,10 +151,10 @@ public:
 private:
   template<class AllocatorT = std::allocator<void>>
   void init(
-    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr & node_base,
-    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr & node_logging,
-    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & node_parameters,
-    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr & node_topics,
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
+    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
+    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
+    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics,
     bool spin_thread,
     const rclcpp::QoS & qos,
     const rclcpp::QoS & static_qos,

--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -82,10 +82,16 @@ get_default_transform_listener_static_sub_options()
 class TransformListener
 {
 public:
-  /**@brief Constructor for transform listener */
+  /** \brief Simplified constructor for transform listener.
+   *
+   * This constructor will create a new ROS 2 node under the hood.
+   * If you already have access to a ROS 2 node and you want to associate the TransformListener
+   * to it, then it's recommended to use one of the other constructors.
+   */
   TF2_ROS_PUBLIC
   explicit TransformListener(tf2::BufferCore & buffer, bool spin_thread = true);
 
+  /** \brief Node constructor */
   template<class NodeT, class AllocatorT = std::allocator<void>>
   TransformListener(
     tf2::BufferCore & buffer,
@@ -97,18 +103,58 @@ public:
     detail::get_default_transform_listener_sub_options<AllocatorT>(),
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options =
     detail::get_default_transform_listener_static_sub_options<AllocatorT>())
+  : TransformListener(
+      buffer,
+      node->get_node_base_interface(),
+      node->get_node_logging_interface(),
+      node->get_node_parameters_interface(),
+      node->get_node_topics_interface(),
+      spin_thread,
+      qos,
+      static_qos,
+      options,
+      static_options)
+  { }
+
+  /** \brief Node interface constructor */
+  template<class AllocatorT = std::allocator<void>>
+  TransformListener(
+    tf2::BufferCore & buffer,
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr & node_base,
+    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr & node_logging,
+    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & node_parameters,
+    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr & node_topics,
+    bool spin_thread = true,
+    const rclcpp::QoS & qos = DynamicListenerQoS(),
+    const rclcpp::QoS & static_qos = StaticListenerQoS(),
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options =
+    detail::get_default_transform_listener_sub_options<AllocatorT>(),
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options =
+    detail::get_default_transform_listener_static_sub_options<AllocatorT>())
   : buffer_(buffer)
   {
-    init(node, spin_thread, qos, static_qos, options, static_options);
+    init(
+      node_base,
+      node_logging,
+      node_parameters,
+      node_topics,
+      spin_thread,
+      qos,
+      static_qos,
+      options,
+      static_options);
   }
 
   TF2_ROS_PUBLIC
   virtual ~TransformListener();
 
 private:
-  template<class NodeT, class AllocatorT = std::allocator<void>>
+  template<class AllocatorT = std::allocator<void>>
   void init(
-    NodeT && node,
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr & node_base,
+    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr & node_logging,
+    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & node_parameters,
+    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr & node_topics,
     bool spin_thread,
     const rclcpp::QoS & qos,
     const rclcpp::QoS & static_qos,
@@ -116,8 +162,8 @@ private:
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options)
   {
     spin_thread_ = spin_thread;
-    node_base_interface_ = node->get_node_base_interface();
-    node_logging_interface_ = node->get_node_logging_interface();
+    node_base_interface_ = node_base;
+    node_logging_interface_ = node_logging;
 
     using callback_t = std::function<void (tf2_msgs::msg::TFMessage::ConstSharedPtr)>;
     callback_t cb = std::bind(
@@ -136,9 +182,14 @@ private:
       tf_static_options.callback_group = callback_group_;
 
       message_subscription_tf_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
-        node, "/tf", qos, std::move(cb), tf_options);
+        node_parameters, node_topics, "/tf", qos, std::move(cb), tf_options);
       message_subscription_tf_static_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
-        node, "/tf_static", static_qos, std::move(static_cb), tf_static_options);
+        node_parameters,
+        node_topics,
+        "/tf_static",
+        static_qos,
+        std::move(static_cb),
+        tf_static_options);
 
       // Create executor with dedicated thread to spin.
       executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
@@ -148,9 +199,14 @@ private:
       buffer_.setUsingDedicatedThread(true);
     } else {
       message_subscription_tf_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
-        node, "/tf", qos, std::move(cb), options);
+        node_parameters, node_topics, "/tf", qos, std::move(cb), options);
       message_subscription_tf_static_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
-        node, "/tf_static", static_qos, std::move(static_cb), static_options);
+        node_parameters,
+        node_topics,
+        "/tf_static",
+        static_qos,
+        std::move(static_cb),
+        static_options);
     }
   }
   /// Callback function for ros message subscriptoin

--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -213,19 +213,18 @@ private:
   TF2_ROS_PUBLIC
   void subscription_callback(tf2_msgs::msg::TFMessage::ConstSharedPtr msg, bool is_static);
 
-  // ros::CallbackQueue tf_message_callback_queue_;
   bool spin_thread_{false};
-  std::unique_ptr<std::thread> dedicated_listener_thread_;
+  std::unique_ptr<std::thread> dedicated_listener_thread_ {nullptr};
   rclcpp::CallbackGroup::SharedPtr callback_group_{nullptr};
-  rclcpp::executors::SingleThreadedExecutor::SharedPtr executor_;
+  rclcpp::Executor::SharedPtr executor_ {nullptr};
 
-  rclcpp::Node::SharedPtr optional_default_node_ = nullptr;
-  rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr message_subscription_tf_;
-  rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr message_subscription_tf_static_;
+  rclcpp::Node::SharedPtr optional_default_node_ {nullptr};
+  rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr message_subscription_tf_ {nullptr};
+  rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr message_subscription_tf_static_ {nullptr};
   tf2::BufferCore & buffer_;
   tf2::TimePoint last_update_;
-  rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_interface_;
-  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface_;
+  rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_interface_ {nullptr};
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface_ {nullptr};
 };
 }  // namespace tf2_ros
 

--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -114,7 +114,7 @@ public:
       static_qos,
       options,
       static_options)
-  { }
+  {}
 
   /** \brief Node interface constructor */
   template<class AllocatorT = std::allocator<void>>
@@ -219,8 +219,10 @@ private:
   rclcpp::Executor::SharedPtr executor_ {nullptr};
 
   rclcpp::Node::SharedPtr optional_default_node_ {nullptr};
-  rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr message_subscription_tf_ {nullptr};
-  rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr message_subscription_tf_static_ {nullptr};
+  rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr
+    message_subscription_tf_ {nullptr};
+  rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr
+    message_subscription_tf_static_ {nullptr};
   tf2::BufferCore & buffer_;
   tf2::TimePoint last_update_;
   rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_interface_ {nullptr};

--- a/tf2_ros/src/transform_listener.cpp
+++ b/tf2_ros/src/transform_listener.cpp
@@ -53,7 +53,11 @@ TransformListener::TransformListener(tf2::BufferCore & buffer, bool spin_thread)
   options.start_parameter_services(false);
   optional_default_node_ = rclcpp::Node::make_shared("_", options);
   init(
-    optional_default_node_, spin_thread, DynamicListenerQoS(), StaticListenerQoS(),
+    optional_default_node_->get_node_base_interface(),
+    optional_default_node_->get_node_logging_interface(),
+    optional_default_node_->get_node_parameters_interface(),
+    optional_default_node_->get_node_topics_interface(),
+    spin_thread, DynamicListenerQoS(), StaticListenerQoS(),
     detail::get_default_transform_listener_sub_options(),
     detail::get_default_transform_listener_static_sub_options());
 }

--- a/tf2_ros/src/transform_listener.cpp
+++ b/tf2_ros/src/transform_listener.cpp
@@ -70,7 +70,6 @@ TransformListener::~TransformListener()
   }
 }
 
-
 void TransformListener::subscription_callback(
   const tf2_msgs::msg::TFMessage::ConstSharedPtr msg,
   bool is_static)


### PR DESCRIPTION
This PR adds new constructors for `TransformBroadcaster` and `TransformListener` that do not require to have access to a full node, but rather can use only the required node interfaces.