### PR TITLE
Use pytest rather than unittest to enable repeat

### DIFF
--- a/tf2_ros_py/test/test_buffer.py
+++ b/tf2_ros_py/test/test_buffer.py
@@ -55,15 +55,15 @@ class TestBuffer:
         rclpy_time = clock.now()
         transform = self.build_transform('foo', 'bar', rclpy_time)
 
-        assert buffer.set_transform(transform, 'unittest') == None
-        assert buffer.can_transform('foo', 'bar', rclpy_time) ==  True
+        assert buffer.set_transform(transform, 'unittest') is None
+        assert buffer.can_transform('foo', 'bar', rclpy_time)
 
         output = buffer.lookup_transform('foo', 'bar', rclpy_time)
 
         assert transform.child_frame_id == output.child_frame_id
         assert transform.transform.translation.x == output.transform.translation.x
-        assert transform.transform.translation.y ==  output.transform.translation.y
-        assert transform.transform.translation.z ==  output.transform.translation.z
+        assert transform.transform.translation.y == output.transform.translation.y
+        assert transform.transform.translation.z == output.transform.translation.z
 
     def test_await_transform_immediately_available(self):
         # wait for a transform that is already available to test short-cut code
@@ -139,10 +139,10 @@ class TestBuffer:
 
         assert buffer.set_transform(transform, 'unittest') is None
 
-        assert buffer.can_transform('foo', 'bar', rclpy_time) == True
+        assert buffer.can_transform('foo', 'bar', rclpy_time)
 
         output = buffer.lookup_transform('foo', 'bar', rclpy_time)
         assert transform.child_frame_id == output.child_frame_id
         assert transform.transform.translation.x == output.transform.translation.x
-        assert transform.transform.translation.y ==  output.transform.translation.y
-        assert transform.transform.translation.z ==  output.transform.translation.z
+        assert transform.transform.translation.y == output.transform.translation.y
+        assert transform.transform.translation.z == output.transform.translation.z

--- a/tf2_ros_py/test/test_buffer.py
+++ b/tf2_ros_py/test/test_buffer.py
@@ -28,14 +28,13 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import unittest
+import pytest
 import rclpy
 
 from tf2_ros.buffer import Buffer
 from geometry_msgs.msg import TransformStamped, PointStamped
 
-
-class TestBuffer(unittest.TestCase):
+class TestBuffer:
     def build_transform(self, target, source, rclpy_time):
         transform = TransformStamped()
         transform.header.frame_id = target
@@ -56,15 +55,15 @@ class TestBuffer(unittest.TestCase):
         rclpy_time = clock.now()
         transform = self.build_transform('foo', 'bar', rclpy_time)
 
-        self.assertEqual(buffer.set_transform(transform, 'unittest'), None)
-
-        self.assertEqual(buffer.can_transform('foo', 'bar', rclpy_time), True)
+        assert buffer.set_transform(transform, 'unittest') == None
+        assert buffer.can_transform('foo', 'bar', rclpy_time) ==  True
 
         output = buffer.lookup_transform('foo', 'bar', rclpy_time)
-        self.assertEqual(transform.child_frame_id, output.child_frame_id)
-        self.assertEqual(transform.transform.translation.x, output.transform.translation.x)
-        self.assertEqual(transform.transform.translation.y, output.transform.translation.y)
-        self.assertEqual(transform.transform.translation.z, output.transform.translation.z)
+
+        assert transform.child_frame_id == output.child_frame_id
+        assert transform.transform.translation.x == output.transform.translation.x
+        assert transform.transform.translation.y ==  output.transform.translation.y
+        assert transform.transform.translation.z ==  output.transform.translation.z
 
     def test_await_transform_immediately_available(self):
         # wait for a transform that is already available to test short-cut code
@@ -76,10 +75,10 @@ class TestBuffer(unittest.TestCase):
         buffer.set_transform(transform, 'unittest')
 
         coro = buffer.lookup_transform_async('foo', 'bar', rclpy_time)
-        with self.assertRaises(StopIteration) as cm:
+        with pytest.raises(StopIteration) as excinfo:
             coro.send(None)
 
-        self.assertEqual(transform, cm.exception.value)
+        assert transform == excinfo.value.value
         coro.close()
 
     def test_await_transform_full_immediately_available(self):
@@ -92,10 +91,10 @@ class TestBuffer(unittest.TestCase):
         buffer.set_transform(transform, 'unittest')
 
         coro = buffer.lookup_transform_full_async('foo', rclpy_time, 'bar', rclpy_time, 'foo')
-        with self.assertRaises(StopIteration) as cm:
+        with pytest.raises(StopIteration) as excinfo:
             coro.send(None)
 
-        self.assertEqual(transform, cm.exception.value)
+        assert transform == excinfo.value.value
         coro.close()
 
     def test_await_transform_delayed(self):
@@ -109,10 +108,10 @@ class TestBuffer(unittest.TestCase):
         coro.send(None)
 
         buffer.set_transform(transform, 'unittest')
-        with self.assertRaises(StopIteration) as cm:
+        with pytest.raises(StopIteration) as excinfo:
             coro.send(None)
 
-        self.assertEqual(transform, cm.exception.value)
+        assert transform == excinfo.value.value
         coro.close()
 
     def test_await_transform_full_delayed(self):
@@ -126,10 +125,10 @@ class TestBuffer(unittest.TestCase):
         coro.send(None)
 
         buffer.set_transform(transform, 'unittest')
-        with self.assertRaises(StopIteration) as cm:
+        with pytest.raises(StopIteration) as excinfo:
             coro.send(None)
 
-        self.assertEqual(transform, cm.exception.value)
+        assert transform == excinfo.value.value
         coro.close()
 
     def test_buffer_non_default_cache(self):
@@ -138,16 +137,12 @@ class TestBuffer(unittest.TestCase):
         rclpy_time = clock.now()
         transform = self.build_transform('foo', 'bar', rclpy_time)
 
-        self.assertEqual(buffer.set_transform(transform, 'unittest'), None)
+        assert buffer.set_transform(transform, 'unittest') is None
 
-        self.assertEqual(buffer.can_transform('foo', 'bar', rclpy_time), True)
+        assert buffer.can_transform('foo', 'bar', rclpy_time) == True
 
         output = buffer.lookup_transform('foo', 'bar', rclpy_time)
-        self.assertEqual(transform.child_frame_id, output.child_frame_id)
-        self.assertEqual(transform.transform.translation.x, output.transform.translation.x)
-        self.assertEqual(transform.transform.translation.y, output.transform.translation.y)
-        self.assertEqual(transform.transform.translation.z, output.transform.translation.z)
-
-
-if __name__ == '__main__':
-    unittest.main()
+        assert transform.child_frame_id == output.child_frame_id
+        assert transform.transform.translation.x == output.transform.translation.x
+        assert transform.transform.translation.y ==  output.transform.translation.y
+        assert transform.transform.translation.z ==  output.transform.translation.z


### PR DESCRIPTION
As part of debugging the buildfarm hanging in `test_buffer.py`, I found that the `unittest.TestCase` derived tests don't work with `pytest-repeat`.

This updates the tests to use `pytest`.

Signed-off-by: Michael Carroll <michael@openrobotics.org>