### PR TITLE
Attempt to discus/fix old-latest timestamp logic

### DIFF
--- a/tf2/include/tf2/time_cache.h
+++ b/tf2/include/tf2/time_cache.h
@@ -76,7 +76,7 @@ public:
    * \brief Get the latest time stored in this cache, and the parent associated with it.  Returns parent = 0 if no data.
    */
   TF2_PUBLIC
-  virtual P_TimeAndFrameID getLatestTimeAndParent() = 0;
+  virtual P_TimeAndFrameID getOldestTimeAndParent() = 0;
 
   /// Debugging information methods
   /** @brief Get the length of the stored list */
@@ -128,7 +128,7 @@ public:
   virtual tf2::CompactFrameID getParent(
     tf2::TimePoint time, std::string * error_str = 0, TF2Error * error_code = 0);
   TF2_PUBLIC
-  virtual P_TimeAndFrameID getLatestTimeAndParent();
+  virtual P_TimeAndFrameID getOldestTimeAndParent();
 
   /// Debugging information methods
   TF2_PUBLIC
@@ -175,7 +175,7 @@ public:
   virtual CompactFrameID getParent(
     TimePoint time, std::string * error_str = 0, TF2Error * error_code = 0);
   TF2_PUBLIC
-  virtual P_TimeAndFrameID getLatestTimeAndParent();
+  virtual P_TimeAndFrameID getOldestTimeAndParent();
 
   /// Debugging information methods
   TF2_PUBLIC

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -952,7 +952,7 @@ tf2::TF2Error BufferCore::getLatestCommonTime(
       break;
     }
 
-    P_TimeAndFrameID latest = cache->getLatestTimeAndParent();
+    P_TimeAndFrameID latest = cache->getOldestTimeAndParent();
 
     if (latest.second == 0) {
       // Just break out here... there may still be a path from source -> target
@@ -1001,7 +1001,7 @@ tf2::TF2Error BufferCore::getLatestCommonTime(
       break;
     }
 
-    P_TimeAndFrameID latest = cache->getLatestTimeAndParent();
+    P_TimeAndFrameID latest = cache->getOldestTimeAndParent();
 
     if (latest.second == 0) {
       break;

--- a/tf2/src/cache.cpp
+++ b/tf2/src/cache.cpp
@@ -145,18 +145,18 @@ uint8_t TimeCache::findClosest(
     }
   }
 
-  TimePoint latest_time = (*storage_.begin()).stamp_;
-  TimePoint earliest_time = (*(storage_.rbegin())).stamp_;
+  const TimePoint oldest_time = getOldestTimestamp();
+  const TimePoint earliest_time = getLatestTimestamp();
 
-  if (target_time == latest_time) {
+  if (target_time == oldest_time) {
     one = &(*storage_.begin());
     return 1;
   } else if (target_time == earliest_time) {
     one = &(*storage_.rbegin());
     return 1;
   } else {   // Catch cases that would require extrapolation
-    if (target_time > latest_time) {
-      cache::createExtrapolationException2(target_time, latest_time, error_str, error_code);
+    if (target_time > oldest_time) {
+      cache::createExtrapolationException2(target_time, oldest_time, error_str, error_code);
       return 0;
     } else {
       if (target_time < earliest_time) {
@@ -280,7 +280,7 @@ unsigned int TimeCache::getListLength()
   return (unsigned int)storage_.size();
 }
 
-P_TimeAndFrameID TimeCache::getLatestTimeAndParent()
+P_TimeAndFrameID TimeCache::getOldestTimeAndParent()
 {
   if (storage_.empty()) {
     return std::make_pair(TimePoint(), 0);
@@ -296,7 +296,7 @@ TimePoint TimeCache::getLatestTimestamp()
   if (storage_.empty()) {
     return TimePoint();
   }
-  return storage_.front().stamp_;
+  return storage_.back().stamp_;
 }
 
 TimePoint TimeCache::getOldestTimestamp()
@@ -305,7 +305,7 @@ TimePoint TimeCache::getOldestTimestamp()
   if (storage_.empty()) {
     return TimePoint();
   }
-  return storage_.back().stamp_;
+  return storage_.front().stamp_;
 }
 
 void TimeCache::pruneList()

--- a/tf2/src/static_cache.cpp
+++ b/tf2/src/static_cache.cpp
@@ -67,7 +67,7 @@ tf2::CompactFrameID tf2::StaticCache::getParent(
   return storage_.frame_id_;
 }
 
-tf2::P_TimeAndFrameID tf2::StaticCache::getLatestTimeAndParent()
+tf2::P_TimeAndFrameID tf2::StaticCache::getOldestTimeAndParent()
 {
   return std::make_pair(TimePoint(), storage_.frame_id_);
 }


### PR DESCRIPTION
This is more like a discussion than a real PR.

Unless I got it completely wrong, the first elements on the list would be the OLDest, time-wise, and the last/back ones the newest

This doesn't seem like an implementation error but more like a naming convention problem OR (more likely) me not understanding it :)

🤔 If I'm not wrong, this makes me wonder, how were these functions working before???

The oldest timestamp would be the very first element in the list, since it's a sorted list and we sort accordingly with the timestamp, the first elements are the "oldest" ones. Similarly, the very last element is the most recent stamp we received in the cache, it will be at the very back of the list