### PR TITLE
Improved Accuracy with RCUTILS

### DIFF
--- a/tf2/src/time.cpp
+++ b/tf2/src/time.cpp
@@ -61,7 +61,7 @@ tf2::TimePoint tf2::timeFromSec(double t_sec)
 double tf2::durationToSec(const tf2::Duration & input)
 {
   int64_t count = input.count();
-  return RCUTILS_NS_TO_S(count);
+  return rcutils_nanoseconds_to_seconds(count);
 }
 
 double tf2::timeToSec(const tf2::TimePoint & timepoint)

--- a/tf2/src/time.cpp
+++ b/tf2/src/time.cpp
@@ -34,6 +34,7 @@
 
 #include "rcutils/snprintf.h"
 #include "rcutils/strerror.h"
+#include "rcutils/time.h"
 #include "tf2/time.h"
 
 tf2::TimePoint tf2::get_now()
@@ -60,16 +61,7 @@ tf2::TimePoint tf2::timeFromSec(double t_sec)
 double tf2::durationToSec(const tf2::Duration & input)
 {
   int64_t count = input.count();
-
-  // scale the nanoseconds separately for improved accuracy
-  int32_t sec, nsec;
-  nsec = static_cast<int32_t>(count % 1000000000l);
-  sec = static_cast<int32_t>((count - nsec) / 1000000000l);
-
-  double sec_double, nsec_double;
-  nsec_double = 1e-9 * static_cast<double>(nsec);
-  sec_double = static_cast<double>(sec);
-  return sec_double + nsec_double;
+  return RCUTILS_NS_TO_S(count);
 }
 
 double tf2::timeToSec(const tf2::TimePoint & timepoint)


### PR DESCRIPTION
This pull request is meant to pair with [this `RCUTILS` PR](https://github.com/ros2/rcutils/pull/460) which will close #68, that way the feature is used immediately. I kept the `durationToSec` function as to prevent an API/ABI breakage. The tests pass locally when the `RCUTILS` fix is applied, but they'll fail until the PR over there is resolved, as there will be too much error without the exact rounding seen originally in this repository.