### PR TITLE
Fix for #589 - Should be able to transform with default timeout

### DIFF
--- a/tf2_ros/src/buffer.cpp
+++ b/tf2_ros/src/buffer.cpp
@@ -141,7 +141,7 @@ Buffer::canTransform(
   const std::string & target_frame, const std::string & source_frame,
   const tf2::TimePoint & time, const tf2::Duration timeout, std::string * errstr) const
 {
-  if (!checkAndErrorDedicatedThreadPresent(errstr)) {
+  if (timeout != tf2::durationFromSec(0.0) && !checkAndErrorDedicatedThreadPresent(errstr)) {
     return false;
   }
 
@@ -171,7 +171,7 @@ Buffer::canTransform(
   const std::string & source_frame, const tf2::TimePoint & source_time,
   const std::string & fixed_frame, const tf2::Duration timeout, std::string * errstr) const
 {
-  if (!checkAndErrorDedicatedThreadPresent(errstr)) {
+  if (timeout != tf2::durationFromSec(0.0) && !checkAndErrorDedicatedThreadPresent(errstr)) {
     return false;
   }
 


### PR DESCRIPTION
As discussed in the issue, this is the fix. I haven't written any tests for this, let me know if I have missed out something.