### PR TITLE
transform polygone: Do not clear poly_in before transforming points

### DIFF
--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.hpp
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.hpp
@@ -463,12 +463,11 @@ void doTransform(
   geometry_msgs::msg::Polygon & poly_out,
   const geometry_msgs::msg::TransformStamped & transform)
 {
-  poly_out.points.clear();
-  for (auto & point : poly_in.points) {
-    geometry_msgs::msg::Point32 point_transformed;
-    doTransform(point, point_transformed, transform);
-    poly_out.points.push_back(point_transformed);
+  std::vector<geometry_msgs::msg::Point32> points_transformed(poly_in.points.size(), {});
+  for (size_t i=0; i < poly_in.points.size(); ++i) {
+    doTransform(poly_in.points[i], points_transformed[i], transform);
   }
+  poly_out.points = points_transformed;
 }
 
 /** \brief Trivial "conversion" function for Polygon message type.

--- a/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
+++ b/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
@@ -462,10 +462,10 @@ TEST(TfGeometry, Polygon)
   {
     geometry_msgs::msg::Polygon res;
     geometry_msgs::msg::Point32 p;
-    res.x = 1;
-    res.y = 2;
-    res.z = 3;
-    v1.points.push_back(p);
+    p.x = 1;
+    p.y = 2;
+    p.z = 3;
+    res.points.push_back(p);
 
     geometry_msgs::msg::TransformStamped t = generate_stamped_transform();
 

--- a/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
+++ b/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
@@ -458,6 +458,23 @@ TEST(TfGeometry, Polygon)
     EXPECT_NEAR(res.points[0].z, 27, EPS);
   }
 
+  // non-stamped by reference
+  {
+    geometry_msgs::msg::Polygon res;
+    geometry_msgs::msg::Point32 p;
+    res.x = 1;
+    res.y = 2;
+    res.z = 3;
+    v1.points.push_back(p);
+
+    geometry_msgs::msg::TransformStamped t = generate_stamped_transform();
+
+    tf2::doTransform(res, res, t);
+    EXPECT_NEAR(res.points[0].x, 11, EPS);
+    EXPECT_NEAR(res.points[0].y, 18, EPS);
+    EXPECT_NEAR(res.points[0].z, 27, EPS);
+  }
+
   // stamped
   {
     geometry_msgs::msg::PolygonStamped v1, res;


### PR DESCRIPTION
Before this MR, `doTransform(my_poly, my_poly, transform)` did not work as it does for other messages, e.g. pose.

If this is the desired behavior should be discussed.