### PR TITLE
Enable document generation using rosdoc2 for ament_python pkgs

### DIFF
--- a/examples_tf2_py/examples_tf2_py/blocking_waits_for_transform.py
+++ b/examples_tf2_py/examples_tf2_py/blocking_waits_for_transform.py
@@ -23,12 +23,12 @@ from tf2_ros.transform_listener import TransformListener
 
 class BlockingWaitsForTransform(Node):
     """
-    Wait for a transform syncronously.
+    Wait for a transform synchronously.
 
     This class is an example of waiting for transforms.
     This will block the executor if used within a callback.
     Coroutine callbacks should be used instead to avoid this.
-    See :doc:`examples_tf2_py/async_waits_for_transform.py` for an example.
+    See :py:mod:`examples_tf2_py.async_waits_for_transform` for an example.
     """
 
     def __init__(self):

--- a/examples_tf2_py/package.xml
+++ b/examples_tf2_py/package.xml
@@ -15,7 +15,11 @@
   <author email="sloretz@openrobotics.org">Shane Loretz</author>
   <author email="tfoote@osrfoundation.org">Tully Foote</author>
 
+  <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>launch_ros</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
   <exec_depend>tf2_ros_py</exec_depend>
 
   <test_depend>ament_copyright</test_depend>

--- a/examples_tf2_py/package.xml
+++ b/examples_tf2_py/package.xml
@@ -15,7 +15,9 @@
   <author email="sloretz@openrobotics.org">Shane Loretz</author>
   <author email="tfoote@osrfoundation.org">Tully Foote</author>
 
-  <!-- Required for automatic document generation using sphinx-autodoc -->
+  <!-- Required for automatic documentation generation (using sphinx-autodoc)
+  for modules in this package that import the tf2_ros module from the
+  tf2_ros_py package. -->
   <doc_depend>tf2_ros</doc_depend>
 
   <exec_depend>geometry_msgs</exec_depend>

--- a/examples_tf2_py/package.xml
+++ b/examples_tf2_py/package.xml
@@ -15,11 +15,13 @@
   <author email="sloretz@openrobotics.org">Shane Loretz</author>
   <author email="tfoote@osrfoundation.org">Tully Foote</author>
 
+  <!-- Required for automatic document generation using sphinx-autodoc -->
+  <doc_depend>tf2_ros</doc_depend>
+
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
-  <exec_depend>tf2_ros</exec_depend>
   <exec_depend>tf2_ros_py</exec_depend>
 
   <test_depend>ament_copyright</test_depend>

--- a/tf2_ros_py/doc/Makefile
+++ b/tf2_ros_py/doc/Makefile
@@ -1,0 +1,21 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    =
+SPHINXBUILD   = sphinx-build
+SPHINXPROJ    = tf2_ros_py
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/tf2_ros_py/doc/make.bat
+++ b/tf2_ros_py/doc/make.bat
@@ -1,0 +1,36 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+set SPHINXPROJ=tf2_ros_py
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/tf2_ros_py/doc/source/conf.py
+++ b/tf2_ros_py/doc/source/conf.py
@@ -1,0 +1,182 @@
+
+# Copyright 2023 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -*- coding: utf-8 -*-
+#
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'tf2_ros_py'
+copyright = '2023, Open Source Robotics Foundation, Inc.'
+author = 'Open Source Robotics Foundation, Inc.'
+
+# The full version, including alpha/beta/rc tags
+release = '0.30.0'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.todo',
+    'sphinx.ext.coverage',
+    'sphinx.ext.mathjax',
+    'sphinx.ext.ifconfig',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.githubpages',
+]
+
+# autodoc settings
+# autodoc_default_options = {
+#     'special-members': '__init__',
+#     'class-doc-from': 'class',
+# }
+autodoc_class_signature = 'separated'
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# The suffix(es) of source filenames.
+# You can specify multiple suffix as a list of string:
+#
+# source_suffix = ['.rst', '.md']
+source_suffix = '.rst'
+
+# The master toctree document.
+master_doc = 'index'
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path .
+exclude_patterns = []
+
+# The name of the Pygments (syntax highlighting) style to use.
+pygments_style = 'sphinx'
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Theme options are theme-specific and customize the look and feel of a theme
+# further.  For a list of options available for each theme, see the
+# documentation.
+#
+# html_theme_options = {}
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+# html_static_path = ['_static']
+
+# Custom sidebar templates, must be a dictionary that maps document names
+# to template names.
+#
+# The default sidebars (for documents that don't match any pattern) are
+# defined by theme itself.  Builtin themes are using these templates by
+# default: ``['localtoc.html', 'relations.html', 'sourcelink.html',
+# 'searchbox.html']``.
+#
+# html_sidebars = {}
+
+# -- Options for HTMLHelp output ---------------------------------------------
+
+# Output file base name for HTML help builder.
+htmlhelp_basename = 'tf2_ros_pydoc'
+
+# -- Options for LaTeX output ------------------------------------------------
+
+latex_elements = {
+    # The paper size ('letterpaper' or 'a4paper').
+    #
+    # 'papersize': 'letterpaper',
+
+    # The font size ('10pt', '11pt' or '12pt').
+    #
+    # 'pointsize': '10pt',
+
+    # Additional stuff for the LaTeX preamble.
+    #
+    # 'preamble': '',
+
+    # Latex figure (float) alignment
+    #
+    # 'figure_align': 'htbp',
+}
+
+# Grouping the document tree into LaTeX files. List of tuples
+# (source start file, target name, title,
+#  author, documentclass [howto, manual, or own class]).
+latex_documents = [
+    (master_doc, 'tf2_ros_py.tex', 'tf2_ros_py Documentation',
+     'Open Source Robotics Foundation, Inc.', 'manual'),
+]
+
+# -- Options for manual page output ------------------------------------------
+
+# One entry per manual page. List of tuples
+# (source start file, name, description, authors, manual section).
+man_pages = [
+    (master_doc, 'tf2_ros_py', 'tf2_ros_py Documentation',
+     [author], 1)
+]
+
+# -- Options for Texinfo output ----------------------------------------------
+
+# Grouping the document tree into Texinfo files. List of tuples
+# (source start file, target name, title, author,
+#  dir menu entry, description, category)
+texinfo_documents = [
+    (master_doc, 'tf2_ros_py', 'tf2_ros_py Documentation',
+     author, 'tf2_ros_py', 'One line description of project.',
+     'Miscellaneous'),
+]
+
+
+# -- Extension configuration -------------------------------------------------
+
+# -- Options for intersphinx extension ---------------------------------------
+
+# Example configuration for intersphinx: refer to the Python standard library.
+intersphinx_mapping = {'https://docs.python.org/': None}
+
+# -- Options for todo extension ----------------------------------------------
+
+# If true, `todo` and `todoList` produce output, else they produce nothing.
+todo_include_todos = True

--- a/tf2_ros_py/doc/source/index.rst
+++ b/tf2_ros_py/doc/source/index.rst
@@ -1,0 +1,21 @@
+.. tf2_ros_py documentation master file, created by
+   sphinx-quickstart on Tue Mar 14 13:13:57 2023.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to tf2_ros_py's documentation!
+======================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   modules
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/tf2_ros_py/package.xml
+++ b/tf2_ros_py/package.xml
@@ -28,5 +28,6 @@
 
   <export>
     <build_type>ament_python</build_type>
+    <rosdoc2>rosdoc2.yaml</rosdoc2>
   </export>
 </package>

--- a/tf2_ros_py/package.xml
+++ b/tf2_ros_py/package.xml
@@ -15,6 +15,9 @@
   <author email="tfoote@osrfoundation.org">Tully Foote</author>
   <author>Wim Meeussen</author>
 
+  <!-- Required for automatic document generation using sphinx-autodoc -->
+  <doc_depend>tf2_ros</doc_depend>
+
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rclpy</exec_depend>
@@ -22,7 +25,6 @@
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>tf2_msgs</exec_depend>
   <exec_depend>tf2_py</exec_depend>
-  <exec_depend>tf2_ros</exec_depend>
 
   <test_depend>python3-pytest</test_depend>
   <test_depend>sensor_msgs</test_depend>

--- a/tf2_ros_py/package.xml
+++ b/tf2_ros_py/package.xml
@@ -15,11 +15,6 @@
   <author email="tfoote@osrfoundation.org">Tully Foote</author>
   <author>Wim Meeussen</author>
 
-  <!-- Required for automatic documentation generation (using sphinx-autodoc)
-  for modules in this package that import the tf2_ros module from the
-  tf2_ros_py package. -->
-  <doc_depend>tf2_ros</doc_depend>
-
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rclpy</exec_depend>

--- a/tf2_ros_py/package.xml
+++ b/tf2_ros_py/package.xml
@@ -15,12 +15,14 @@
   <author email="tfoote@osrfoundation.org">Tully Foote</author>
   <author>Wim Meeussen</author>
 
+  <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>tf2_msgs</exec_depend>
   <exec_depend>tf2_py</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
 
   <test_depend>python3-pytest</test_depend>
   <test_depend>sensor_msgs</test_depend>

--- a/tf2_ros_py/package.xml
+++ b/tf2_ros_py/package.xml
@@ -15,7 +15,9 @@
   <author email="tfoote@osrfoundation.org">Tully Foote</author>
   <author>Wim Meeussen</author>
 
-  <!-- Required for automatic document generation using sphinx-autodoc -->
+  <!-- Required for automatic documentation generation (using sphinx-autodoc)
+  for modules in this package that import the tf2_ros module from the
+  tf2_ros_py package. -->
   <doc_depend>tf2_ros</doc_depend>
 
   <exec_depend>builtin_interfaces</exec_depend>

--- a/tf2_ros_py/rosdoc2.yaml
+++ b/tf2_ros_py/rosdoc2.yaml
@@ -1,0 +1,73 @@
+## This 'attic section' self-documents this file's type and version.
+type: 'rosdoc2 config'
+version: 1
+
+---
+
+settings:
+    ## If this is true, a standard index page is generated in the output directory.
+    ## It uses the package information from the 'package.xml' to show details
+    ## about the package, creates a table of contents for the various builders
+    ## that were run, and may contain links to things like build farm jobs for
+    ## this package or links to other versions of this package.
+
+    ## If false, you can still include content that would have been in the index
+    ## into one of your '.rst' files from your Sphinx project, using the
+    ## '.. include::' directive in Sphinx.
+    ## For example, you could include it in a custom 'index.rst' so you can have
+    ## the standard information followed by custom content.
+
+    ## TODO(wjwwood): provide a concrete example of this (relative path?)
+
+    ## If this is not specified explicitly, it defaults to 'true'.
+    generate_package_index: true
+
+    ## This setting is relevant mostly if the standard Python package layout cannot
+    ## be assumed for 'sphinx-apidoc' invocation. The user can provide the path
+    ## (relative to the 'package.xml' file) where the Python modules defined by this
+    ## package are located.
+    python_source: 'tf2_ros'
+
+    ## This setting, if true, attempts to run `doxygen` and the `breathe`/`exhale`
+    ## extensions to `sphinx` regardless of build type. This is most useful if the
+    ## user would like to generate C/C++ API documentation for a package that is not
+    ## of the `ament_cmake/cmake` build type.
+    always_run_doxygen: false
+
+    ## This setting, if true, attempts to run `sphinx-apidoc` regardless of build
+    ## type. This is most useful if the user would like to generate Python API
+    ## documentation for a package that is not of the `ament_python` build type.
+    always_run_sphinx_apidoc: true
+
+    # This setting, if True, will ensure breathe is part of the 'extensions',
+    # and will set all of the breathe configurations, if not set, and override
+    # settings as needed if they are set by this configuration.
+    enable_breathe: false
+
+    # This setting, if True, will ensure exhale is part of the 'extensions',
+    # and will set all of the exhale configurations, if not set, and override
+    # settings as needed if they are set by this configuration.
+    enable_exhale: false
+
+builders:
+    ## Each stanza represents a separate build step, performed by a specific 'builder'.
+    ## The key of each stanza is the builder to use; this must be one of the
+    ## available builders.
+    ## The value of each stanza is a dictionary of settings for the builder that
+    ## outputs to that directory.
+    ## Required keys in the settings dictionary are:
+    ##  * 'output_dir' - determines output subdirectory for builder instance
+    ##                   relative to --output-directory
+    ##  * 'name' - used when referencing the built docs from the index.
+
+    - doxygen: {
+        name: 'tf2_ros Public C/C++ API',
+        output_dir: 'generated/doxygen'
+    }
+    - sphinx: {
+        name: 'tf2_ros',
+        ## This path is relative to output staging.
+        # doxygen_xml_directory: 'generated/doxygen/xml',
+        sphinx_sourcedir: 'doc/source/',
+        output_dir: ''
+    }

--- a/tf2_tools/package.xml
+++ b/tf2_tools/package.xml
@@ -21,6 +21,7 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>tf2_msgs</exec_depend>
   <exec_depend>tf2_py</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
   <exec_depend>tf2_ros_py</exec_depend>
 
   <export>

--- a/tf2_tools/package.xml
+++ b/tf2_tools/package.xml
@@ -16,12 +16,14 @@
   <author email="tfoote@osrfoundation.org">Tully Foote</author>
   <author>Wim Meeussen</author>
 
+  <!-- Required for automatic document generation using sphinx-autodoc -->
+  <doc_depend>tf2_ros</doc_depend>
+
   <exec_depend>graphviz</exec_depend>
   <exec_depend>python3-yaml</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>tf2_msgs</exec_depend>
   <exec_depend>tf2_py</exec_depend>
-  <exec_depend>tf2_ros</exec_depend>
   <exec_depend>tf2_ros_py</exec_depend>
 
   <export>

--- a/tf2_tools/package.xml
+++ b/tf2_tools/package.xml
@@ -16,7 +16,9 @@
   <author email="tfoote@osrfoundation.org">Tully Foote</author>
   <author>Wim Meeussen</author>
 
-  <!-- Required for automatic document generation using sphinx-autodoc -->
+  <!-- Required for automatic documentation generation (using sphinx-autodoc)
+  for modules in this package that import the tf2_ros module from the
+  tf2_ros_py package. -->
   <doc_depend>tf2_ros</doc_depend>
 
   <exec_depend>graphviz</exec_depend>


### PR DESCRIPTION
Fix missing `exec_depends` in `package.xmls` and docstrings to generate documentation without any warnings using `autodoc`