### PR TITLE
MessageFilter Generalizated Nodes

### DIFF
--- a/tf2_eigen_kdl/CMakeLists.txt
+++ b/tf2_eigen_kdl/CMakeLists.txt
@@ -46,7 +46,7 @@ install(TARGETS ${PROJECT_NAME}
   EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
-  RUNTIME DESTINATION lib)
+  RUNTIME DESTINATION bin)
 
 ament_export_dependencies(
   Eigen3

--- a/tf2_eigen_kdl/CMakeLists.txt
+++ b/tf2_eigen_kdl/CMakeLists.txt
@@ -46,7 +46,7 @@ install(TARGETS ${PROJECT_NAME}
   EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin)
+  RUNTIME DESTINATION lib)
 
 ament_export_dependencies(
   Eigen3

--- a/tf2_ros/include/tf2_ros/message_filter.h
+++ b/tf2_ros/include/tf2_ros/message_filter.h
@@ -50,6 +50,8 @@
 #include "message_filters/connection.h"
 #include "message_filters/message_traits.h"
 #include "message_filters/simple_filter.h"
+#include "rclcpp/node_interfaces/get_node_logging_interface.hpp"
+#include "rclcpp/node_interfaces/get_node_clock_interface.hpp"
 #include "tf2/buffer_core_interface.h"
 #include "tf2/time.h"
 #include "tf2_ros/async_buffer_interface.h"
@@ -165,12 +167,13 @@ public:
     typename TimeRepT = int64_t, typename TimeT = std::nano>
   MessageFilter(
     BufferT & buffer, const std::string & target_frame, uint32_t queue_size,
-    const NodeT & node,
+    NodeT && node,
     std::chrono::duration<TimeRepT, TimeT> buffer_timeout =
     std::chrono::duration<TimeRepT, TimeT>::max())
   : MessageFilter(
-      buffer, target_frame, queue_size, node->get_node_logging_interface(),
-      node->get_node_clock_interface(), buffer_timeout)
+      buffer, target_frame, queue_size,
+      rclcpp::node_interfaces::get_node_logging_interface(node),
+      rclcpp::node_interfaces::get_node_clock_interface(node), buffer_timeout)
   {
     static_assert(
       std::is_base_of<tf2::BufferCoreInterface, BufferT>::value,
@@ -221,12 +224,13 @@ public:
     typename TimeRepT = int64_t, typename TimeT = std::nano>
   MessageFilter(
     F & f, BufferT & buffer, const std::string & target_frame, uint32_t queue_size,
-    const NodeT & node,
+    NodeT && node,
     std::chrono::duration<TimeRepT, TimeT> buffer_timeout =
     std::chrono::duration<TimeRepT, TimeT>::max())
   : MessageFilter(
-      f, buffer, target_frame, queue_size, node->get_node_logging_interface(),
-      node->get_node_clock_interface(), buffer_timeout)
+      f, buffer, target_frame, queue_size,
+      rclcpp::node_interfaces::get_node_logging_interface(node),
+      rclcpp::node_interfaces::get_node_clock_interface(node), buffer_timeout)
   {
   }
 

--- a/tf2_ros/include/tf2_ros/message_filter.h
+++ b/tf2_ros/include/tf2_ros/message_filter.h
@@ -161,10 +161,11 @@ public:
    * \param node The ros2 node to use for logging and clock operations
    * \param buffer_timeout The timeout duration after requesting transforms from the buffer.
    */
-  template<typename TimeRepT = int64_t, typename TimeT = std::nano>
+  template<typename NodeT = rclcpp::Node::SharedPtr,
+    typename TimeRepT = int64_t, typename TimeT = std::nano>
   MessageFilter(
     BufferT & buffer, const std::string & target_frame, uint32_t queue_size,
-    const rclcpp::Node::SharedPtr & node,
+    const NodeT & node,
     std::chrono::duration<TimeRepT, TimeT> buffer_timeout =
     std::chrono::duration<TimeRepT, TimeT>::max())
   : MessageFilter(
@@ -216,10 +217,11 @@ public:
    * \param node The ros2 node to use for logging and clock operations
    * \param buffer_timeout The timeout duration after requesting transforms from the buffer.
    */
-  template<class F, typename TimeRepT = int64_t, typename TimeT = std::nano>
+  template<class F, typename NodeT = rclcpp::Node::SharedPtr,
+    typename TimeRepT = int64_t, typename TimeT = std::nano>
   MessageFilter(
     F & f, BufferT & buffer, const std::string & target_frame, uint32_t queue_size,
-    const rclcpp::Node::SharedPtr & node,
+    const NodeT & node,
     std::chrono::duration<TimeRepT, TimeT> buffer_timeout =
     std::chrono::duration<TimeRepT, TimeT>::max())
   : MessageFilter(


### PR DESCRIPTION
This PR should entirely resolve #95 as pull request #96 didn't use a templated `Node` in the `MessageFilter` constructors. There were concerns of:
> Retain[ing] the existing node-based interface for backwards compatibility.

which we can do with defaulted templated `Nodes` and `node_interface` methods.