### PR TITLE
[cache_unittest] Add direct implementation testing on ordering, pruning

### DIFF
--- a/tf2/include/tf2/time_cache.h
+++ b/tf2/include/tf2/time_cache.h
@@ -105,11 +105,6 @@ constexpr tf2::Duration TIMECACHE_DEFAULT_MAX_STORAGE_TIME = std::chrono::second
 class TimeCache : public TimeCacheInterface
 {
 public:
-  // TODO(eric.cousineau): This appears to be unused / irrelevant?
-  /// Maximum length of linked list, to make sure not to be able to use unlimited memory.
-  TF2_PUBLIC
-  static const unsigned int MAX_LENGTH_LINKED_LIST = 1000000;
-
   TF2_PUBLIC
   explicit TimeCache(tf2::Duration max_storage_time = TIMECACHE_DEFAULT_MAX_STORAGE_TIME);
 
@@ -138,16 +133,10 @@ public:
   virtual TimePoint getOldestTimestamp();
 
 protected:
-  // Retrieve a copy of all items, sorted in order. Any items with the same
-  // timestamp will be in reverse order of insertion.
-  // @warning Portions of this contract may change based upon implementation.
+  // Return a reference to the internal list of tf2 frames, which are sorted in timestamp order.
+  // Any items with the same timestamp will be in reverse order of insertion.
   TF2_PUBLIC
-  std::list<TransformStorage> getAllItems() const
-  {
-    // TODO(eric.cousineau): Unclear why, deferring this definition to source
-    // file appears to cause a linker error, at least for cache_unittest.
-    return storage_;
-  }
+  const std::list<TransformStorage> & getAllItems() const;
 
 private:
   typedef std::list<TransformStorage> L_TransformStorage;

--- a/tf2/include/tf2/time_cache.h
+++ b/tf2/include/tf2/time_cache.h
@@ -97,11 +97,6 @@ using TimeCacheInterfacePtr = std::shared_ptr<TimeCacheInterface>;
 /// default value of 10 seconds storage
 constexpr tf2::Duration TIMECACHE_DEFAULT_MAX_STORAGE_TIME = std::chrono::seconds(10);
 
-namespace impl
-{
-class TestFriend;
-}  // namespace impl
-
 /** \brief A class to keep a sorted linked list in time (newest first, oldest
  * last).
  * This builds and maintains a list of timestamped
@@ -161,7 +156,8 @@ private:
 
   void pruneList();
 
-  friend class impl::TestFriend;
+  // Internal access for testing only.
+  friend class InternalTestAccess;
 };
 
 class StaticCache : public TimeCacheInterface

--- a/tf2/include/tf2/time_cache.h
+++ b/tf2/include/tf2/time_cache.h
@@ -133,7 +133,8 @@ public:
   virtual TimePoint getOldestTimestamp();
 
 protected:
-  // Return a reference to the internal list of tf2 frames, which are sorted in timestamp order.
+  // (Internal) Return a reference to the internal list of tf2 frames, which
+  // are sorted in timestamp order.
   // Any items with the same timestamp will be in reverse order of insertion.
   TF2_PUBLIC
   const std::list<TransformStorage> & getAllItems() const;

--- a/tf2/include/tf2/time_cache.h
+++ b/tf2/include/tf2/time_cache.h
@@ -137,6 +137,16 @@ public:
   TF2_PUBLIC
   virtual TimePoint getOldestTimestamp();
 
+  /// Retrieve a copy of all items, sorted in order. Any items with the same
+  /// timestamp will be in reverse order of insertion.
+  /// @warning Portions of this contract may change based upon implementation.
+  TF2_PUBLIC
+  std::list<TransformStorage> getAllItems() const {
+    // TODO(eric.cousineau): Unclear why, deferring this definition to source
+    // file appears to cause a linker error, at least for cache_unittest.
+    return storage_;
+  }
+
 private:
   typedef std::list<TransformStorage> L_TransformStorage;
   L_TransformStorage storage_;
@@ -155,9 +165,6 @@ private:
     tf2::TimePoint time, tf2::TransformStorage & output);
 
   void pruneList();
-
-  // Internal access for testing only.
-  friend class InternalTestAccess;
 };
 
 class StaticCache : public TimeCacheInterface

--- a/tf2/include/tf2/time_cache.h
+++ b/tf2/include/tf2/time_cache.h
@@ -142,7 +142,8 @@ protected:
   // timestamp will be in reverse order of insertion.
   // @warning Portions of this contract may change based upon implementation.
   TF2_PUBLIC
-  std::list<TransformStorage> getAllItems() const {
+  std::list<TransformStorage> getAllItems() const
+  {
     // TODO(eric.cousineau): Unclear why, deferring this definition to source
     // file appears to cause a linker error, at least for cache_unittest.
     return storage_;

--- a/tf2/include/tf2/time_cache.h
+++ b/tf2/include/tf2/time_cache.h
@@ -137,9 +137,10 @@ public:
   TF2_PUBLIC
   virtual TimePoint getOldestTimestamp();
 
-  /// Retrieve a copy of all items, sorted in order. Any items with the same
-  /// timestamp will be in reverse order of insertion.
-  /// @warning Portions of this contract may change based upon implementation.
+protected:
+  // Retrieve a copy of all items, sorted in order. Any items with the same
+  // timestamp will be in reverse order of insertion.
+  // @warning Portions of this contract may change based upon implementation.
   TF2_PUBLIC
   std::list<TransformStorage> getAllItems() const {
     // TODO(eric.cousineau): Unclear why, deferring this definition to source

--- a/tf2/include/tf2/time_cache.h
+++ b/tf2/include/tf2/time_cache.h
@@ -97,16 +97,24 @@ using TimeCacheInterfacePtr = std::shared_ptr<TimeCacheInterface>;
 /// default value of 10 seconds storage
 constexpr tf2::Duration TIMECACHE_DEFAULT_MAX_STORAGE_TIME = std::chrono::seconds(10);
 
-/** \brief A class to keep a sorted linked list in time
+namespace impl
+{
+class TestFriend;
+}  // namespace impl
+
+/** \brief A class to keep a sorted linked list in time (newest first, oldest
+ * last).
  * This builds and maintains a list of timestamped
  * data.  And provides lookup functions to get
  * data out as a function of time. */
 class TimeCache : public TimeCacheInterface
 {
 public:
+  // TODO(eric.cousineau): This appears to be unused / irrelevant?
   /// Maximum length of linked list, to make sure not to be able to use unlimited memory.
   TF2_PUBLIC
   static const unsigned int MAX_LENGTH_LINKED_LIST = 1000000;
+
   TF2_PUBLIC
   explicit TimeCache(tf2::Duration max_storage_time = TIMECACHE_DEFAULT_MAX_STORAGE_TIME);
 
@@ -152,6 +160,8 @@ private:
     tf2::TimePoint time, tf2::TransformStorage & output);
 
   void pruneList();
+
+  friend class impl::TestFriend;
 };
 
 class StaticCache : public TimeCacheInterface

--- a/tf2/src/cache.cpp
+++ b/tf2/src/cache.cpp
@@ -30,6 +30,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <list>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -305,6 +306,11 @@ TimePoint TimeCache::getOldestTimestamp()
     return TimePoint();
   }
   return storage_.back().stamp_;
+}
+
+const std::list<TransformStorage> & TimeCache::getAllItems() const
+{
+  return storage_;
 }
 
 void TimeCache::pruneList()

--- a/tf2/test/cache_unittest.cpp
+++ b/tf2/test/cache_unittest.cpp
@@ -68,6 +68,13 @@ void setIdentity(tf2::TransformStorage & stor)
   stor.rotation_.setValue(0.0, 0.0, 0.0, 1.0);
 }
 
+class TimeCacheInternal : public tf2::TimeCache
+{
+public:
+  using tf2::TimeCache::TimeCache;
+  using tf2::TimeCache::getAllItems;
+};
+
 // Shorthand for making incomplete but unique transforms.
 tf2::TransformStorage makeItem(uint32_t nanosec, uint32_t frame_id)
 {
@@ -107,7 +114,7 @@ std::string listToMakeItemStrings(const std::list<tf2::TransformStorage> & stora
 TEST(TimeCache, GetAllItems)
 {
   tf2::Duration max_storage_time(std::chrono::nanoseconds(10));
-  tf2::TimeCache cache(max_storage_time);
+  TimeCacheInternal cache(max_storage_time);
 
   const auto item_a = makeItem(0, 0);
   const auto item_b = makeItem(10, 1);

--- a/tf2/test/cache_unittest.cpp
+++ b/tf2/test/cache_unittest.cpp
@@ -68,20 +68,6 @@ void setIdentity(tf2::TransformStorage & stor)
   stor.rotation_.setValue(0.0, 0.0, 0.0, 1.0);
 }
 
-namespace tf2
-{
-
-class InternalTestAccess
-{
-public:
-  static const std::list<tf2::TransformStorage> & getAllItems(const tf2::TimeCache & cache)
-  {
-    return cache.storage_;
-  }
-};
-
-}  // namespace tf2
-
 // Shorthand for making incomplete but unique transforms.
 tf2::TransformStorage makeItem(uint32_t nanosec, uint32_t frame_id)
 {
@@ -118,11 +104,10 @@ std::string listToMakeItemStrings(const std::list<tf2::TransformStorage> & stora
 // Tests the behavior of sorting and pruning relevant to the implementation for
 // performance concerns. Certain details may change as the implementation
 // evolves.
-TEST(TimeCache, ImplSortedDescendingUniqueEntries)
+TEST(TimeCache, GetAllItems)
 {
   tf2::Duration max_storage_time(std::chrono::nanoseconds(10));
   tf2::TimeCache cache(max_storage_time);
-  const std::list<tf2::TransformStorage> & storage = tf2::InternalTestAccess::getAllItems(cache);
 
   const auto item_a = makeItem(0, 0);
   const auto item_b = makeItem(10, 1);
@@ -160,6 +145,7 @@ TEST(TimeCache, ImplSortedDescendingUniqueEntries)
     item_d,
     item_a};
 
+  const std::list<tf2::TransformStorage> storage = cache.getAllItems();
   EXPECT_EQ(storage, storage_expected)
     << "storage: " << listToMakeItemStrings(storage) << "\n"
     << "storage_expected: " << listToMakeItemStrings(storage_expected) << "\n";
@@ -173,8 +159,9 @@ TEST(TimeCache, ImplSortedDescendingUniqueEntries)
   cache.insertData(item_b);
   cache.insertData(item_a);
 
-  EXPECT_EQ(storage, storage_expected)
-    << "storage: " << listToMakeItemStrings(storage) << "\n"
+  const std::list<tf2::TransformStorage> storage_repeat = cache.getAllItems();
+  EXPECT_EQ(storage_repeat, storage_expected)
+    << "storage_repeat: " << listToMakeItemStrings(storage_repeat) << "\n"
     << "storage_expected: " << listToMakeItemStrings(storage_expected) << "\n";
 
   // Insert newer data, and expect stale data to be pruned, even if newly inserted.
@@ -195,8 +182,9 @@ TEST(TimeCache, ImplSortedDescendingUniqueEntries)
     item_j,
     item_c};
   // item_a, item_d, and item_i are pruned.
-  EXPECT_EQ(storage, storage_expected_new)
-    << "storage: " << listToMakeItemStrings(storage) << "\n"
+  const std::list<tf2::TransformStorage> storage_new = cache.getAllItems();
+  EXPECT_EQ(storage_new, storage_expected_new)
+    << "storage_new: " << listToMakeItemStrings(storage_new) << "\n"
     << "storage_expected_new: " << listToMakeItemStrings(storage_expected_new) << "\n";
 }
 

--- a/tf2/test/cache_unittest.cpp
+++ b/tf2/test/cache_unittest.cpp
@@ -70,19 +70,16 @@ void setIdentity(tf2::TransformStorage & stor)
 
 namespace tf2
 {
-namespace impl
-{
 
-class TestFriend
+class InternalTestAccess
 {
 public:
-  static const std::list<tf2::TransformStorage> & getList(const tf2::TimeCache & cache)
+  static const std::list<tf2::TransformStorage> & getAllItems(const tf2::TimeCache & cache)
   {
     return cache.storage_;
   }
 };
 
-}  // namespace impl
 }  // namespace tf2
 
 // Shorthand for making incomplete but unique transforms.
@@ -125,7 +122,7 @@ TEST(TimeCache, ImplSortedDescendingUniqueEntries)
 {
   tf2::Duration max_storage_time(std::chrono::nanoseconds(10));
   tf2::TimeCache cache(max_storage_time);
-  const std::list<tf2::TransformStorage> & storage = tf2::impl::TestFriend::getList(cache);
+  const std::list<tf2::TransformStorage> & storage = tf2::InternalTestAccess::getAllItems(cache);
 
   const auto item_a = makeItem(0, 0);
   const auto item_b = makeItem(10, 1);

--- a/tf2/test/cache_unittest.cpp
+++ b/tf2/test/cache_unittest.cpp
@@ -90,9 +90,9 @@ tf2::TransformStorage makeItem(uint32_t nanosec, uint32_t frame_id)
 std::string toMakeItemString(const tf2::TransformStorage & item)
 {
   std::stringstream out;
-  const uint32_t nanosec = std::chrono::duration_cast<std::chrono::nanoseconds>(
-    item.stamp_.time_since_epoch()).count();
-  out << "makeItem(" << nanosec << ", " << item.frame_id_ << ")";
+  std::chrono::duration nanosec = std::chrono::duration_cast<std::chrono::nanoseconds>(
+    item.stamp_.time_since_epoch());
+  out << "makeItem(" << nanosec.count() << ", " << item.frame_id_ << ")";
   return out.str();
 }
 


### PR DESCRIPTION
Towards #676
This changes nothing pertaining to the implementation. It only adds testing.
Some of it is implementation-specific, but towards the ends of performance checks.

From https://github.com/ros2/geometry2/issues/676#issuecomment-2102512107

> 1. It needs to hold an arbitrary number of entries, because we don't know the rate at which we will get data.
> 2. The items needs to be in sorted order by timestamp, from the newest entry to the oldest.
> 3. New items need to be inserted into arbitrary positions, as timestamps may come in out-of-order.
> 4. Duplicates shouldn't be allowed.
> 5. Old items need to be pruned out.

To answer them:

1. There appears to be no limit on size. Not sure how to test this in a bounded fashion.
2. This was not tested. Now explicitly tested via `ImplSortedDescendingUniqueEntries`
3. This was not tested. Now explicitly tested via `ImplSortedDescendingUniqueEntries`
4. This was already tested, but is also explicitly tested via `ImplSortedDescendingUniqueEntries`
5. This was not tested (I believe). Now explicitly tested via `ImplSortedDescendingUniqueEntries`