### PR TITLE
Added overriding namespaces in tf2_ros_py

### DIFF
--- a/tf2_ros_py/test/test_namespaced_listener_and_broadcaster.py
+++ b/tf2_ros_py/test/test_namespaced_listener_and_broadcaster.py
@@ -1,0 +1,168 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the Willow Garage nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import pytest
+import rclpy
+
+from geometry_msgs.msg import TransformStamped
+from tf2_ros.buffer import Buffer
+from tf2_ros.transform_broadcaster import TransformBroadcaster
+from tf2_ros.static_transform_broadcaster import StaticTransformBroadcaster
+from tf2_ros.transform_listener import TransformListener
+from tf2_ros import ExtrapolationException
+
+
+def build_transform(target_frame, source_frame, stamp):
+    transform = TransformStamped()
+    transform.header.frame_id = target_frame
+    transform.header.stamp = stamp
+    transform.child_frame_id = source_frame
+
+    transform.transform.translation.x = 42.0
+    transform.transform.translation.y = -3.14
+    transform.transform.translation.z = 0.0
+    transform.transform.rotation.w = 1.0
+    transform.transform.rotation.x = 0.0
+    transform.transform.rotation.y = 0.0
+    transform.transform.rotation.z = 0.0
+
+    return transform
+
+
+class TestBroadcasterAndListener:
+    @classmethod
+    def setup_class(cls):
+        rclpy.init()
+
+        cls.buffer = Buffer()
+        cls.node = rclpy.create_node('test_broadcaster_listener', namespace="/tf_namespace")
+        cls.broadcaster = TransformBroadcaster(cls.node, override_tf_topics_namespaces=True)
+        cls.static_broadcaster = StaticTransformBroadcaster(cls.node, override_tf_topics_namespaces=True)
+        cls.listener = TransformListener(
+            buffer=cls.buffer, node=cls.node, spin_thread=False, override_tf_topics_namespaces=True)
+
+        cls.executor = rclpy.executors.SingleThreadedExecutor()
+        cls.executor.add_node(cls.node)
+
+    @classmethod
+    def teardown_class(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown()
+
+    def setup_method(self, method):
+        self.buffer = Buffer()
+        self.listener.buffer = self.buffer
+
+    def broadcast_transform(self, target_frame, source_frame, time_stamp):
+        broadcast_transform = build_transform(
+            target_frame=target_frame, source_frame=source_frame, stamp=time_stamp)
+
+        self.broadcaster.sendTransform(broadcast_transform)
+
+        self.executor.spin_once()
+
+        return broadcast_transform
+
+    def broadcast_static_transform(self, target_frame, source_frame, time_stamp):
+        broadcast_transform = build_transform(
+            target_frame=target_frame, source_frame=source_frame, stamp=time_stamp)
+
+        self.static_broadcaster.sendTransform(broadcast_transform)
+
+        self.executor.spin_once()
+
+        return broadcast_transform
+
+    def test_broadcaster_and_listener(self):
+        time_stamp = rclpy.time.Time(seconds=1, nanoseconds=0).to_msg()
+
+        broadcasted_transform = self.broadcast_transform(
+            target_frame='foo', source_frame='bar', time_stamp=time_stamp)
+
+        listened_transform = self.buffer.lookup_transform(
+            target_frame='foo', source_frame='bar', time=time_stamp)
+
+        assert broadcasted_transform == listened_transform
+
+        # Execute a coroutine
+        listened_transform_async = None
+        coro = self.buffer.lookup_transform_async(
+            target_frame='foo', source_frame='bar', time=time_stamp)
+        try:
+            coro.send(None)
+        except StopIteration as e:
+            # The coroutine finished; store the result
+            coro.close()
+            listened_transform_async = e.value
+
+        assert broadcasted_transform == listened_transform_async
+
+    def test_extrapolation_exception(self):
+        self.broadcast_transform(
+            target_frame='foo', source_frame='bar',
+            time_stamp=rclpy.time.Time(seconds=0.3, nanoseconds=0).to_msg())
+
+        self.broadcast_transform(
+            target_frame='foo', source_frame='bar',
+            time_stamp=rclpy.time.Time(seconds=0.2, nanoseconds=0).to_msg())
+
+        with pytest.raises(ExtrapolationException) as excinfo:
+            self.buffer.lookup_transform(
+                target_frame='foo', source_frame='bar',
+                time=rclpy.time.Time(seconds=0.1, nanoseconds=0).to_msg())
+
+        assert 'Lookup would require extrapolation into the past' in str(excinfo.value)
+
+        with pytest.raises(ExtrapolationException) as excinfo:
+            self.buffer.lookup_transform(
+                target_frame='foo', source_frame='bar',
+                time=rclpy.time.Time(seconds=0.4, nanoseconds=0).to_msg())
+
+        assert 'Lookup would require extrapolation into the future' in str(excinfo.value)
+
+    def test_static_broadcaster_and_listener(self):
+        broadcasted_transform = self.broadcast_static_transform(
+            target_frame='foo', source_frame='bar',
+            time_stamp=rclpy.time.Time(seconds=1.1, nanoseconds=0).to_msg())
+
+        listened_transform = self.buffer.lookup_transform(
+            target_frame='foo', source_frame='bar',
+            time=rclpy.time.Time(seconds=1.5, nanoseconds=0).to_msg())
+
+        assert broadcasted_transform.header.stamp.sec == 1
+        assert broadcasted_transform.header.stamp.nanosec == 100000000
+
+        assert listened_transform.header.stamp.sec == 1
+        assert listened_transform.header.stamp.nanosec == 500000000
+
+        assert broadcasted_transform.header.frame_id == listened_transform.header.frame_id
+        assert broadcasted_transform.child_frame_id == listened_transform.child_frame_id
+        assert broadcasted_transform.transform.translation == listened_transform.transform.translation
+        assert broadcasted_transform.transform.rotation == listened_transform.transform.rotation

--- a/tf2_ros_py/tf2_ros/static_transform_broadcaster.py
+++ b/tf2_ros_py/tf2_ros/static_transform_broadcaster.py
@@ -46,20 +46,32 @@ class StaticTransformBroadcaster:
     :class:`StaticTransformBroadcaster` is a convenient way to send static transformation on the ``"/tf_static"`` message topic.
     """
 
-    def __init__(self, node: Node, qos: Optional[Union[QoSProfile, int]] = None) -> None:
+    def __init__(
+        self,
+        node: Node,
+        qos: Optional[Union[QoSProfile, int]] = None,
+        override_tf_topics_namespaces: bool = False,
+    ) -> None:
         """
         Constructor.
 
         :param node: The ROS2 node.
         :param qos: A QoSProfile or a history depth to apply to the publisher.
+        :param override_tf_topics_namespaces: It true it remaps /tf to tf and /tf_static to tf_static. It allows to use namespaces.
         """
+
+        tf_static_topic = '/tf_static'
+
+        if override_tf_topics_namespaces:
+            tf_static_topic = 'tf_static'
+
         if qos is None:
             qos = QoSProfile(
                 depth=1,
                 durability=DurabilityPolicy.TRANSIENT_LOCAL,
                 history=HistoryPolicy.KEEP_LAST,
                 )
-        self.pub_tf = node.create_publisher(TFMessage, "/tf_static", qos)
+        self.pub_tf = node.create_publisher(TFMessage, tf_static_topic, qos)
 
         self.net_message = TFMessage()
         self._child_frame_ids = set()

--- a/tf2_ros_py/tf2_ros/transform_broadcaster.py
+++ b/tf2_ros_py/tf2_ros/transform_broadcaster.py
@@ -46,7 +46,8 @@ class TransformBroadcaster:
     def __init__(
         self,
         node: Node,
-        qos: Optional[Union[QoSProfile, int]] = None
+        qos: Optional[Union[QoSProfile, int]] = None,
+        override_tf_topics_namespaces: bool = False,
     ) -> None:
         """
         .. function:: __init__(node, qos=None)
@@ -55,10 +56,17 @@ class TransformBroadcaster:
 
             :param node: The ROS2 node.
             :param qos: A QoSProfile or a history depth to apply to the publisher.
+            :param override_tf_topics_namespaces: It true it remaps /tf to tf and /tf_static to tf_static. It allows to use namespaces.
         """
+
+        tf_topic = '/tf'
+
+        if override_tf_topics_namespaces:
+            tf_topic = 'tf'
+
         if qos is None:
             qos = QoSProfile(depth=100)
-        self.pub_tf = node.create_publisher(TFMessage, "/tf", qos)
+        self.pub_tf = node.create_publisher(TFMessage, tf_topic, qos)
 
     def sendTransform(
         self,


### PR DESCRIPTION
Related with https://github.com/ros2/geometry2/issues/433  and https://github.com/ros2/geometry2/issues/389
It gives the compatibility with nav2 (https://github.com/ros-planning/navigation2/blob/main/nav2_bringup/launch/navigation_launch.py#L60) architecture which gives every tf topic for every robot e. g.:
robot1: `/robot1/tf`
robot2: `/robot2/tf`

Added test passes:
```bash
colcon test --packages-select tf2_ros_py
Starting >>> tf2_ros_py
Finished <<< tf2_ros_py [1.32s]          

Summary: 1 package finished [1.51s]
```

