### PR TITLE
Include required header Scalar.h

### DIFF
--- a/tf2/include/tf2/LinearMath/MinMax.h
+++ b/tf2/include/tf2/LinearMath/MinMax.h
@@ -17,6 +17,8 @@ subject to the following restrictions:
 #ifndef GEN_MINMAX_H
 #define GEN_MINMAX_H
 
+#include <tf2/LinearMath/Scalar.h>
+
 template <class T>
 TF2SIMD_FORCE_INLINE const T& tf2Min(const T& a, const T& b) 
 {

--- a/tf2/include/tf2/LinearMath/MinMax.h
+++ b/tf2/include/tf2/LinearMath/MinMax.h
@@ -17,7 +17,7 @@ subject to the following restrictions:
 #ifndef GEN_MINMAX_H
 #define GEN_MINMAX_H
 
-#include <tf2/LinearMath/Scalar.h>
+#include "Scalar.h"
 
 template <class T>
 TF2SIMD_FORCE_INLINE const T& tf2Min(const T& a, const T& b) 


### PR DESCRIPTION
I noticed downstream code was working around this bug here: https://github.com/locusrobotics/tf2_2d/blob/beb6a7a29fcdba7abb1540d9524e81cb9795b9ac/include/tf2_2d/rotation_impl.h#L37-L38

`Scalar.h` is needed for the `TF2SIMD_FORCE_INLINE` value to be defined.