### PR TITLE
Fix constantly increasing memory in std::list

### DIFF
--- a/tf2/CMakeLists.txt
+++ b/tf2/CMakeLists.txt
@@ -105,6 +105,11 @@ if(BUILD_TESTING)
   if(TARGET test_time)
     target_link_libraries(test_time tf2)
   endif()
+
+  ament_add_gtest(test_storage test/test_storage.cpp)
+  if(TARGET test_storage)
+    target_link_libraries(test_storage tf2)
+  endif()
 endif()
 
 ament_export_dependencies(console_bridge geometry_msgs rcutils rosidl_runtime_cpp)

--- a/tf2/include/tf2/transform_storage.h
+++ b/tf2/include/tf2/transform_storage.h
@@ -67,6 +67,22 @@ public:
     return *this;
   }
 
+  TF2_PUBLIC
+  bool operator==(const TransformStorage & rhs) const
+  {
+    return (this->rotation_ == rhs.rotation_) &&
+           (this->translation_ == rhs.translation_) &&
+           (this->stamp_ == rhs.stamp_) &&
+           (this->frame_id_ == rhs.frame_id_) &&
+           (this->child_frame_id_ == rhs.child_frame_id_);
+  }
+
+  TF2_PUBLIC
+  bool operator!=(const TransformStorage & rhs) const
+  {
+    return !(*this == rhs);
+  }
+
   tf2::Quaternion rotation_;
   tf2::Vector3 translation_;
   TimePoint stamp_;

--- a/tf2/src/cache.cpp
+++ b/tf2/src/cache.cpp
@@ -260,7 +260,10 @@ bool TimeCache::insertData(const TransformStorage & new_data)
     }
     storage_it++;
   }
-  storage_.insert(storage_it, new_data);
+  // Insert elements only if the stamp is already not present
+  if (storage_it->stamp_ != new_data.stamp_) {
+    storage_.insert(storage_it, new_data);
+  }
 
   pruneList();
   return true;

--- a/tf2/src/cache.cpp
+++ b/tf2/src/cache.cpp
@@ -28,6 +28,7 @@
 
 /** \author Tully Foote */
 
+#include <algorithm>
 #include <cassert>
 #include <sstream>
 #include <string>
@@ -260,8 +261,8 @@ bool TimeCache::insertData(const TransformStorage & new_data)
     }
     storage_it++;
   }
-  // Insert elements only if the stamp is already not present
-  if (storage_it->stamp_ != new_data.stamp_) {
+  // Insert elements only if not already already present
+  if (std::find(storage_.begin(), storage_.end(), new_data) == storage_.end()) {
     storage_.insert(storage_it, new_data);
   }
 

--- a/tf2/src/cache.cpp
+++ b/tf2/src/cache.cpp
@@ -261,7 +261,7 @@ bool TimeCache::insertData(const TransformStorage & new_data)
     }
     storage_it++;
   }
-  // Insert elements only if not already already present
+  // Insert elements only if not already present
   if (std::find(storage_.begin(), storage_.end(), new_data) == storage_.end()) {
     storage_.insert(storage_it, new_data);
   }

--- a/tf2/test/cache_unittest.cpp
+++ b/tf2/test/cache_unittest.cpp
@@ -114,7 +114,7 @@ TEST(TimeCache, RepeatabilityReverseInsertOrder)
 
 TEST(TimeCache, RepeatedElements)
 {
-  unsigned int runs = 100;
+  constexpr uint64_t runs = 100;
 
   tf2::TimeCache cache;
   EXPECT_EQ(cache.getListLength(), 0);

--- a/tf2/test/cache_unittest.cpp
+++ b/tf2/test/cache_unittest.cpp
@@ -125,7 +125,7 @@ TEST(TimeCache, RepeatedElements)
   stor.stamp_ = tf2::TimePoint(std::chrono::nanoseconds(0));
 
   // Attempt to insert the same element 100 times
-  for (uint64_t i = 1; i < runs; i++) {
+  for (uint64_t i = 1; i < runs; ++i) {
     cache.insertData(stor);
   }
 

--- a/tf2/test/cache_unittest.cpp
+++ b/tf2/test/cache_unittest.cpp
@@ -112,6 +112,27 @@ TEST(TimeCache, RepeatabilityReverseInsertOrder)
   }
 }
 
+TEST(TimeCache, RepeatedElements)
+{
+  unsigned int runs = 100;
+
+  tf2::TimeCache cache;
+  EXPECT_EQ(cache.getListLength(), 0);
+
+  tf2::TransformStorage stor;
+  setIdentity(stor);
+  stor.frame_id_ = tf2::CompactFrameID(0);
+  stor.stamp_ = tf2::TimePoint(std::chrono::nanoseconds(0));
+
+  // Attempt to inster 100 times the exact same element
+  for (uint64_t i = 1; i < runs; i++) {
+    cache.insertData(stor);
+  }
+
+  // Even after 100 insertions, there should be one unique element in the internal list
+  EXPECT_EQ(cache.getListLength(), 1);
+}
+
 TEST(TimeCache, ZeroAtFront)
 {
   uint64_t runs = 100;

--- a/tf2/test/cache_unittest.cpp
+++ b/tf2/test/cache_unittest.cpp
@@ -124,7 +124,7 @@ TEST(TimeCache, RepeatedElements)
   stor.frame_id_ = tf2::CompactFrameID(0);
   stor.stamp_ = tf2::TimePoint(std::chrono::nanoseconds(0));
 
-  // Attempt to inster 100 times the exact same element
+  // Attempt to insert the same element 100 times
   for (uint64_t i = 1; i < runs; i++) {
     cache.insertData(stor);
   }

--- a/tf2/test/test_storage.cpp
+++ b/tf2/test/test_storage.cpp
@@ -1,0 +1,104 @@
+// Copyright (c) 2024 Dexory
+
+#include <gtest/gtest.h>
+
+#include "tf2/LinearMath/Quaternion.h"
+#include "tf2/LinearMath/Vector3.h"
+#include "tf2/time.h"
+#include "tf2/transform_storage.h"
+
+class TransformStorageTest : public ::testing::Test
+{
+protected:
+  tf2::TransformStorage createTransformStorage()
+  {
+    const tf2::CompactFrameID frame_id(0);
+    const tf2::CompactFrameID child_frame_id(1);
+    const tf2::TimePoint stamp(tf2::TimePointZero);
+    const tf2::Quaternion rotation(0.0, 0.0, 0.0, 1.0);
+    const tf2::Vector3 translation(0.0, 0.0, 0.0);
+    return tf2::TransformStorage(stamp, rotation, translation, frame_id, child_frame_id);
+  }
+};
+
+TEST_F(TransformStorageTest, EqualityOperator) {
+  // Create a dummy storage, set to identity
+  tf2::TransformStorage transformStorage1 = createTransformStorage();
+
+  // tf2::Quaternion rotation_;
+  {
+    tf2::TransformStorage transformStorage2 = createTransformStorage();
+    ASSERT_TRUE(transformStorage1 == transformStorage2);
+    transformStorage2.rotation_.setValue(1.0, 0.0, 0.0, 0.0);
+    ASSERT_FALSE(transformStorage1 == transformStorage2);
+  }
+  // tf2::Vector3 translation_;
+  {
+    tf2::TransformStorage transformStorage2 = createTransformStorage();
+    ASSERT_TRUE(transformStorage1 == transformStorage2);
+    transformStorage2.translation_.setValue(1.0, 0.0, 0.0);
+    ASSERT_FALSE(transformStorage1 == transformStorage2);
+  }
+  // TimePoint stamp_;
+  {
+    tf2::TransformStorage transformStorage2 = createTransformStorage();
+    ASSERT_TRUE(transformStorage1 == transformStorage2);
+    transformStorage2.stamp_ = tf2::TimePoint(tf2::durationFromSec(1.0));
+    ASSERT_FALSE(transformStorage1 == transformStorage2);
+  }
+  // CompactFrameID frame_id_;
+  {
+    tf2::TransformStorage transformStorage2 = createTransformStorage();
+    ASSERT_TRUE(transformStorage1 == transformStorage2);
+    transformStorage2.frame_id_ = 55;
+    ASSERT_FALSE(transformStorage1 == transformStorage2);
+  }
+  // CompactFrameID child_frame_id_;
+  {
+    tf2::TransformStorage transformStorage2 = createTransformStorage();
+    ASSERT_TRUE(transformStorage1 == transformStorage2);
+    transformStorage2.translation_.setValue(1.0, 0.0, 0.0);
+    ASSERT_FALSE(transformStorage1 == transformStorage2);
+  }
+}
+
+TEST_F(TransformStorageTest, InequalityOperator) {
+  // Create a dummy storage, set to identity
+  tf2::TransformStorage transformStorage1 = createTransformStorage();
+
+  // tf2::Quaternion rotation_;
+  {
+    tf2::TransformStorage transformStorage2 = createTransformStorage();
+    ASSERT_TRUE(transformStorage1 == transformStorage2);
+    transformStorage2.rotation_.setValue(1.0, 0.0, 0.0, 0.0);
+    ASSERT_TRUE(transformStorage1 != transformStorage2);
+  }
+  // tf2::Vector3 translation_;
+  {
+    tf2::TransformStorage transformStorage2 = createTransformStorage();
+    ASSERT_TRUE(transformStorage1 == transformStorage2);
+    transformStorage2.translation_.setValue(1.0, 0.0, 0.0);
+    ASSERT_TRUE(transformStorage1 != transformStorage2);
+  }
+  // TimePoint stamp_;
+  {
+    tf2::TransformStorage transformStorage2 = createTransformStorage();
+    ASSERT_TRUE(transformStorage1 == transformStorage2);
+    transformStorage2.stamp_ = tf2::TimePoint(tf2::durationFromSec(1.0));
+    ASSERT_TRUE(transformStorage1 != transformStorage2);
+  }
+  // CompactFrameID frame_id_;
+  {
+    tf2::TransformStorage transformStorage2 = createTransformStorage();
+    ASSERT_TRUE(transformStorage1 == transformStorage2);
+    transformStorage2.frame_id_ = 55;
+    ASSERT_TRUE(transformStorage1 != transformStorage2);
+  }
+  // CompactFrameID child_frame_id_;
+  {
+    tf2::TransformStorage transformStorage2 = createTransformStorage();
+    ASSERT_TRUE(transformStorage1 == transformStorage2);
+    transformStorage2.translation_.setValue(1.0, 0.0, 0.0);
+    ASSERT_TRUE(transformStorage1 != transformStorage2);
+  }
+}

--- a/tf2/test/test_storage.cpp
+++ b/tf2/test/test_storage.cpp
@@ -1,4 +1,30 @@
-// Copyright (c) 2024 Dexory
+// Copyright (c) 2024 Dexory. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Willow Garage nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
## Description

This PR solve this issue **for us** : https://github.com/ros2/geometry2/pull/630

When someone is constantly publishing with the same tf2 timestamp (application error, I know), the storage_ of the tf2::TimeCache grows unbounded causing system-wide memory leaks. In a ROS system, each tf2 Listener will spawn one of these TimeCache objects and thus, all ROS nodes that have any sort of tf2 listener will slowly start allocating more and more memory

## How to test it

I would like to add a unit test for this, but I'd add this to my ToDo list since now I have no more time to solve that.

I've created a small repo where the code used for doing an isolation test of this problem can be found: https://github.com/nachovizzo/cyclone_dds_leak (ignore the name)

In that repo, there are 2 nodes, the offender one that publishes non-stop a tf over the wire, which never change its timestamp.  The Second node is not doing anything. It's just creating a tf2 listener, but because of the offender, the `storage_` member of the `TimeCache` gets populated without any sort of bounds, and thus, start allocating more and more memory on that list. This is just 1 node, without doing anything particular, you can imagine the massive amount of memory leaks that we were experiencing in our system with dozens of nodes that have a `tf2_ros::TransformListener` 

### Offender node:
```cpp
class LeakyNode : public rclcpp::Node {
public:
    explicit LeakyNode(const std::string &name) : Node(name) {
        // Capture the moment where the node is created
        fixed_timestamp = this->get_clock()->now();
        // Create a tf broadcaster to send over the wire dummy transformations
        tf_broadcaster_ = std::make_unique<tf2_ros::TransformBroadcaster>(*this);
        // Control the publishing with a timer, do it fast to observe the "leak" right away
        timer_ = create_wall_timer(std::chrono::duration<double>(1.0 / publish_rate_),
                                   std::bind(&LeakyNode::timerCallback, this));
    }

    void timerCallback() {
        geometry_msgs::msg::TransformStamped dummy_pose;
        dummy_pose.header.stamp = fixed_timestamp;  // does not change (application error)
        dummy_pose.child_frame_id = "jose";
        dummy_pose.header.frame_id = "pepe";
        tf_broadcaster_->sendTransform(dummy_pose);
    }

    std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
    rclcpp::TimerBase::SharedPtr timer_;
    double publish_rate_ = 1000.0;
    rclcpp::Time fixed_timestamp;
};
```

### Consumer node, the poor guy who shows the memory leak symptoms:

```cpp
class LeakyNode : public rclcpp::Node {
public:
    explicit LeakyNode(const std::string &name) : Node(name) {
        tf_buffer = std::make_unique<tf2_ros::Buffer>(this->get_clock());
        tf_listener = std::make_unique<tf2_ros::TransformListener>(*tf_buffer);
    }
    std::unique_ptr<tf2_ros::TransformListener> tf_listener;
    std::unique_ptr<tf2_ros::Buffer> tf_buffer;
};
```

Just running those 2 nodes it's sufficient for these tests

### Heaptrack memory analysts (massif can also be used)

Originally this is how we detected the problem after many hours of debugging, by running the nodes that had a tf2 listener through valgrind/massif/heaptrack.

I let the leaky nodes run for 7 minutes without touching my system and these are the results:

#### Heaptrack analysts after 7 minutes from `rolling`
In this case, the tf2_node already consumed 45MiB, which is all duplicates of the `dummy` transform spit at the offender node:

![image](https://github.com/ros2/geometry2/assets/21349875/aa7d3923-90b7-4c50-8974-bd255d297a14)
![image](https://github.com/ros2/geometry2/assets/21349875/6abe1bc0-8152-4181-8950-8af6f0195f4e)

#### Heaptrack analysts after 7 minutes from `rolling` + this PR
By avoiding inserting repeated elements into the list, then the results are as expected
![image](https://github.com/ros2/geometry2/assets/21349875/be2d9e3c-da14-43f7-8ce8-822e3a6c8f55)
![image](https://github.com/ros2/geometry2/assets/21349875/63e7001c-bd5a-4b6c-b430-f7e561181bfe)


## Open questions

- [ ] I'd like to carry on a bit of improvement (I already did on a private branch) on this module, improving some of the readability of the implementation without sacrificing performance. Are you guys interested in me doing this? Branch: https://github.com/nachovizzo/geometry2/tree/nacho/improve_tf2_cache
- [ ] I also found that there is this constant lying on the header but not consumed anywhere, I'd love to also open a PR to avoid the linked list growing (beyond this PR)
https://github.com/ros2/geometry2/blob/e07648f5952a353f646a5a4d8e2261ba98200b64/tf2/include/tf2/time_cache.h#L113
- [ ] I also tried using [std::list::<T>::unique](https://en.cppreference.com/w/cpp/container/list/unique) at the end of the `pruneList()` method, and this indeed also solved our leak problems, but it would degrade a *bit* the performance. Are you guys interested also in adding that just as a sanity check?

## Possible related issues

- https://github.com/ros2/geometry2/pull/630
- https://github.com/ros2/rmw_cyclonedds/issues/471
- https://github.com/ksuszka/cyclonedds_iceoryx_memory_leak