### PR TITLE
allow construction of tf broadcaster from node object (not a pointer)

### DIFF
--- a/tf2_ros/include/tf2_ros/transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/transform_broadcaster.h
@@ -38,6 +38,8 @@
 
 #include "tf2_ros/visibility_control.h"
 
+#include "rclcpp/node_interfaces/get_node_parameters_interface.hpp"
+#include "rclcpp/node_interfaces/get_node_topics_interface.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "tf2_msgs/msg/tf_message.hpp"
@@ -68,8 +70,8 @@ public:
       return options;
     } ())
     : TransformBroadcaster(
-      node->get_node_parameters_interface(),
-      node->get_node_topics_interface(),
+      rclcpp::node_interfaces::get_node_parameters_interface(node),
+      rclcpp::node_interfaces::get_node_topics_interface(node),
       qos,
       options)
   {}

--- a/tf2_ros/test/test_transform_broadcaster.cpp
+++ b/tf2_ros/test/test_transform_broadcaster.cpp
@@ -53,8 +53,14 @@ private:
 TEST(tf2_test_transform_broadcaster, transform_broadcaster_rclcpp_node)
 {
   auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
-
-  tf2_ros::TransformBroadcaster tfb(node);
+  // Construct tf broadcaster from node pointer
+  {
+    tf2_ros::TransformBroadcaster tfb(node);
+  }
+  // Construct tf broadcaster from node object
+  {
+    tf2_ros::TransformBroadcaster tfb(*node);
+  }
 }
 
 TEST(tf2_test_transform_broadcaster, transform_broadcaster_custom_rclcpp_node)


### PR DESCRIPTION
Follow up PR to https://github.com/ros2/geometry2/pull/552.
Addresses https://github.com/ros2/geometry2/issues/554


