### PR TITLE
Fix clang build warnings.

### DIFF
--- a/tf2_eigen/test/tf2_eigen-test.cpp
+++ b/tf2_eigen/test/tf2_eigen-test.cpp
@@ -43,12 +43,12 @@
 // https://salsa.debian.org/science-team/eigen3/-/merge_requests/1 .
 // However, it is not clear that that fix is going to make it into Ubuntu 22.04 before it
 // freezes, so disable the warning here.
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wclass-memaccess"
 #endif
 #include <Eigen/Geometry>  // NOLINT
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/tf2_eigen_kdl/include/tf2_eigen_kdl/tf2_eigen_kdl.hpp
+++ b/tf2_eigen_kdl/include/tf2_eigen_kdl/tf2_eigen_kdl.hpp
@@ -43,13 +43,13 @@
 // https://salsa.debian.org/science-team/eigen3/-/merge_requests/1 .
 // However, it is not clear that that fix is going to make it into Ubuntu 22.04 before it
 // freezes, so disable the warning here.
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wclass-memaccess"
 #endif
 #include <Eigen/Core>
 #include <Eigen/Geometry>
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/tf2_sensor_msgs/include/tf2_sensor_msgs/tf2_sensor_msgs.hpp
+++ b/tf2_sensor_msgs/include/tf2_sensor_msgs/tf2_sensor_msgs.hpp
@@ -37,13 +37,13 @@
 // https://salsa.debian.org/science-team/eigen3/-/merge_requests/1 .
 // However, it is not clear that that fix is going to make it into Ubuntu 22.04 before it
 // freezes, so disable the warning here.
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wclass-memaccess"
 #endif
 #include <Eigen/Eigen>  // NOLINT
 #include <Eigen/Geometry>  // NOLINT
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 


### PR DESCRIPTION
For Ubuntu 22.04, we disabled some warnings with GCC specifically for arm64.  However, those flags are not supported on clang, and further clang defines __GNU__ when compiling.  Add in an additional check for being on clang so we avoid a clang warning.

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=19529)](http://ci.ros2.org/job/ci_linux/19529/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=14048)](http://ci.ros2.org/job/ci_linux-aarch64/14048/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=20249)](http://ci.ros2.org/job/ci_windows/20249/)