### PR TITLE
Removed deprecated enuns

### DIFF
--- a/tf2/include/tf2/exceptions.h
+++ b/tf2/include/tf2/exceptions.h
@@ -40,13 +40,6 @@
 namespace tf2
 {
 
-// TODO(clalancette): We can remove these workarounds when we remove the
-// deprecated TF2Error enums.
-#if defined(_WIN32)
-#pragma push_macro("NO_ERROR")
-#undef NO_ERROR
-#endif
-
 enum class TF2Error : std::uint8_t
 {
   // While the TF2_ prefix here is a bit redundant, it also prevents us from
@@ -62,10 +55,6 @@ enum class TF2Error : std::uint8_t
   TF2_FORWARD_EXTRAPOLATION_ERROR = 8,
   TF2_NO_DATA_FOR_EXTRAPOLATION_ERROR = 9,
 };
-
-#if defined(_WIN32)
-#pragma pop_macro("NO_ERROR")
-#endif
 
 /** \brief A base class for all tf2 exceptions
  * This inherits from ros::exception

--- a/tf2/include/tf2/exceptions.h
+++ b/tf2/include/tf2/exceptions.h
@@ -46,14 +46,6 @@ namespace tf2
 #pragma push_macro("NO_ERROR")
 #undef NO_ERROR
 #endif
-#if defined(__APPLE__) || defined(__clang__)
-// The clang compiler on Apple claims that [[deprecated]] on an enumerator value
-// is a C++17 feature, when it was really introduced in C++14.  Ignore that
-// warning when defining the structure; this whole thing will go away when we
-// remove the deprecated values.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wc++17-extensions"
-#endif
 
 enum class TF2Error : std::uint8_t
 {
@@ -69,21 +61,8 @@ enum class TF2Error : std::uint8_t
   TF2_BACKWARD_EXTRAPOLATION_ERROR = 7,
   TF2_FORWARD_EXTRAPOLATION_ERROR = 8,
   TF2_NO_DATA_FOR_EXTRAPOLATION_ERROR = 9,
-
-  NO_ERROR [[deprecated("Use TF2_NO_ERROR instead")]] = 0,
-  LOOKUP_ERROR [[deprecated("Use TF2_LOOKUP_ERROR instead")]] = 1,
-  CONNECTIVITY_ERROR [[deprecated("Use TF2_CONNECTIVITY_ERROR instead")]] = 2,
-  EXTRAPOLATION_ERROR [[deprecated("Use TF2_EXTRAPOLATION_ERROR instead")]] = 3,
-  INVALID_ARGUMENT_ERROR [[deprecated("Use TF2_INVALID_ARGUMENT_ERROR instead")]] = 4,
-  TIMEOUT_ERROR [[deprecated("Use TF2_TIMEOUT_ERROR instead")]] = 5,
-  TRANSFORM_ERROR [[deprecated("Use TF2_TRANSFORM_ERROR instead")]] = 6
 };
 
-// TODO(clalancette): We can remove these workarounds when we remove the
-// deprecated TF2Error enums.
-#if defined(__APPLE__)
-#pragma clang diagnostic pop
-#endif
 #if defined(_WIN32)
 #pragma pop_macro("NO_ERROR")
 #endif


### PR DESCRIPTION
Removed deprecated enums from tf2 exceptions. This was deprecated on `humble` at least. It should be safe remove this here