### PR TITLE
Replace deprecated spin_until_future_complete

### DIFF
--- a/tf2_ros/test/test_buffer_server.cpp
+++ b/tf2_ros/test/test_buffer_server.cpp
@@ -175,7 +175,7 @@ TEST_F(TestBufferServer, lookup_transform_available)
   transform.rotation.w = 1.0;
   setTransform("test_target_link", "test_source_link", transform);
 
-  auto spin_result = executor_.spin_until_future_complete(
+  auto spin_result = executor_.spin_until_complete(
     result_ready_future, std::chrono::seconds(3));
   ASSERT_EQ(spin_result, rclcpp::FutureReturnCode::SUCCESS);
 
@@ -192,7 +192,7 @@ TEST_F(TestBufferServer, lookup_transform_timeout)
     "test_target_link", "test_source_link", std::chrono::seconds(1));
 
   auto start_time = std::chrono::system_clock::now();
-  auto spin_result = executor_.spin_until_future_complete(
+  auto spin_result = executor_.spin_until_complete(
     result_ready_future, std::chrono::seconds(3));
   ASSERT_EQ(spin_result, rclcpp::FutureReturnCode::SUCCESS);
   auto end_time = std::chrono::system_clock::now();
@@ -213,7 +213,7 @@ TEST_F(TestBufferServer, lookup_transform_delayed)
     "test_target_link", "test_source_link", std::chrono::seconds(5));
 
   // Expect executor to timeout since transform is not available yet
-  auto spin_result = executor_.spin_until_future_complete(
+  auto spin_result = executor_.spin_until_complete(
     result_ready_future, std::chrono::seconds(1));
   EXPECT_EQ(spin_result, rclcpp::FutureReturnCode::TIMEOUT);
 
@@ -228,7 +228,7 @@ TEST_F(TestBufferServer, lookup_transform_delayed)
   setTransform("test_target_link", "test_source_link", transform);
 
   // Wait some more
-  spin_result = executor_.spin_until_future_complete(
+  spin_result = executor_.spin_until_complete(
     result_ready_future, std::chrono::seconds(3));
   ASSERT_EQ(spin_result, rclcpp::FutureReturnCode::SUCCESS);
 

--- a/tf2_tools/tf2_tools/view_frames.py
+++ b/tf2_tools/tf2_tools/view_frames.py
@@ -75,7 +75,7 @@ def main():
         node.get_logger().info('service not available, waiting again...')
 
     future = cli.call_async(req)
-    rclpy.spin_until_future_complete(node, future)
+    rclpy.spin_until_complete(node, future)
 
     ret = 1
     try:


### PR DESCRIPTION
Replaces #512

Requires https://github.com/ros2/rclcpp/pull/2475
Requires https://github.com/ros2/rclpy/pull/1268

Part of https://github.com/ros2/rclcpp/pull/2475