### PR TITLE
[rosdoc2] Fix document generation on buildfarm

### DIFF
--- a/tf2_ros_py/doc/source/conf.py
+++ b/tf2_ros_py/doc/source/conf.py
@@ -29,7 +29,7 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath('.'))
 
 
 # -- Project information -----------------------------------------------------


### PR DESCRIPTION
This PR is a follow up to https://github.com/ros-infrastructure/rosdoc2/pull/52
It inserts the current working directory to sys.path as this directory will contain the `tf2_ros/` folder with modules inside it. Previously the modules were copied directly to the current working directory.