### PR TITLE
Enable StaticTransformBroadcaster in Intra-process enabled components

### DIFF
--- a/tf2_ros/include/tf2_ros/static_transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/static_transform_broadcaster.h
@@ -66,6 +66,14 @@ public:
         rclcpp::QosPolicyKind::Depth,
         rclcpp::QosPolicyKind::History,
         rclcpp::QosPolicyKind::Reliability};
+      /*
+        This flag disables intra-process communication while subscribing to
+        /tf topic, when the TransformListener is constructed using an existing
+        node handle which happens to be a component (in rclcpp terminology).
+        Required until rclcpp intra-process communication supports
+        transient_local QoS durability.
+      */
+      options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
       return options;
     } ())
     : StaticTransformBroadcaster(
@@ -87,6 +95,14 @@ public:
         rclcpp::QosPolicyKind::Depth,
         rclcpp::QosPolicyKind::History,
         rclcpp::QosPolicyKind::Reliability};
+      /*
+        This flag disables intra-process communication while subscribing to
+        /tf topic, when the TransformListener is constructed using an existing
+        node handle which happens to be a component (in rclcpp terminology).
+        Required until rclcpp intra-process communication supports
+        transient_local QoS durability.
+      */
+      options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
       return options;
     } ())
   {

--- a/tf2_ros/include/tf2_ros/static_transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/static_transform_broadcaster.h
@@ -68,7 +68,7 @@ public:
         rclcpp::QosPolicyKind::Reliability};
       /*
         This flag disables intra-process communication while subscribing to
-        /tf topic, when the TransformListener is constructed using an existing
+        /tf_static topic, when the TransformListener is constructed using an existing
         node handle which happens to be a component (in rclcpp terminology).
         Required until rclcpp intra-process communication supports
         transient_local QoS durability.
@@ -97,7 +97,7 @@ public:
         rclcpp::QosPolicyKind::Reliability};
       /*
         This flag disables intra-process communication while subscribing to
-        /tf topic, when the TransformListener is constructed using an existing
+        /tf_static topic, when the TransformListener is constructed using an existing
         node handle which happens to be a component (in rclcpp terminology).
         Required until rclcpp intra-process communication supports
         transient_local QoS durability.

--- a/tf2_ros/include/tf2_ros/static_transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/static_transform_broadcaster.h
@@ -67,9 +67,10 @@ public:
         rclcpp::QosPolicyKind::History,
         rclcpp::QosPolicyKind::Reliability};
       /*
-        This flag disables intra-process communication while subscribing to
-        /tf_static topic, when the TransformListener is constructed using an existing
-        node handle which happens to be a component (in rclcpp terminology).
+        This flag disables intra-process communication while publishing to
+        /tf_static topic, when the StaticTransformBroadcaster is constructed
+        using an existing node handle which happens to be a component
+        (in rclcpp terminology).
         Required until rclcpp intra-process communication supports
         transient_local QoS durability.
       */
@@ -96,9 +97,10 @@ public:
         rclcpp::QosPolicyKind::History,
         rclcpp::QosPolicyKind::Reliability};
       /*
-        This flag disables intra-process communication while subscribing to
-        /tf_static topic, when the TransformListener is constructed using an existing
-        node handle which happens to be a component (in rclcpp terminology).
+        This flag disables intra-process communication while publishing to
+        /tf_static topic, when the StaticTransformBroadcaster is constructed
+        using an existing node handle which happens to be a component
+        (in rclcpp terminology).
         Required until rclcpp intra-process communication supports
         transient_local QoS durability.
       */

--- a/tf2_ros/test/test_static_transform_broadcaster.cpp
+++ b/tf2_ros/test/test_static_transform_broadcaster.cpp
@@ -50,6 +50,22 @@ private:
   std::shared_ptr<tf2_ros::StaticTransformBroadcaster> tf_broadcaster_;
 };
 
+class CustomComposableNode : public rclcpp::Node
+{
+public:
+  explicit CustomComposableNode(const rclcpp::NodeOptions & options)
+  : rclcpp::Node("tf2_ros_test_static_transform_broadcaster_composable_node", options)
+  {}
+
+  void init_tf_broadcaster()
+  {
+    tf_broadcaster_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(shared_from_this());
+  }
+
+private:
+  std::shared_ptr<tf2_ros::StaticTransformBroadcaster> tf_broadcaster_;
+};
+
 TEST(tf2_test_static_transform_broadcaster, transform_broadcaster_rclcpp_node)
 {
   auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
@@ -68,6 +84,15 @@ TEST(tf2_test_static_transform_broadcaster, transform_broadcaster_rclcpp_node)
       node->get_node_parameters_interface(),
       node->get_node_topics_interface());
   }
+}
+
+TEST(tf2_test_static_transform_broadcaster, transform_broadcaster_with_intraprocess)
+{
+  rclcpp::executors::SingleThreadedExecutor exec;
+  rclcpp::NodeOptions options;
+  options = options.use_intra_process_comms(true);
+  auto custom_node = std::make_shared<CustomComposableNode>(options);
+  custom_node->init_tf_broadcaster();
 }
 
 TEST(tf2_test_static_transform_broadcaster, transform_broadcaster_custom_rclcpp_node)


### PR DESCRIPTION
Follow up of [this](https://github.com/ros2/geometry2/pull/572#issuecomment-1361192871) comment made by @FranzAlbers (and PR #572 in general).

FYI  @nachovizzo(https://github.com/PRBonn/kiss-icp/pull/171) and @fixit-davide. 
