### PR TITLE
Add configurable TF topics to view_frames

### DIFF
--- a/tf2_ros/doc/cli_tools.rst
+++ b/tf2_ros/doc/cli_tools.rst
@@ -73,6 +73,13 @@ In the current working folder, you should now have a file called "frames_$(data)
 
 .. image:: images/view_frames.png
 
+
+If you need to view the frames from non-standard topics, you can override them like so:
+
+.. code-block:: bash
+
+   ros2 run tf2_tools view_frames --tf_topic=/foo  --tf_static_topic=bar
+
 Fields
 ~~~~~~
   * Recorded at time: shows the absolute timestamp when this graph was generated.

--- a/tf2_ros_py/tf2_ros/transform_listener.py
+++ b/tf2_ros_py/tf2_ros/transform_listener.py
@@ -40,12 +40,15 @@ from tf2_ros.buffer import Buffer
 from tf2_msgs.msg import TFMessage
 from threading import Thread
 
+DEFAULT_TF_TOPIC = '/tf'
+DEFAULT_STATIC_TF_TOPIC = '/tf_static'
 
 class TransformListener:
     """
     :class:`TransformListener` is a convenient way to listen for coordinate frame transformation info.
     This class takes an object that instantiates the :class:`BufferInterface` interface, to which
-    it propagates changes to the tf frame graph.
+    it propagates changes to the tf frame graph. It listens to both static and dynamic
+    transforms.
     """
     def __init__(
         self,
@@ -54,7 +57,9 @@ class TransformListener:
         *,
         spin_thread: bool = False,
         qos: Optional[Union[QoSProfile, int]] = None,
-        static_qos: Optional[Union[QoSProfile, int]] = None
+        static_qos: Optional[Union[QoSProfile, int]] = None,
+        tf_topic: str = DEFAULT_TF_TOPIC,
+        tf_static_topic: str = DEFAULT_STATIC_TF_TOPIC
     ) -> None:
         """
         Constructor.
@@ -64,6 +69,8 @@ class TransformListener:
         :param spin_thread: Whether to create a dedidcated thread to spin this node.
         :param qos: A QoSProfile or a history depth to apply to subscribers.
         :param static_qos: A QoSProfile or a history depth to apply to tf_static subscribers.
+        :param tf_topic: Which topic to listen to for dynamic transforms.
+        :param tf_static_topic: Which topic to listen to for static transforms.
         """
         if qos is None:
             qos = QoSProfile(
@@ -83,9 +90,9 @@ class TransformListener:
         # from another callback in the same group.
         self.group = ReentrantCallbackGroup()
         self.tf_sub = node.create_subscription(
-            TFMessage, '/tf', self.callback, qos, callback_group=self.group)
+            TFMessage, tf_topic, self.callback, qos, callback_group=self.group)
         self.tf_static_sub = node.create_subscription(
-            TFMessage, '/tf_static', self.static_callback, static_qos, callback_group=self.group)
+            TFMessage, tf_static_topic, self.static_callback, static_qos, callback_group=self.group)
 
         if spin_thread:
             self.executor = SingleThreadedExecutor()

--- a/tf2_tools/tf2_tools/view_frames.py
+++ b/tf2_tools/tf2_tools/view_frames.py
@@ -36,6 +36,7 @@ import time
 import rclpy
 from tf2_msgs.srv import FrameGraph
 import tf2_ros
+from tf2_ros.transform_listener import DEFAULT_STATIC_TF_TOPIC, DEFAULT_TF_TOPIC
 
 import yaml
 
@@ -50,12 +51,19 @@ def main():
         '--wait-time', '-t', type=float, default=5.0,
         help='Listen to the /tf topic for this many seconds before rendering the frame tree')
     parser.add_argument('-o', '--output', help='Output filename')
+    parser.add_argument('--tf_topic', help='Topic for dynamic transforms',
+                        default=DEFAULT_TF_TOPIC)
+    parser.add_argument('--tf_static_topic', help='Topic for static transforms',
+                        default=DEFAULT_STATIC_TF_TOPIC)
+
     parsed_args = parser.parse_args(args=args_without_ros[1:])
 
     node = rclpy.create_node('view_frames')
 
     buf = tf2_ros.Buffer(node=node)
-    listener = tf2_ros.TransformListener(buf, node, spin_thread=False)
+    listener = tf2_ros.TransformListener(buf, node, spin_thread=False,
+                                         tf_topic=parsed_args.tf_topic,
+                                         tf_static_topic=parsed_args.tf_static_topic)
     listener  # To quiet a flake8 warning
 
     executor = rclpy.executors.SingleThreadedExecutor()


### PR DESCRIPTION
Here's the python implementation of #708. It's a convenience over the following for those who don't understand remaps.
```bash
ros2 run tf2_tools view_frames --ros-args -r tf:=foo -r tf_static:=bar
```


**help text**
```bash
$ ros2 run tf2_tools view_frames -h
usage: view_frames [-h] [--wait-time WAIT_TIME] [-o OUTPUT] [--tf_topic TF_TOPIC] [--tf_static_topic TF_STATIC_TOPIC]

Create a diagram of the TF frames being broadcast over ROS

options:
  -h, --help            show this help message and exit
  --wait-time WAIT_TIME, -t WAIT_TIME
                        Listen to the /tf topic for this many seconds before rendering the frame tree
  -o OUTPUT, --output OUTPUT
                        Output filename
  --tf_topic TF_TOPIC   Topic for dynamic transforms
  --tf_static_topic TF_STATIC_TOPIC
                        Topic for static transforms
```
**Run the node**
```bash
$ ros2 run tf2_tools view_frames --tf_topic=/foo  --tf_static_topic=bar
[INFO] [1726288349.673591679] [view_frames]: Listening to tf data for 5.0 seconds...
[INFO] [1726288354.694076715] [view_frames]: Generating graph...
[INFO] [1726288354.694984295] [view_frames]: Result:tf2_msgs.srv.FrameGraph_Response(frame_yaml='[]')
[INFO] [1726288354.695316110] [view_frames]: Exporting graph in frames_2024-09-13_22.32.34.pdf file...
```

**Get it's node info while running to prove the topics are different**
```bash
$ ros2 node info /view_frames 
/view_frames
  Subscribers:
    /bar: tf2_msgs/msg/TFMessage
    /foo: tf2_msgs/msg/TFMessage
  Publishers:
    /parameter_events: rcl_interfaces/msg/ParameterEvent
    /rosout: rcl_interfaces/msg/Log
  Service Servers:
    /tf2_frames: tf2_msgs/srv/FrameGraph
    /view_frames/describe_parameters: rcl_interfaces/srv/DescribeParameters
    /view_frames/get_parameter_types: rcl_interfaces/srv/GetParameterTypes
    /view_frames/get_parameters: rcl_interfaces/srv/GetParameters
    /view_frames/list_parameters: rcl_interfaces/srv/ListParameters
    /view_frames/set_parameters: rcl_interfaces/srv/SetParameters
    /view_frames/set_parameters_atomically: rcl_interfaces/srv/SetParametersAtomically
  Service Clients:
    /tf2_frames: tf2_msgs/srv/FrameGraph
  Action Servers:

  Action Clients:
```