### PR TITLE
Destroy callback group before node

### DIFF
--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -243,7 +243,6 @@ private:
   rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_interface_ {nullptr};
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface_ {nullptr};
   rclcpp::CallbackGroup::SharedPtr callback_group_{nullptr};
-
 };
 }  // namespace tf2_ros
 

--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -231,7 +231,6 @@ private:
 
   bool spin_thread_{false};
   std::unique_ptr<std::thread> dedicated_listener_thread_ {nullptr};
-  rclcpp::CallbackGroup::SharedPtr callback_group_{nullptr};
   rclcpp::Executor::SharedPtr executor_ {nullptr};
 
   rclcpp::Node::SharedPtr optional_default_node_ {nullptr};
@@ -243,6 +242,8 @@ private:
   tf2::TimePoint last_update_;
   rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_interface_ {nullptr};
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface_ {nullptr};
+  rclcpp::CallbackGroup::SharedPtr callback_group_{nullptr};
+
 };
 }  // namespace tf2_ros
 


### PR DESCRIPTION
The new executor implementation gives an exception if callback groups and nodes are destructed out of order.  

It is incorrect for callback groups to be held alive longer than their owning nodes, but we previous didn't warn about it.