### PR TITLE
Avoid unecessary time conversions

### DIFF
--- a/tf2_ros/include/tf2_ros/message_filter.h
+++ b/tf2_ros/include/tf2_ros/message_filter.h
@@ -456,7 +456,7 @@ public:
    */
   void add(const MConstPtr & message)
   {
-    builtin_interfaces::msg::Time t = node_clock_->get_clock()->now();
+    auto t = node_clock_->get_clock()->now();
     add(MEvent(message, t));
   }
 

--- a/tf2_ros/test/listener_unittest.cpp
+++ b/tf2_ros/test/listener_unittest.cpp
@@ -72,7 +72,7 @@ TEST(tf2_ros_test_listener, transform_listener)
 
   geometry_msgs::msg::TransformStamped out_rootc = buffer.lookupTransform(
     "a", "b",
-    builtin_interfaces::msg::Time());
+    rclcpp::Time());
 
   EXPECT_EQ(1, out_rootc.transform.translation.x);
   EXPECT_EQ(2, out_rootc.transform.translation.y);


### PR DESCRIPTION
To conform with potential changes introduced in https://github.com/ros2/rclcpp/pull/2293

Mostly avoid unnecessary conversions between rclcpp::Time and builtin_interfaces::msg::Time that require implicit conversion/constructors.