### PR TITLE
Enable TransformListener node-based constructor in Intra-process enabled components

### DIFF
--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -61,6 +61,7 @@ get_default_transform_listener_sub_options()
     rclcpp::QosPolicyKind::Durability,
     rclcpp::QosPolicyKind::History,
     rclcpp::QosPolicyKind::Reliability};
+  options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
   return options;
 }
 
@@ -73,6 +74,7 @@ get_default_transform_listener_static_sub_options()
     rclcpp::QosPolicyKind::Depth,
     rclcpp::QosPolicyKind::History,
     rclcpp::QosPolicyKind::Reliability};
+  options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
   return options;
 }
 }  // namespace detail

--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -81,7 +81,7 @@ get_default_transform_listener_static_sub_options()
     rclcpp::QosPolicyKind::Depth,
     rclcpp::QosPolicyKind::History,
     rclcpp::QosPolicyKind::Reliability};
-  /* 
+  /*
     This flag disables intra-process communication while subscribing to
     /tf_static topic, when the TransformListener is constructed using an existing
     node handle which happens to be a component (in rclcpp terminology).

--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -88,7 +88,7 @@ get_default_transform_listener_static_sub_options()
     Required until rclcpp intra-process communication supports
     transient_local QoS durability.
   */
-options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
+  options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
   return options;
 }
 }  // namespace detail

--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -65,7 +65,7 @@ get_default_transform_listener_sub_options()
     This flag disables intra-process communication while subscribing to
     /tf topic, when the TransformListener is constructed using an existing
     node handle which happens to be a component (in rclcpp terminology).
-    Required until rclcpp intra-process communication does not support 
+    Required until rclcpp intra-process communication supports
     transient_local QoS durability.
   */
   options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;

--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -85,7 +85,7 @@ get_default_transform_listener_static_sub_options()
     This flag disables intra-process communication while subscribing to
     /tf_static topic, when the TransformListener is constructed using an existing
     node handle which happens to be a component (in rclcpp terminology).
-    Required until rclcpp intra-process communication does not support 
+    Required until rclcpp intra-process communication supports
     transient_local QoS durability.
   */
 options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;

--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -61,6 +61,13 @@ get_default_transform_listener_sub_options()
     rclcpp::QosPolicyKind::Durability,
     rclcpp::QosPolicyKind::History,
     rclcpp::QosPolicyKind::Reliability};
+  /* 
+    This flag disables intra-process communication while subscribing to
+    /tf topic, when the TransformListener is constructed using an existing
+    node handle which happens to be a component (in rclcpp terminology).
+    Required until rclcpp intra-process communication does not support 
+    transient_local QoS durability.
+  */
   options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
   return options;
 }
@@ -74,7 +81,14 @@ get_default_transform_listener_static_sub_options()
     rclcpp::QosPolicyKind::Depth,
     rclcpp::QosPolicyKind::History,
     rclcpp::QosPolicyKind::Reliability};
-  options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
+  /* 
+    This flag disables intra-process communication while subscribing to
+    /tf_static topic, when the TransformListener is constructed using an existing
+    node handle which happens to be a component (in rclcpp terminology).
+    Required until rclcpp intra-process communication does not support 
+    transient_local QoS durability.
+  */
+options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
   return options;
 }
 }  // namespace detail

--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -61,7 +61,7 @@ get_default_transform_listener_sub_options()
     rclcpp::QosPolicyKind::Durability,
     rclcpp::QosPolicyKind::History,
     rclcpp::QosPolicyKind::Reliability};
-  /* 
+  /*
     This flag disables intra-process communication while subscribing to
     /tf topic, when the TransformListener is constructed using an existing
     node handle which happens to be a component (in rclcpp terminology).

--- a/tf2_ros/test/test_transform_listener.cpp
+++ b/tf2_ros/test/test_transform_listener.cpp
@@ -53,6 +53,24 @@ private:
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
 };
 
+class CustomComposableNode : public rclcpp::Node
+{
+public:
+  explicit CustomComposableNode(const rclcpp::NodeOptions & options)
+  : rclcpp::Node("tf2_ros_test_transform_listener_composable_node", options)
+  {}
+
+  void init_tf_listener()
+  {
+    rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+    tf2_ros::Buffer buffer(clock);
+    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(buffer, shared_from_this(), false);
+  }
+
+private:
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+};
+
 TEST(tf2_test_transform_listener, transform_listener_rclcpp_node)
 {
   auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
@@ -74,6 +92,15 @@ TEST(tf2_test_transform_listener, transform_listener_custom_rclcpp_node)
 TEST(tf2_test_transform_listener, transform_listener_as_member)
 {
   auto custom_node = std::make_shared<CustomNode>();
+  custom_node->init_tf_listener();
+}
+
+TEST(tf2_test_transform_listener, transform_listener_with_intraprocess)
+{
+  rclcpp::executors::SingleThreadedExecutor exec;
+  rclcpp::NodeOptions options;
+  options = options.use_intra_process_comms(true);
+  auto custom_node = std::make_shared<CustomComposableNode>(options);
   custom_node->init_tf_listener();
 }
 


### PR DESCRIPTION
Fixes #571 

With this patch, TransformListener can be constructed using existing node references, when those nodes are in fact Intra-Process Enabled C++ ROS2 Components.

Intra-process communication is disabled per-subscription.