### PR TITLE
Fix a potential crash in TimeCache::findClosest

### DIFF
--- a/tf2/src/cache.cpp
+++ b/tf2/src/cache.cpp
@@ -120,7 +120,9 @@ uint8_t TimeCache::findClosest(
 
   // No values stored
   if (storage_.empty()) {
-    *error_code = TF2Error::TF2_NO_DATA_FOR_EXTRAPOLATION_ERROR;
+    if (error_code) {
+      *error_code = TF2Error::TF2_NO_DATA_FOR_EXTRAPOLATION_ERROR;
+    }
     return 0;
   }
 


### PR DESCRIPTION
That is, make sure to check that the error_code passed in is not NULL before assigning to it.

This was introduced in #586 .  @roncapat FYI.