### PR TITLE
Add time jump callback

### DIFF
--- a/tf2_ros_py/tf2_ros/buffer.py
+++ b/tf2_ros_py/tf2_ros/buffer.py
@@ -85,10 +85,11 @@ class Buffer(tf2.BufferCore, tf2_ros.BufferInterface):
         self._callbacks_to_remove: List[Callable[[], None]] = []
         self._callbacks_lock = threading.RLock()
 
-        self.clock = rclpy.clock.Clock()
         if node is not None:
             self.srv = node.create_service(FrameGraph, 'tf2_frames', self.__get_frames)
             self.clock = node.get_clock()
+        else:
+            self.clock = rclpy.clock.Clock()
 
         # create a jump callback so as to clear the buffer if use_sim_true is true and there is a jump in time
         threshold = JumpThreshold(min_forward=None,


### PR DESCRIPTION
When use_sim_time is set the python tf2 buffer should be cleared. However, this wasn't happening. To handle this a time jump callback was added to clear the buffer when a time jump is detected.