### PR TITLE
On Windows fix installation directory of .dll files in tf2_eigen_kdl

### DIFF
--- a/tf2_eigen_kdl/CMakeLists.txt
+++ b/tf2_eigen_kdl/CMakeLists.txt
@@ -46,7 +46,7 @@ install(TARGETS ${PROJECT_NAME}
   EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
-  RUNTIME DESTINATION lib)
+  RUNTIME DESTINATION bin)
 
 ament_export_dependencies(
   Eigen3


### PR DESCRIPTION
For consistency with the rest of geometry2 : 
* https://github.com/ros2/geometry2/blob/b81000d18c92e4841fcc46bfc7b541da44723c0d/tf2/CMakeLists.txt#L40
* https://github.com/ros2/geometry2/blob/b81000d18c92e4841fcc46bfc7b541da44723c0d/tf2_ros/CMakeLists.txt#L104

On Windows it is important to install the `.dll` libraries (`RUNTIME` in CMake jargon) in `<prefix>/bin`, as otherwise the Windows dynamic loader is not able to find them.

Cross-ref downstream issue:
* https://github.com/RoboStack/ros-noetic/issues/457#issuecomment-1987875265