### PR TITLE
Add namespace to tf2_ros tf subscibers/publishers.

### DIFF
--- a/tf2_ros/include/tf2_ros/transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/transform_broadcaster.h
@@ -90,10 +90,11 @@ public:
         rclcpp::QosPolicyKind::History,
         rclcpp::QosPolicyKind::Reliability};
       return options;
-    } ())
+    } (),
+    const std::string& tf_ns = "" )
   {
     publisher_ = rclcpp::create_publisher<tf2_msgs::msg::TFMessage>(
-      node_parameters, node_topics, "/tf", qos, options);
+      node_parameters, node_topics, tf_ns + "/tf", qos, options);
   }
 
   /** \brief Send a TransformStamped message

--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -175,7 +175,8 @@ private:
     const rclcpp::QoS & qos,
     const rclcpp::QoS & static_qos,
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
-    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options)
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options,
+    const std::string& tf_ns = "")
   {
     spin_thread_ = spin_thread;
     node_base_interface_ = node_base;
@@ -198,11 +199,11 @@ private:
       tf_static_options.callback_group = callback_group_;
 
       message_subscription_tf_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
-        node_parameters, node_topics, "/tf", qos, std::move(cb), tf_options);
+        node_parameters, node_topics, tf_ns + "/tf", qos, std::move(cb), tf_options);
       message_subscription_tf_static_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
         node_parameters,
         node_topics,
-        "/tf_static",
+        tf_ns + "/tf_static",
         static_qos,
         std::move(static_cb),
         tf_static_options);
@@ -215,11 +216,11 @@ private:
       buffer_.setUsingDedicatedThread(true);
     } else {
       message_subscription_tf_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
-        node_parameters, node_topics, "/tf", qos, std::move(cb), options);
+        node_parameters, node_topics, tf_ns + "/tf", qos, std::move(cb), options);
       message_subscription_tf_static_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
         node_parameters,
         node_topics,
-        "/tf_static",
+        tf_ns + "/tf_static",
         static_qos,
         std::move(static_cb),
         static_options);

--- a/tf2_ros/src/tf2_monitor.cpp
+++ b/tf2_ros/src/tf2_monitor.cpp
@@ -120,7 +120,7 @@ public:
 
   TFMonitor(
     rclcpp::Node::SharedPtr node, bool using_specific_chain,
-    std::string framea = "", std::string frameb = "")
+    std::string framea = "", std::string frameb = "", std::string tf_ns = "")
   : framea_(framea),
     frameb_(frameb),
     using_specific_chain_(using_specific_chain),
@@ -153,10 +153,10 @@ public:
     }
 
     subscriber_tf_ = node_->create_subscription<tf2_msgs::msg::TFMessage>(
-      "/tf", tf2_ros::DynamicListenerQoS(),
+      tf_ns + "/tf", tf2_ros::DynamicListenerQoS(),
       std::bind(&TFMonitor::callback, this, std::placeholders::_1));
     subscriber_tf_message_ = node_->create_subscription<tf2_msgs::msg::TFMessage>(
-      "/tf_static", tf2_ros::StaticListenerQoS(),
+      tf_ns + "/tf_static", tf2_ros::StaticListenerQoS(),
       std::bind(&TFMonitor::callback, this, std::placeholders::_1));
   }
 

--- a/tf2_ros_py/tf2_ros/static_transform_broadcaster.py
+++ b/tf2_ros_py/tf2_ros/static_transform_broadcaster.py
@@ -46,7 +46,7 @@ class StaticTransformBroadcaster:
     :class:`StaticTransformBroadcaster` is a convenient way to send static transformation on the ``"/tf_static"`` message topic.
     """
 
-    def __init__(self, node: Node, qos: Optional[Union[QoSProfile, int]] = None) -> None:
+    def __init__(self, node: Node, qos: Optional[Union[QoSProfile, int]] = None, tf_ns="") -> None:
         """
         Constructor.
 
@@ -59,7 +59,7 @@ class StaticTransformBroadcaster:
                 durability=DurabilityPolicy.TRANSIENT_LOCAL,
                 history=HistoryPolicy.KEEP_LAST,
                 )
-        self.pub_tf = node.create_publisher(TFMessage, "/tf_static", qos)
+        self.pub_tf = node.create_publisher(TFMessage, tf_ns + "/tf_static", qos)
 
     def sendTransform(self, transform: Union[TransformStamped, List[TransformStamped]]) -> None:
         if not isinstance(transform, list):

--- a/tf2_ros_py/tf2_ros/transform_broadcaster.py
+++ b/tf2_ros_py/tf2_ros/transform_broadcaster.py
@@ -46,7 +46,8 @@ class TransformBroadcaster:
     def __init__(
         self,
         node: Node,
-        qos: Optional[Union[QoSProfile, int]] = None
+        qos: Optional[Union[QoSProfile, int]] = None,
+        ns = ""
     ) -> None:
         """
         .. function:: __init__(node, qos=None)
@@ -58,7 +59,7 @@ class TransformBroadcaster:
         """
         if qos is None:
             qos = QoSProfile(depth=100)
-        self.pub_tf = node.create_publisher(TFMessage, "/tf", qos)
+        self.pub_tf = node.create_publisher(TFMessage, ns + "/tf", qos)
 
     def sendTransform(
         self,


### PR DESCRIPTION
This PR is just a draft, but I want to see if you could add an argument to personalize the topic on which tf are listened/broadcasted.

I think that many applications can benefit of this. For example, a multi-robot simulator can publish the tf of the different robot under different namespaces for different robots. 

Here in the PR, I suggest giving the option to specify a namespace instead of the full topic name so we still enforce that all the tf tree are published on **/tf , **/tf_static topics. 