### PR TITLE
Extend TimeCache API to provide rich ExtrapolationException infos

### DIFF
--- a/tf2/include/tf2/exceptions.h
+++ b/tf2/include/tf2/exceptions.h
@@ -66,6 +66,9 @@ enum class TF2Error : std::uint8_t
   TF2_INVALID_ARGUMENT_ERROR = 4,
   TF2_TIMEOUT_ERROR = 5,
   TF2_TRANSFORM_ERROR = 6,
+  TF2_BACKWARD_EXTRAPOLATION_ERROR = 7,
+  TF2_FORWARD_EXTRAPOLATION_ERROR = 8,
+  TF2_NO_DATA_FOR_EXTRAPOLATION_ERROR = 9,
 
   NO_ERROR [[deprecated("Use TF2_NO_ERROR instead")]] = 0,
   LOOKUP_ERROR [[deprecated("Use TF2_LOOKUP_ERROR instead")]] = 1,
@@ -143,6 +146,45 @@ public:
   TF2_PUBLIC
   explicit ExtrapolationException(const std::string errorDescription)
   : tf2::TransformException(errorDescription)
+  {
+  }
+};
+
+/** \brief An exception class to notify that the requested value would have required extrapolation in the past.
+ *
+ */
+class BackwardExtrapolationException : public ExtrapolationException
+{
+public:
+  TF2_PUBLIC
+  explicit BackwardExtrapolationException(const std::string errorDescription)
+  : ExtrapolationException(errorDescription)
+  {
+  }
+};
+
+/** \brief An exception class to notify that the requested value would have required extrapolation in the future.
+ *
+ */
+class ForwardExtrapolationException : public ExtrapolationException
+{
+public:
+  TF2_PUBLIC
+  explicit ForwardExtrapolationException(const std::string errorDescription)
+  : ExtrapolationException(errorDescription)
+  {
+  }
+};
+
+/** \brief An exception class to notify that the requested value would have required extrapolation, but only zero or one data is available, so not enough for extrapolation.
+ *
+ */
+class NoDataForExtrapolationException : public ExtrapolationException
+{
+public:
+  TF2_PUBLIC
+  explicit NoDataForExtrapolationException(const std::string errorDescription)
+  : ExtrapolationException(errorDescription)
   {
   }
 };

--- a/tf2/include/tf2/time_cache.h
+++ b/tf2/include/tf2/time_cache.h
@@ -64,7 +64,7 @@ public:
   TF2_PUBLIC
   virtual bool getData(
     tf2::TimePoint time, tf2::TransformStorage & data_out,
-    TimeCacheError * error_code = 0, std::string * error_str = 0) = 0;
+    std::string * error_str = 0, TimeCacheError * error_code = 0) = 0;
 
   /** \brief Insert data into the cache */
   TF2_PUBLIC
@@ -77,7 +77,7 @@ public:
   /** \brief Retrieve the parent at a specific time */
   TF2_PUBLIC
   virtual CompactFrameID getParent(
-    tf2::TimePoint time, TimeCacheError * error_code = 0, std::string * error_str = 0) = 0;
+    tf2::TimePoint time, std::string * error_str = 0, TimeCacheError * error_code = 0) = 0;
 
   /**
    * \brief Get the latest time stored in this cache, and the parent associated with it.  Returns parent = 0 if no data.
@@ -126,14 +126,14 @@ public:
   TF2_PUBLIC
   virtual bool getData(
     tf2::TimePoint time, tf2::TransformStorage & data_out,
-    TimeCacheError * error_code = 0, std::string * error_str = 0);
+    std::string * error_str = 0, TimeCacheError * error_code = 0);
   TF2_PUBLIC
   virtual bool insertData(const tf2::TransformStorage & new_data);
   TF2_PUBLIC
   virtual void clearList();
   TF2_PUBLIC
   virtual tf2::CompactFrameID getParent(
-    tf2::TimePoint time, TimeCacheError * error_code = 0, std::string * error_str = 0);
+    tf2::TimePoint time, std::string * error_str = 0, TimeCacheError * error_code = 0);
   TF2_PUBLIC
   virtual P_TimeAndFrameID getLatestTimeAndParent();
 
@@ -156,7 +156,7 @@ private:
   // Assumes storage is already locked for it
   inline uint8_t findClosest(
     tf2::TransformStorage * & one, TransformStorage * & two,
-    tf2::TimePoint target_time, TimeCacheError * error_code, std::string * error_str);
+    tf2::TimePoint target_time, std::string * error_str = 0, TimeCacheError * error_code = 0);
 
   inline void interpolate(
     const tf2::TransformStorage & one, const tf2::TransformStorage & two,
@@ -172,7 +172,7 @@ public:
   TF2_PUBLIC
   virtual bool getData(
     TimePoint time, TransformStorage & data_out,
-    TimeCacheError * error_code = 0, std::string * error_str = 0);
+    std::string * error_str = 0, TimeCacheError * error_code = 0);
   // returns false if data unavailable (should be thrown as lookup exception
   TF2_PUBLIC
   virtual bool insertData(const TransformStorage & new_data);
@@ -180,7 +180,7 @@ public:
   virtual void clearList();
   TF2_PUBLIC
   virtual CompactFrameID getParent(
-    TimePoint time, TimeCacheError * error_code = 0, std::string * error_str = 0);
+    TimePoint time, std::string * error_str = 0, TimeCacheError * error_code = 0);
   TF2_PUBLIC
   virtual P_TimeAndFrameID getLatestTimeAndParent();
 

--- a/tf2/include/tf2/time_cache.h
+++ b/tf2/include/tf2/time_cache.h
@@ -44,6 +44,14 @@ namespace tf2
 {
 typedef std::pair<tf2::TimePoint, tf2::CompactFrameID> P_TimeAndFrameID;
 
+enum class TimeCacheError : std::uint8_t
+{
+  TIME_CACHE_NO_ERROR = 0,
+  TIME_CACHE_NOT_ENOUGH_DATA_ERROR = 1,
+  TIME_CACHE_BACKWARD_EXTRAPOLATION_ERROR = 2,
+  TIME_CACHE_FORWARD_EXTRAPOLATION_ERROR = 3,
+};
+
 class TimeCacheInterface
 {
 public:
@@ -56,7 +64,7 @@ public:
   TF2_PUBLIC
   virtual bool getData(
     tf2::TimePoint time, tf2::TransformStorage & data_out,
-    std::string * error_str = 0) = 0;
+    TimeCacheError * error_code = 0, std::string * error_str = 0) = 0;
 
   /** \brief Insert data into the cache */
   TF2_PUBLIC
@@ -68,7 +76,7 @@ public:
 
   /** \brief Retrieve the parent at a specific time */
   TF2_PUBLIC
-  virtual CompactFrameID getParent(tf2::TimePoint time, std::string * error_str) = 0;
+  virtual CompactFrameID getParent(tf2::TimePoint time, TimeCacheError * error_code = 0, std::string * error_str = 0) = 0;
 
   /**
    * \brief Get the latest time stored in this cache, and the parent associated with it.  Returns parent = 0 if no data.
@@ -117,13 +125,13 @@ public:
   TF2_PUBLIC
   virtual bool getData(
     tf2::TimePoint time, tf2::TransformStorage & data_out,
-    std::string * error_str = 0);
+    TimeCacheError * error_code = 0, std::string * error_str = 0);
   TF2_PUBLIC
   virtual bool insertData(const tf2::TransformStorage & new_data);
   TF2_PUBLIC
   virtual void clearList();
   TF2_PUBLIC
-  virtual tf2::CompactFrameID getParent(tf2::TimePoint time, std::string * error_str);
+  virtual tf2::CompactFrameID getParent(tf2::TimePoint time, TimeCacheError * error_code = 0, std::string * error_str = 0);
   TF2_PUBLIC
   virtual P_TimeAndFrameID getLatestTimeAndParent();
 
@@ -146,7 +154,7 @@ private:
   // Assumes storage is already locked for it
   inline uint8_t findClosest(
     tf2::TransformStorage * & one, TransformStorage * & two,
-    tf2::TimePoint target_time, std::string * error_str);
+    tf2::TimePoint target_time, TimeCacheError * error_code, std::string * error_str);
 
   inline void interpolate(
     const tf2::TransformStorage & one, const tf2::TransformStorage & two,
@@ -160,14 +168,14 @@ class StaticCache : public TimeCacheInterface
 public:
   /// Virtual methods
   TF2_PUBLIC
-  virtual bool getData(TimePoint time, TransformStorage & data_out, std::string * error_str = 0);
+  virtual bool getData(TimePoint time, TransformStorage & data_out, TimeCacheError * error_code = 0, std::string * error_str = 0);
   // returns false if data unavailable (should be thrown as lookup exception
   TF2_PUBLIC
   virtual bool insertData(const TransformStorage & new_data);
   TF2_PUBLIC
   virtual void clearList();
   TF2_PUBLIC
-  virtual CompactFrameID getParent(TimePoint time, std::string * error_str);
+  virtual CompactFrameID getParent(TimePoint time, TimeCacheError * error_code = 0, std::string * error_str = 0);
   TF2_PUBLIC
   virtual P_TimeAndFrameID getLatestTimeAndParent();
 

--- a/tf2/include/tf2/time_cache.h
+++ b/tf2/include/tf2/time_cache.h
@@ -39,18 +39,11 @@
 
 #include "tf2/visibility_control.h"
 #include "tf2/transform_storage.h"
+#include "tf2/exceptions.h"
 
 namespace tf2
 {
 typedef std::pair<tf2::TimePoint, tf2::CompactFrameID> P_TimeAndFrameID;
-
-enum class TimeCacheError : std::uint8_t
-{
-  TIME_CACHE_NO_ERROR = 0,
-  TIME_CACHE_NOT_ENOUGH_DATA_ERROR = 1,
-  TIME_CACHE_BACKWARD_EXTRAPOLATION_ERROR = 2,
-  TIME_CACHE_FORWARD_EXTRAPOLATION_ERROR = 3,
-};
 
 class TimeCacheInterface
 {
@@ -64,7 +57,7 @@ public:
   TF2_PUBLIC
   virtual bool getData(
     tf2::TimePoint time, tf2::TransformStorage & data_out,
-    std::string * error_str = 0, TimeCacheError * error_code = 0) = 0;
+    std::string * error_str = 0, TF2Error * error_code = 0) = 0;
 
   /** \brief Insert data into the cache */
   TF2_PUBLIC
@@ -77,7 +70,7 @@ public:
   /** \brief Retrieve the parent at a specific time */
   TF2_PUBLIC
   virtual CompactFrameID getParent(
-    tf2::TimePoint time, std::string * error_str = 0, TimeCacheError * error_code = 0) = 0;
+    tf2::TimePoint time, std::string * error_str = 0, TF2Error * error_code = 0) = 0;
 
   /**
    * \brief Get the latest time stored in this cache, and the parent associated with it.  Returns parent = 0 if no data.
@@ -126,14 +119,14 @@ public:
   TF2_PUBLIC
   virtual bool getData(
     tf2::TimePoint time, tf2::TransformStorage & data_out,
-    std::string * error_str = 0, TimeCacheError * error_code = 0);
+    std::string * error_str = 0, TF2Error * error_code = 0);
   TF2_PUBLIC
   virtual bool insertData(const tf2::TransformStorage & new_data);
   TF2_PUBLIC
   virtual void clearList();
   TF2_PUBLIC
   virtual tf2::CompactFrameID getParent(
-    tf2::TimePoint time, std::string * error_str = 0, TimeCacheError * error_code = 0);
+    tf2::TimePoint time, std::string * error_str = 0, TF2Error * error_code = 0);
   TF2_PUBLIC
   virtual P_TimeAndFrameID getLatestTimeAndParent();
 
@@ -156,7 +149,7 @@ private:
   // Assumes storage is already locked for it
   inline uint8_t findClosest(
     tf2::TransformStorage * & one, TransformStorage * & two,
-    tf2::TimePoint target_time, std::string * error_str = 0, TimeCacheError * error_code = 0);
+    tf2::TimePoint target_time, std::string * error_str = 0, TF2Error * error_code = 0);
 
   inline void interpolate(
     const tf2::TransformStorage & one, const tf2::TransformStorage & two,
@@ -172,7 +165,7 @@ public:
   TF2_PUBLIC
   virtual bool getData(
     TimePoint time, TransformStorage & data_out,
-    std::string * error_str = 0, TimeCacheError * error_code = 0);
+    std::string * error_str = 0, TF2Error * error_code = 0);
   // returns false if data unavailable (should be thrown as lookup exception
   TF2_PUBLIC
   virtual bool insertData(const TransformStorage & new_data);
@@ -180,7 +173,7 @@ public:
   virtual void clearList();
   TF2_PUBLIC
   virtual CompactFrameID getParent(
-    TimePoint time, std::string * error_str = 0, TimeCacheError * error_code = 0);
+    TimePoint time, std::string * error_str = 0, TF2Error * error_code = 0);
   TF2_PUBLIC
   virtual P_TimeAndFrameID getLatestTimeAndParent();
 

--- a/tf2/include/tf2/time_cache.h
+++ b/tf2/include/tf2/time_cache.h
@@ -76,7 +76,8 @@ public:
 
   /** \brief Retrieve the parent at a specific time */
   TF2_PUBLIC
-  virtual CompactFrameID getParent(tf2::TimePoint time, TimeCacheError * error_code = 0, std::string * error_str = 0) = 0;
+  virtual CompactFrameID getParent(
+    tf2::TimePoint time, TimeCacheError * error_code = 0, std::string * error_str = 0) = 0;
 
   /**
    * \brief Get the latest time stored in this cache, and the parent associated with it.  Returns parent = 0 if no data.
@@ -131,7 +132,8 @@ public:
   TF2_PUBLIC
   virtual void clearList();
   TF2_PUBLIC
-  virtual tf2::CompactFrameID getParent(tf2::TimePoint time, TimeCacheError * error_code = 0, std::string * error_str = 0);
+  virtual tf2::CompactFrameID getParent(
+    tf2::TimePoint time, TimeCacheError * error_code = 0, std::string * error_str = 0);
   TF2_PUBLIC
   virtual P_TimeAndFrameID getLatestTimeAndParent();
 
@@ -168,14 +170,17 @@ class StaticCache : public TimeCacheInterface
 public:
   /// Virtual methods
   TF2_PUBLIC
-  virtual bool getData(TimePoint time, TransformStorage & data_out, TimeCacheError * error_code = 0, std::string * error_str = 0);
+  virtual bool getData(
+    TimePoint time, TransformStorage & data_out,
+    TimeCacheError * error_code = 0, std::string * error_str = 0);
   // returns false if data unavailable (should be thrown as lookup exception
   TF2_PUBLIC
   virtual bool insertData(const TransformStorage & new_data);
   TF2_PUBLIC
   virtual void clearList();
   TF2_PUBLIC
-  virtual CompactFrameID getParent(TimePoint time, TimeCacheError * error_code = 0, std::string * error_str = 0);
+  virtual CompactFrameID getParent(
+    TimePoint time, TimeCacheError * error_code = 0, std::string * error_str = 0);
   TF2_PUBLIC
   virtual P_TimeAndFrameID getLatestTimeAndParent();
 

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -367,7 +367,7 @@ tf2::TF2Error BufferCore::walkToTopParent(
       break;
     }
 
-    CompactFrameID parent = f.gather(cache, time, &error_code, &extrapolation_error_string);
+    CompactFrameID parent = f.gather(cache, time, &extrapolation_error_string, &error_code);
     if (parent == 0) {
       // Just break out here... there may still be a path from source -> target
       top_parent = frame;
@@ -413,7 +413,7 @@ tf2::TF2Error BufferCore::walkToTopParent(
       break;
     }
 
-    CompactFrameID parent = f.gather(cache, time, &error_code, error_string);
+    CompactFrameID parent = f.gather(cache, time, error_string, &error_code);
     if (parent == 0) {
       if (error_string) {
         std::stringstream ss;
@@ -524,9 +524,9 @@ struct TransformAccum
   }
 
   CompactFrameID gather(TimeCacheInterfacePtr cache, TimePoint time,
-    TimeCacheError * error_code, std::string * error_string)
+    std::string * error_string, TimeCacheError * error_code)
   {
-    if (!cache->getData(time, st, error_code, error_string)) {
+    if (!cache->getData(time, st, error_string, error_code)) {
       return 0;
     }
 
@@ -725,9 +725,9 @@ void BufferCore::lookupTransformImpl(
 struct CanTransformAccum
 {
   CompactFrameID gather(TimeCacheInterfacePtr cache, TimePoint time,
-    TimeCacheError * error_code, std::string * error_string)
+    std::string * error_string, TimeCacheError * error_code)
   {
-    return cache->getParent(time, error_code, error_string);
+    return cache->getParent(time, error_string, error_code);
   }
 
   void accum(bool source)

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -351,7 +351,7 @@ tf2::TF2Error BufferCore::walkToTopParent(
   CompactFrameID top_parent = frame;
   uint32_t depth = 0;
 
-  TimeCacheError error_code = TimeCacheError::TIME_CACHE_NO_ERROR;
+  TF2Error error_code = TF2Error::TF2_NO_ERROR;
   std::string extrapolation_error_string;
   bool extrapolation_might_have_occurred = false;
 
@@ -422,16 +422,7 @@ tf2::TF2Error BufferCore::walkToTopParent(
         *error_string = ss.str();
       }
 
-      switch (error_code) {
-        case TimeCacheError::TIME_CACHE_BACKWARD_EXTRAPOLATION_ERROR:
-          return tf2::TF2Error::TF2_BACKWARD_EXTRAPOLATION_ERROR;
-        case TimeCacheError::TIME_CACHE_FORWARD_EXTRAPOLATION_ERROR:
-          return tf2::TF2Error::TF2_FORWARD_EXTRAPOLATION_ERROR;
-        case TimeCacheError::TIME_CACHE_NOT_ENOUGH_DATA_ERROR:
-          return tf2::TF2Error::TF2_NO_DATA_FOR_EXTRAPOLATION_ERROR;
-        default:  // Shall never fall down here
-          return tf2::TF2Error::TF2_EXTRAPOLATION_ERROR;
-      }
+      return error_code;
     }
 
     // Early out... source frame is a direct parent of the target frame
@@ -467,16 +458,7 @@ tf2::TF2Error BufferCore::walkToTopParent(
           lookupFrameString(source_id) << "] to frame [" << lookupFrameString(target_id) << "]";
         *error_string = ss.str();
       }
-      switch (error_code) {
-        case TimeCacheError::TIME_CACHE_BACKWARD_EXTRAPOLATION_ERROR:
-          return tf2::TF2Error::TF2_BACKWARD_EXTRAPOLATION_ERROR;
-        case TimeCacheError::TIME_CACHE_FORWARD_EXTRAPOLATION_ERROR:
-          return tf2::TF2Error::TF2_FORWARD_EXTRAPOLATION_ERROR;
-        case TimeCacheError::TIME_CACHE_NOT_ENOUGH_DATA_ERROR:
-          return tf2::TF2Error::TF2_NO_DATA_FOR_EXTRAPOLATION_ERROR;
-        default:  // Shall never fall down here
-          return tf2::TF2Error::TF2_EXTRAPOLATION_ERROR;
-      }
+      return error_code;
     }
     createConnectivityErrorString(source_id, target_id, error_string);
     return tf2::TF2Error::TF2_CONNECTIVITY_ERROR;
@@ -525,7 +507,7 @@ struct TransformAccum
 
   CompactFrameID gather(
     TimeCacheInterfacePtr cache, TimePoint time,
-    std::string * error_string, TimeCacheError * error_code)
+    std::string * error_string, TF2Error * error_code)
   {
     if (!cache->getData(time, st, error_string, error_code)) {
       return 0;
@@ -727,7 +709,7 @@ struct CanTransformAccum
 {
   CompactFrameID gather(
     TimeCacheInterfacePtr cache, TimePoint time,
-    std::string * error_string, TimeCacheError * error_code)
+    std::string * error_string, TF2Error * error_code)
   {
     return cache->getParent(time, error_string, error_code);
   }

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -426,10 +426,10 @@ tf2::TF2Error BufferCore::walkToTopParent(
         case TimeCacheError::TIME_CACHE_BACKWARD_EXTRAPOLATION_ERROR:
           return tf2::TF2Error::TF2_BACKWARD_EXTRAPOLATION_ERROR;
         case TimeCacheError::TIME_CACHE_FORWARD_EXTRAPOLATION_ERROR:
-          return tf2::TF2Error::TF2_FORWARD_EXTRAPOLATION_ERROR;        
+          return tf2::TF2Error::TF2_FORWARD_EXTRAPOLATION_ERROR;
         case TimeCacheError::TIME_CACHE_NOT_ENOUGH_DATA_ERROR:
           return tf2::TF2Error::TF2_NO_DATA_FOR_EXTRAPOLATION_ERROR;
-        default: // Shall never fall down here
+        default:  // Shall never fall down here
           return tf2::TF2Error::TF2_EXTRAPOLATION_ERROR;
       }
     }
@@ -471,10 +471,10 @@ tf2::TF2Error BufferCore::walkToTopParent(
         case TimeCacheError::TIME_CACHE_BACKWARD_EXTRAPOLATION_ERROR:
           return tf2::TF2Error::TF2_BACKWARD_EXTRAPOLATION_ERROR;
         case TimeCacheError::TIME_CACHE_FORWARD_EXTRAPOLATION_ERROR:
-          return tf2::TF2Error::TF2_FORWARD_EXTRAPOLATION_ERROR;        
+          return tf2::TF2Error::TF2_FORWARD_EXTRAPOLATION_ERROR;
         case TimeCacheError::TIME_CACHE_NOT_ENOUGH_DATA_ERROR:
           return tf2::TF2Error::TF2_NO_DATA_FOR_EXTRAPOLATION_ERROR;
-        default: // Shall never fall down here
+        default:  // Shall never fall down here
           return tf2::TF2Error::TF2_EXTRAPOLATION_ERROR;
       }
     }
@@ -523,7 +523,8 @@ struct TransformAccum
   {
   }
 
-  CompactFrameID gather(TimeCacheInterfacePtr cache, TimePoint time, TimeCacheError * error_code, std::string * error_string)
+  CompactFrameID gather(TimeCacheInterfacePtr cache, TimePoint time,
+    TimeCacheError * error_code, std::string * error_string)
   {
     if (!cache->getData(time, st, error_code, error_string)) {
       return 0;
@@ -723,7 +724,8 @@ void BufferCore::lookupTransformImpl(
 
 struct CanTransformAccum
 {
-  CompactFrameID gather(TimeCacheInterfacePtr cache, TimePoint time, TimeCacheError * error_code, std::string * error_string)
+  CompactFrameID gather(TimeCacheInterfacePtr cache, TimePoint time,
+    TimeCacheError * error_code, std::string * error_string)
   {
     return cache->getParent(time, error_code, error_string);
   }

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -523,7 +523,8 @@ struct TransformAccum
   {
   }
 
-  CompactFrameID gather(TimeCacheInterfacePtr cache, TimePoint time,
+  CompactFrameID gather(
+    TimeCacheInterfacePtr cache, TimePoint time,
     std::string * error_string, TimeCacheError * error_code)
   {
     if (!cache->getData(time, st, error_string, error_code)) {
@@ -724,7 +725,8 @@ void BufferCore::lookupTransformImpl(
 
 struct CanTransformAccum
 {
-  CompactFrameID gather(TimeCacheInterfacePtr cache, TimePoint time,
+  CompactFrameID gather(
+    TimeCacheInterfacePtr cache, TimePoint time,
     std::string * error_string, TimeCacheError * error_code)
   {
     return cache->getParent(time, error_string, error_code);

--- a/tf2/src/cache.cpp
+++ b/tf2/src/cache.cpp
@@ -68,10 +68,10 @@ namespace cache
 // hoisting these into separate functions causes an ~8% speedup.
 // Removing calling them altogether adds another ~10%
 void createExtrapolationException1(
-  TimePoint t0, TimePoint t1, std::string * error_str, TimeCacheError * error_code)
+  TimePoint t0, TimePoint t1, std::string * error_str, TF2Error * error_code)
 {
   if (error_code) {
-    *error_code = TimeCacheError::TIME_CACHE_NOT_ENOUGH_DATA_ERROR;
+    *error_code = TF2Error::TF2_NO_DATA_FOR_EXTRAPOLATION_ERROR;
   }
   if (error_str) {
     std::stringstream ss;
@@ -82,10 +82,10 @@ void createExtrapolationException1(
 }
 
 void createExtrapolationException2(
-  TimePoint t0, TimePoint t1, std::string * error_str, TimeCacheError * error_code)
+  TimePoint t0, TimePoint t1, std::string * error_str, TF2Error * error_code)
 {
   if (error_code) {
-    *error_code = TimeCacheError::TIME_CACHE_FORWARD_EXTRAPOLATION_ERROR;
+    *error_code = TF2Error::TF2_FORWARD_EXTRAPOLATION_ERROR;
   }
   if (error_str) {
     std::stringstream ss;
@@ -96,10 +96,10 @@ void createExtrapolationException2(
 }
 
 void createExtrapolationException3(
-  TimePoint t0, TimePoint t1, std::string * error_str, TimeCacheError * error_code)
+  TimePoint t0, TimePoint t1, std::string * error_str, TF2Error * error_code)
 {
   if (error_code) {
-    *error_code = TimeCacheError::TIME_CACHE_BACKWARD_EXTRAPOLATION_ERROR;
+    *error_code = TF2Error::TF2_BACKWARD_EXTRAPOLATION_ERROR;
   }
   if (error_str) {
     std::stringstream ss;
@@ -112,15 +112,15 @@ void createExtrapolationException3(
 
 uint8_t TimeCache::findClosest(
   TransformStorage * & one, TransformStorage * & two,
-  TimePoint target_time, std::string * error_str, TimeCacheError * error_code)
+  TimePoint target_time, std::string * error_str, TF2Error * error_code)
 {
   if (error_code) {
-    *error_code = TimeCacheError::TIME_CACHE_NO_ERROR;
+    *error_code = TF2Error::TF2_NO_ERROR;
   }
 
   // No values stored
   if (storage_.empty()) {
-    *error_code = TimeCacheError::TIME_CACHE_NOT_ENOUGH_DATA_ERROR;
+    *error_code = TF2Error::TF2_NO_DATA_FOR_EXTRAPOLATION_ERROR;
     return 0;
   }
 
@@ -205,7 +205,7 @@ void TimeCache::interpolate(
 
 bool TimeCache::getData(
   TimePoint time, TransformStorage & data_out,
-  std::string * error_str, TimeCacheError * error_code)
+  std::string * error_str, TF2Error * error_code)
 {
   // returns false if data not available
   TransformStorage * p_temp_1;
@@ -229,7 +229,7 @@ bool TimeCache::getData(
 }
 
 CompactFrameID TimeCache::getParent(
-  TimePoint time, std::string * error_str, TimeCacheError * error_code)
+  TimePoint time, std::string * error_str, TF2Error * error_code)
 {
   TransformStorage * p_temp_1;
   TransformStorage * p_temp_2;

--- a/tf2/src/cache.cpp
+++ b/tf2/src/cache.cpp
@@ -68,7 +68,7 @@ namespace cache
 // hoisting these into separate functions causes an ~8% speedup.
 // Removing calling them altogether adds another ~10%
 void createExtrapolationException1(
-  TimePoint t0, TimePoint t1, TimeCacheError * error_code, std::string * error_str)
+  TimePoint t0, TimePoint t1, std::string * error_str, TimeCacheError * error_code)
 {
   if (error_code) {
     *error_code = TimeCacheError::TIME_CACHE_NOT_ENOUGH_DATA_ERROR;
@@ -82,7 +82,7 @@ void createExtrapolationException1(
 }
 
 void createExtrapolationException2(
-  TimePoint t0, TimePoint t1, TimeCacheError * error_code, std::string * error_str)
+  TimePoint t0, TimePoint t1, std::string * error_str, TimeCacheError * error_code)
 {
   if (error_code) {
     *error_code = TimeCacheError::TIME_CACHE_FORWARD_EXTRAPOLATION_ERROR;
@@ -96,7 +96,7 @@ void createExtrapolationException2(
 }
 
 void createExtrapolationException3(
-  TimePoint t0, TimePoint t1, TimeCacheError * error_code, std::string * error_str)
+  TimePoint t0, TimePoint t1, std::string * error_str, TimeCacheError * error_code)
 {
   if (error_code) {
     *error_code = TimeCacheError::TIME_CACHE_BACKWARD_EXTRAPOLATION_ERROR;
@@ -112,7 +112,7 @@ void createExtrapolationException3(
 
 uint8_t TimeCache::findClosest(
   TransformStorage * & one, TransformStorage * & two,
-  TimePoint target_time, TimeCacheError * error_code, std::string * error_str)
+  TimePoint target_time, std::string * error_str, TimeCacheError * error_code)
 {
   if (error_code) {
     *error_code = TimeCacheError::TIME_CACHE_NO_ERROR;
@@ -137,7 +137,7 @@ uint8_t TimeCache::findClosest(
       one = &ts;
       return 1;
     } else {
-      cache::createExtrapolationException1(target_time, ts.stamp_, error_code, error_str);
+      cache::createExtrapolationException1(target_time, ts.stamp_, error_str, error_code);
       return 0;
     }
   }
@@ -153,11 +153,11 @@ uint8_t TimeCache::findClosest(
     return 1;
   } else {   // Catch cases that would require extrapolation
     if (target_time > latest_time) {
-      cache::createExtrapolationException2(target_time, latest_time, error_code, error_str);
+      cache::createExtrapolationException2(target_time, latest_time, error_str, error_code);
       return 0;
     } else {
       if (target_time < earliest_time) {
-        cache::createExtrapolationException3(target_time, earliest_time, error_code, error_str);
+        cache::createExtrapolationException3(target_time, earliest_time, error_str, error_code);
         return 0;
       }
     }
@@ -205,13 +205,13 @@ void TimeCache::interpolate(
 
 bool TimeCache::getData(
   TimePoint time, TransformStorage & data_out,
-  TimeCacheError * error_code, std::string * error_str)
+  std::string * error_str, TimeCacheError * error_code)
 {
   // returns false if data not available
   TransformStorage * p_temp_1;
   TransformStorage * p_temp_2;
 
-  int num_nodes = findClosest(p_temp_1, p_temp_2, time, error_code, error_str);
+  int num_nodes = findClosest(p_temp_1, p_temp_2, time, error_str, error_code);
   if (num_nodes == 0) {
     return false;
   } else if (num_nodes == 1) {
@@ -229,12 +229,12 @@ bool TimeCache::getData(
 }
 
 CompactFrameID TimeCache::getParent(
-  TimePoint time, TimeCacheError * error_code, std::string * error_str)
+  TimePoint time, std::string * error_str, TimeCacheError * error_code)
 {
   TransformStorage * p_temp_1;
   TransformStorage * p_temp_2;
 
-  int num_nodes = findClosest(p_temp_1, p_temp_2, time, error_code, error_str);
+  int num_nodes = findClosest(p_temp_1, p_temp_2, time, error_str, error_code);
   if (num_nodes == 0) {
     return 0;
   }

--- a/tf2/src/cache.cpp
+++ b/tf2/src/cache.cpp
@@ -67,7 +67,8 @@ namespace cache
 {
 // hoisting these into separate functions causes an ~8% speedup.
 // Removing calling them altogether adds another ~10%
-void createExtrapolationException1(TimePoint t0, TimePoint t1, TimeCacheError * error_code, std::string * error_str)
+void createExtrapolationException1(
+  TimePoint t0, TimePoint t1, TimeCacheError * error_code, std::string * error_str)
 {
   if (error_code) {
     *error_code = TimeCacheError::TIME_CACHE_NOT_ENOUGH_DATA_ERROR;
@@ -80,7 +81,8 @@ void createExtrapolationException1(TimePoint t0, TimePoint t1, TimeCacheError * 
   }
 }
 
-void createExtrapolationException2(TimePoint t0, TimePoint t1, TimeCacheError * error_code, std::string * error_str)
+void createExtrapolationException2(
+  TimePoint t0, TimePoint t1, TimeCacheError * error_code, std::string * error_str)
 {
   if (error_code) {
     *error_code = TimeCacheError::TIME_CACHE_FORWARD_EXTRAPOLATION_ERROR;
@@ -93,7 +95,8 @@ void createExtrapolationException2(TimePoint t0, TimePoint t1, TimeCacheError * 
   }
 }
 
-void createExtrapolationException3(TimePoint t0, TimePoint t1, TimeCacheError * error_code, std::string * error_str)
+void createExtrapolationException3(
+  TimePoint t0, TimePoint t1, TimeCacheError * error_code, std::string * error_str)
 {
   if (error_code) {
     *error_code = TimeCacheError::TIME_CACHE_BACKWARD_EXTRAPOLATION_ERROR;
@@ -225,7 +228,8 @@ bool TimeCache::getData(
   return true;
 }
 
-CompactFrameID TimeCache::getParent(TimePoint time, TimeCacheError * error_code, std::string * error_str)
+CompactFrameID TimeCache::getParent(
+  TimePoint time, TimeCacheError * error_code, std::string * error_str)
 {
   TransformStorage * p_temp_1;
   TransformStorage * p_temp_2;

--- a/tf2/src/static_cache.cpp
+++ b/tf2/src/static_cache.cpp
@@ -38,7 +38,7 @@
 
 bool tf2::StaticCache::getData(
   tf2::TimePoint time,
-  tf2::TransformStorage & data_out, TimeCacheError * error_code, std::string * error_str)
+  tf2::TransformStorage & data_out, std::string * error_str, TimeCacheError * error_code)
 {
   (void)error_code;
   (void)error_str;
@@ -57,7 +57,7 @@ void tf2::StaticCache::clearList() {}
 
 unsigned tf2::StaticCache::getListLength() {return 1;}
 
-tf2::CompactFrameID tf2::StaticCache::getParent(tf2::TimePoint time, TimeCacheError * error_code, std::string * error_str)
+tf2::CompactFrameID tf2::StaticCache::getParent(tf2::TimePoint time, std::string * error_str, TimeCacheError * error_code)
 {
   (void)time;
   (void)error_code;

--- a/tf2/src/static_cache.cpp
+++ b/tf2/src/static_cache.cpp
@@ -38,7 +38,7 @@
 
 bool tf2::StaticCache::getData(
   tf2::TimePoint time,
-  tf2::TransformStorage & data_out, std::string * error_str, TimeCacheError * error_code)
+  tf2::TransformStorage & data_out, std::string * error_str, TF2Error * error_code)
 {
   (void)error_code;
   (void)error_str;
@@ -59,7 +59,7 @@ unsigned tf2::StaticCache::getListLength() {return 1;}
 
 tf2::CompactFrameID tf2::StaticCache::getParent(
   tf2::TimePoint time, std::string * error_str,
-  TimeCacheError * error_code)
+  TF2Error * error_code)
 {
   (void)time;
   (void)error_code;

--- a/tf2/src/static_cache.cpp
+++ b/tf2/src/static_cache.cpp
@@ -38,8 +38,9 @@
 
 bool tf2::StaticCache::getData(
   tf2::TimePoint time,
-  tf2::TransformStorage & data_out, std::string * error_str)
+  tf2::TransformStorage & data_out, TimeCacheError * error_code, std::string * error_str)
 {
+  (void)error_code;
   (void)error_str;
   data_out = storage_;
   data_out.stamp_ = time;
@@ -56,9 +57,10 @@ void tf2::StaticCache::clearList() {}
 
 unsigned tf2::StaticCache::getListLength() {return 1;}
 
-tf2::CompactFrameID tf2::StaticCache::getParent(tf2::TimePoint time, std::string * error_str)
+tf2::CompactFrameID tf2::StaticCache::getParent(tf2::TimePoint time, TimeCacheError * error_code, std::string * error_str)
 {
   (void)time;
+  (void)error_code;
   (void)error_str;
   return storage_.frame_id_;
 }

--- a/tf2/src/static_cache.cpp
+++ b/tf2/src/static_cache.cpp
@@ -57,7 +57,9 @@ void tf2::StaticCache::clearList() {}
 
 unsigned tf2::StaticCache::getListLength() {return 1;}
 
-tf2::CompactFrameID tf2::StaticCache::getParent(tf2::TimePoint time, std::string * error_str, TimeCacheError * error_code)
+tf2::CompactFrameID tf2::StaticCache::getParent(
+  tf2::TimePoint time, std::string * error_str,
+  TimeCacheError * error_code)
 {
   (void)time;
   (void)error_code;

--- a/tf2/test/simple_tf2_core.cpp
+++ b/tf2/test/simple_tf2_core.cpp
@@ -162,6 +162,54 @@ TEST(tf2_lookupTransform, LookupException_One_Exists)
           1))), tf2::LookupException);
 }
 
+TEST(tf2_lookupTransform, TransformException_Backward_Forward)
+{
+  tf2::BufferCore tfc;
+  geometry_msgs::msg::TransformStamped st;
+  st.header.frame_id = "foo";
+  st.header.stamp = builtin_interfaces::msg::Time();
+  st.header.stamp.sec = 2;
+  st.header.stamp.nanosec = 0;
+  st.child_frame_id = "bar";
+  st.transform.rotation.w = 1;
+  EXPECT_TRUE(tfc.setTransform(st, "authority1"));
+  EXPECT_NO_THROW(
+    tfc.lookupTransform(
+      "foo", "bar", tf2::TimePoint(
+        std::chrono::seconds(
+          2))));
+  EXPECT_THROW(
+    tfc.lookupTransform(
+      "foo", "bar", tf2::TimePoint(
+        std::chrono::seconds(
+          4))), tf2::TransformException);
+  EXPECT_THROW(
+    tfc.lookupTransform(
+      "foo", "bar", tf2::TimePoint(
+        std::chrono::seconds(
+          4))), tf2::ExtrapolationException);
+  EXPECT_THROW(
+    tfc.lookupTransform(
+      "foo", "bar", tf2::TimePoint(
+        std::chrono::seconds(
+          4))), tf2::NoDataForExtrapolationException);
+
+  st.header.stamp.sec = 3;
+  EXPECT_TRUE(tfc.setTransform(st, "authority1"));
+
+  EXPECT_THROW(
+    tfc.lookupTransform(
+      "foo", "bar", tf2::TimePoint(
+        std::chrono::seconds(
+          1))), tf2::BackwardExtrapolationException);
+
+  EXPECT_THROW(
+    tfc.lookupTransform(
+      "foo", "bar", tf2::TimePoint(
+        std::chrono::seconds(
+          4))), tf2::ForwardExtrapolationException);
+}
+
 TEST(tf2_canTransform, One_Exists)
 {
   tf2::BufferCore tfc;


### PR DESCRIPTION
(See #567) 
This PR extends the internal API to expose more granular extrapolation error types.
Prior to this PR, detecting a "too in the past" or "too in the future" extrapolation errors was only possible by inspecting the error string.

This patch should not break any existing package. 
Code catching tf2::ExtrapolationError will continue to catch all the sub-types.

This patch does not modifies BufferServer/BufferClient. 
This is because it would require exception definitions in the interface (tf2_msgs).
A patch is ready also for exposing the new exceptions there, so tell me if a following/separate PR is better or if you'd like I push everything here.