### PR TITLE
[TimeCache] Improve performance for insertData() and pruneList()

### DIFF
--- a/tf2/src/cache.cpp
+++ b/tf2/src/cache.cpp
@@ -256,8 +256,8 @@ bool TimeCache::insertData(const TransformStorage & new_data)
 
   // Find the oldest element in the list before the incoming stamp.
   auto insertion_pos = std::find_if(
-    storage_.begin(), storage_.end(), [&](const auto & transfrom) {
-      return transfrom.stamp_ <= new_data.stamp_;
+    storage_.begin(), storage_.end(), [&](const auto & transform) {
+      return transform.stamp_ <= new_data.stamp_;
     });
 
   bool should_insert = true;

--- a/tf2/src/cache.cpp
+++ b/tf2/src/cache.cpp
@@ -255,7 +255,7 @@ bool TimeCache::insertData(const TransformStorage & new_data)
   }
 
   // Find the oldest element in the list before the incoming stamp.
-  auto last_transform_pos = std::find_if(
+  auto insertion_pos = std::find_if(
     storage_.begin(), storage_.end(), [&](const auto & transfrom) {
       return transfrom.stamp_ <= new_data.stamp_;
     });
@@ -263,17 +263,18 @@ bool TimeCache::insertData(const TransformStorage & new_data)
   bool should_insert = true;
   // Search along all data with same timestamp (sorted), and only insert if we
   // did not find the exact same data.
-  while (last_transform_pos != storage_.end() && last_transform_pos->stamp_ == new_data.stamp_) {
-    if (*last_transform_pos == new_data) {
+  auto maybe_same_pos = insertion_pos;
+  while (maybe_same_pos != storage_.end() && maybe_same_pos->stamp_ == new_data.stamp_) {
+    if (*maybe_same_pos == new_data) {
       should_insert = false;
       break;
     }
-    last_transform_pos++;
+    maybe_same_pos++;
   }
 
   // Insert elements only if not already present
   if (should_insert) {
-    storage_.insert(last_transform_pos, new_data);
+    storage_.insert(insertion_pos, new_data);
   }
 
   pruneList();

--- a/tf2/src/cache.cpp
+++ b/tf2/src/cache.cpp
@@ -250,6 +250,10 @@ bool TimeCache::insertData(const TransformStorage & new_data)
 {
   const TimePoint latest_time = getLatestTimestamp();
 
+  // Always prune data. This (a) ensures we trim data we should not access, and
+  // (b) ensures we don't waste time iterating over items to be removed.
+  pruneList();
+
   // Avoid inserting data in the past that already exceeds the max_storage_time_
   if (!storage_.empty() && new_data.stamp_ < latest_time - max_storage_time_) {
     return false;
@@ -278,7 +282,6 @@ bool TimeCache::insertData(const TransformStorage & new_data)
     storage_.insert(insertion_pos, new_data);
   }
 
-  pruneList();
   return true;
 }
 


### PR DESCRIPTION
Resolves #676

Per https://github.com/ros2/geometry2/issues/676#issuecomment-2109109282, this should yield a ~1000x speedup for `insertData` (for inserting new data only)