### PR TITLE
Switch to using a context manager for the python examples.

### DIFF
--- a/examples_tf2_py/examples_tf2_py/async_waits_for_transform.py
+++ b/examples_tf2_py/examples_tf2_py/async_waits_for_transform.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 import rclpy.time
 from tf2_ros import LookupException
@@ -62,10 +63,9 @@ class AsyncWaitsForTransform(Node):
 
 
 def main():
-    rclpy.init()
-    node = AsyncWaitsForTransform()
     try:
-        rclpy.spin(node)
-    except KeyboardInterrupt:
+        with rclpy.init():
+            node = AsyncWaitsForTransform()
+            rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
         pass
-    rclpy.shutdown()

--- a/examples_tf2_py/examples_tf2_py/blocking_waits_for_transform.py
+++ b/examples_tf2_py/examples_tf2_py/blocking_waits_for_transform.py
@@ -14,6 +14,7 @@
 
 import rclpy
 from rclpy.duration import Duration
+from rclpy.executors import ExternalShutdownException, MultiThreadedExecutor
 from rclpy.node import Node
 import rclpy.time
 from tf2_ros import LookupException
@@ -55,16 +56,12 @@ class BlockingWaitsForTransform(Node):
 
 
 def main():
-    from rclpy.executors import MultiThreadedExecutor
-
-    rclpy.init()
-    node = BlockingWaitsForTransform()
-    # this node blocks in a callback, so a MultiThreadedExecutor is required
-    executor = MultiThreadedExecutor()
-    executor.add_node(node)
     try:
-        executor.spin()
-    except KeyboardInterrupt:
+        with rclpy.init():
+            node = BlockingWaitsForTransform()
+            # this node blocks in a callback, so a MultiThreadedExecutor is required
+            executor = MultiThreadedExecutor()
+            executor.add_node(node)
+            executor.spin()
+    except (KeyboardInterrupt, ExternalShutdownException):
         pass
-    executor.shutdown()
-    rclpy.shutdown()

--- a/examples_tf2_py/examples_tf2_py/dynamic_broadcaster.py
+++ b/examples_tf2_py/examples_tf2_py/dynamic_broadcaster.py
@@ -16,6 +16,7 @@ import math
 
 from geometry_msgs.msg import TransformStamped
 import rclpy
+from rclpy.executors import ExternalShutdownException, SingleThreadedExecutor
 from rclpy.node import Node
 from rclpy.qos import QoSProfile
 from sensor_msgs.msg import JointState
@@ -87,20 +88,16 @@ class FakeJointStatePublisher(Node):
 
 
 def main():
-    rclpy.init()
-    nodes = []
-    nodes.append(DynamicFramePublisher())
-    nodes.append(FakeJointStatePublisher())
-
-    from rclpy.executors import SingleThreadedExecutor
-    executor = SingleThreadedExecutor()
-    for node in nodes:
-        executor.add_node(node)
-
     try:
-        executor.spin()
-    except KeyboardInterrupt:
-        pass
+        with rclpy.init():
+            nodes = []
+            nodes.append(DynamicFramePublisher())
+            nodes.append(FakeJointStatePublisher())
 
-    executor.shutdown()
-    rclpy.shutdown()
+            executor = SingleThreadedExecutor()
+            for node in nodes:
+                executor.add_node(node)
+
+            executor.spin()
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass

--- a/examples_tf2_py/examples_tf2_py/frame_dumper.py
+++ b/examples_tf2_py/examples_tf2_py/frame_dumper.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from tf2_ros.buffer import Buffer
 from tf2_ros.transform_listener import TransformListener
@@ -34,11 +35,9 @@ class FrameDumper(Node):
 
 
 def main():
-    rclpy.init()
-    node = FrameDumper()
     try:
-        rclpy.spin(node)
-    except KeyboardInterrupt:
+        with rclpy.init():
+            node = FrameDumper()
+            rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
         pass
-
-    rclpy.shutdown()

--- a/examples_tf2_py/examples_tf2_py/static_broadcaster.py
+++ b/examples_tf2_py/examples_tf2_py/static_broadcaster.py
@@ -16,6 +16,7 @@ import math
 
 from geometry_msgs.msg import TransformStamped
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from tf2_ros.static_transform_broadcaster import StaticTransformBroadcaster
 
@@ -109,11 +110,9 @@ class StaticFramePublisher(Node):
 
 
 def main():
-    rclpy.init()
-    node = StaticFramePublisher()
     try:
-        rclpy.spin(node)
-    except KeyboardInterrupt:
+        with rclpy.init():
+            node = StaticFramePublisher()
+            rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
         pass
-
-    rclpy.shutdown()

--- a/examples_tf2_py/examples_tf2_py/waits_for_transform.py
+++ b/examples_tf2_py/examples_tf2_py/waits_for_transform.py
@@ -15,6 +15,7 @@
 import threading
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 import rclpy.time
 from tf2_ros import LookupException
@@ -73,10 +74,9 @@ class WaitsForTransform(Node):
 
 
 def main():
-    rclpy.init()
-    node = WaitsForTransform()
     try:
-        rclpy.spin(node)
-    except KeyboardInterrupt:
+        with rclpy.init():
+            node = WaitsForTransform()
+            rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
         pass
-    rclpy.shutdown()

--- a/test_tf2/test/test_buffer_client.py
+++ b/test_tf2/test/test_buffer_client.py
@@ -59,6 +59,9 @@ class TestBufferClient(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        cls.executor.remove_node(cls.node)
+        cls.node.destroy_node()
+        cls.executor.shutdown()
         rclpy.shutdown(context=cls.context)
 
     def setUp(self):

--- a/tf2_ros_py/test/test_buffer_client.py
+++ b/tf2_ros_py/test/test_buffer_client.py
@@ -112,6 +112,8 @@ class TestBufferClient:
 
     @classmethod
     def teardown_class(cls):
+        cls.executor.remove_node(cls.node)
+        cls.executor.shutdown()
         cls.mock_action_server.destroy()
         cls.node.destroy_node()
         rclpy.shutdown(context=cls.context)

--- a/tf2_ros_py/test/test_listener_and_broadcaster.py
+++ b/tf2_ros_py/test/test_listener_and_broadcaster.py
@@ -73,6 +73,7 @@ class TestBroadcasterAndListener:
 
     @classmethod
     def teardown_class(cls):
+        cls.executor.remove_node(cls.node)
         cls.node.destroy_node()
         rclpy.shutdown()
 


### PR DESCRIPTION
That way we can be sure to always clean up, but use less code doing so.

This is part of https://github.com/ros2/rclpy/issues/1280