### PR TITLE
Removed warning

### DIFF
--- a/tf2/test/cache_benchmark.cpp
+++ b/tf2/test/cache_benchmark.cpp
@@ -54,7 +54,7 @@ static void benchmark_insertion(benchmark::State & state)
   }
 
   // Insert data to cache
-  auto insert_data = [&example_items, dt](
+  auto insert_data = [=, &example_items](
     tf2::TimeCache & cache,
     tf2::TimePoint timestamp,
     int step,

--- a/tf2/test/cache_benchmark.cpp
+++ b/tf2/test/cache_benchmark.cpp
@@ -54,7 +54,7 @@ static void benchmark_insertion(benchmark::State & state)
   }
 
   // Insert data to cache
-  auto insert_data = [&example_items, num_tform, dt](
+  auto insert_data = [&example_items, dt](
     tf2::TimeCache & cache,
     tf2::TimePoint timestamp,
     int step,

--- a/tf2/test/cache_benchmark.cpp
+++ b/tf2/test/cache_benchmark.cpp
@@ -54,7 +54,7 @@ static void benchmark_insertion(benchmark::State & state)
   }
 
   // Insert data to cache
-  auto insert_data = [=, &example_items](
+  auto insert_data = [ =, &example_items](
     tf2::TimeCache & cache,
     tf2::TimePoint timestamp,
     int step,


### PR DESCRIPTION
There is a new warning when compiling with clang https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/1890/clang-tidy/new/folder.1973258341/

This should fix it.