### PR TITLE
When finding Python3, use python3 executable as a hint

### DIFF
--- a/tf2_geometry_msgs/CMakeLists.txt
+++ b/tf2_geometry_msgs/CMakeLists.txt
@@ -15,6 +15,8 @@ if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
   find_package(PythonExtra REQUIRED)
   # Force FindPython3 to use the debug interpretter where ROS 2 expects it
   set(Python3_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
+elseif(NOT Python3_EXECUTABLE)
+  find_program(Python3_EXECUTABLE python3)
 endif()
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
 

--- a/tf2_geometry_msgs/CMakeLists.txt
+++ b/tf2_geometry_msgs/CMakeLists.txt
@@ -15,7 +15,16 @@ if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
   find_package(PythonExtra REQUIRED)
   # Force FindPython3 to use the debug interpretter where ROS 2 expects it
   set(Python3_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
-elseif(NOT Python3_EXECUTABLE)
+elseif(NOT WIN32 AND NOT Python3_EXECUTABLE)
+  # We expect that Python dependencies are met for whatever Python interpreter
+  # is invoked by the "python3" executable, however this may not be the latest
+  # Python version installed on the system. The default behavior of
+  # find_package(Python3) is to use the latest version (e.x. python3.12), so we
+  # specifically look for a "python3" executable and if found, instruct
+  # find_package(Python3) to use that.
+  # On Windows, the find_package(Python3) logic is different and doesn't
+  # appear to prefer specific versions (e.x. python3.12) over plain
+  # "python.exe" so this extra logic is unnecessary there.
   find_program(Python3_EXECUTABLE python3)
 endif()
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development)

--- a/tf2_py/CMakeLists.txt
+++ b/tf2_py/CMakeLists.txt
@@ -26,7 +26,16 @@ if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
   find_package(PythonExtra REQUIRED)
   # Force FindPython3 to use the debug interpretter where ROS 2 expects it
   set(Python3_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
-elseif(NOT Python3_EXECUTABLE)
+elseif(NOT WIN32 AND NOT Python3_EXECUTABLE)
+  # We expect that Python dependencies are met for whatever Python interpreter
+  # is invoked by the "python3" executable, however this may not be the latest
+  # Python version installed on the system. The default behavior of
+  # find_package(Python3) is to use the latest version (e.x. python3.12), so we
+  # specifically look for a "python3" executable and if found, instruct
+  # find_package(Python3) to use that.
+  # On Windows, the find_package(Python3) logic is different and doesn't
+  # appear to prefer specific versions (e.x. python3.12) over plain
+  # "python.exe" so this extra logic is unnecessary there.
   find_program(Python3_EXECUTABLE python3)
 endif()
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development)

--- a/tf2_py/CMakeLists.txt
+++ b/tf2_py/CMakeLists.txt
@@ -26,6 +26,8 @@ if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
   find_package(PythonExtra REQUIRED)
   # Force FindPython3 to use the debug interpretter where ROS 2 expects it
   set(Python3_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
+elseif(NOT Python3_EXECUTABLE)
+  find_program(Python3_EXECUTABLE python3)
 endif()
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
 


### PR DESCRIPTION
The existing find_package(Python3) call will locate the Python interpreter with the latest version number. However, this may not be the system's default Python interpreter for which our dependencies have been installed.

If Python3_EXECUTABLE is not explicitly specified, use find_program to locate the Python interpreter behind the "python3" command, which is likely the system's default and the one that we want.

If no executable can be found by the name "python3", the find_program call will silently fail and the existing behavior will manifest.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=20297)](http://ci.ros2.org/job/ci_linux/20297/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=14708)](http://ci.ros2.org/job/ci_linux-aarch64/14708/)
* Linux-rhel [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=582)](https://ci.ros2.org/job/ci_linux-rhel/582/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=21028)](http://ci.ros2.org/job/ci_windows/21028/)
* Windows-debug [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=21027)](https://ci.ros2.org/job/ci_windows/21027/) <- did I trigger this wrong? Is it even expected to work?