### PR TITLE
Adding NodeInterfaces API Design

### DIFF
--- a/test_tf2/test/test_buffer_server.cpp
+++ b/test_tf2/test/test_buffer_server.cpp
@@ -47,7 +47,7 @@ int main(int argc, char ** argv)
   auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock);
+  tf2_ros::Buffer buffer(clock, *node);
   tf2_ros::TransformListener tfl(buffer, node, false);
   std::unique_ptr<tf2_ros::BufferServer> server = std::make_unique<tf2_ros::BufferServer>(
     buffer,

--- a/test_tf2/test/test_buffer_server.cpp
+++ b/test_tf2/test/test_buffer_server.cpp
@@ -47,8 +47,8 @@ int main(int argc, char ** argv)
   auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock, *node);
-  tf2_ros::TransformListener tfl(buffer, node, false);
+  tf2_ros::Buffer buffer(clock);
+  tf2_ros::TransformListener tfl(buffer, *node, false);
   std::unique_ptr<tf2_ros::BufferServer> server = std::make_unique<tf2_ros::BufferServer>(
     buffer,
     node,

--- a/test_tf2/test/test_message_filter.cpp
+++ b/test_tf2/test/test_message_filter.cpp
@@ -79,12 +79,10 @@ public:
 TEST(MessageFilter, noTransforms)
 {
   auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
-  auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-    node->get_node_base_interface(),
-    node->get_node_timers_interface());
+  auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*node);
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock);
+  tf2_ros::Buffer buffer(clock, *node);
   buffer.setCreateTimerInterface(create_timer_interface);
   tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "frame1", 10, node);
   Notification n(1);
@@ -102,12 +100,10 @@ TEST(MessageFilter, noTransforms)
 TEST(MessageFilter, noTransformsSameFrame)
 {
   auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
-  auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-    node->get_node_base_interface(),
-    node->get_node_timers_interface());
+  auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*node);
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock);
+  tf2_ros::Buffer buffer(clock, *node);
   buffer.setCreateTimerInterface(create_timer_interface);
   tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "frame1", 10, node);
   Notification n(1);
@@ -145,12 +141,10 @@ geometry_msgs::msg::TransformStamped createTransform(
 TEST(MessageFilter, preexistingTransforms)
 {
   auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
-  auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-    node->get_node_base_interface(),
-    node->get_node_timers_interface());
+  auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*node);
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock);
+  tf2_ros::Buffer buffer(clock, *node);
   buffer.setCreateTimerInterface(create_timer_interface);
   tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "frame1", 10, node);
   Notification n(1);
@@ -176,12 +170,10 @@ TEST(MessageFilter, preexistingTransforms)
 TEST(MessageFilter, postTransforms)
 {
   auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
-  auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-    node->get_node_base_interface(),
-    node->get_node_timers_interface());
+  auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*node);
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock);
+  tf2_ros::Buffer buffer(clock, *node);
   buffer.setCreateTimerInterface(create_timer_interface);
   tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "frame1", 10, node);
   Notification n(1);
@@ -212,9 +204,7 @@ TEST(MessageFilter, concurrentTransforms)
   const int messages = 30;
   const int buffer_size = messages;
   auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
-  auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-    node->get_node_base_interface(),
-    node->get_node_timers_interface());
+  auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*node);
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
 
@@ -225,7 +215,7 @@ TEST(MessageFilter, concurrentTransforms)
   msg->header.stamp = stamp;
   msg->header.frame_id = "frame2";
 
-  tf2_ros::Buffer buffer(clock);
+  tf2_ros::Buffer buffer(clock, *node);
   for (int i = 0; i < 50; i++) {
     buffer.setCreateTimerInterface(create_timer_interface);
     tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "frame1", buffer_size,
@@ -294,12 +284,10 @@ TEST(MessageFilter, concurrentTransforms)
 TEST(MessageFilter, setTargetFrame)
 {
   auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
-  auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-    node->get_node_base_interface(),
-    node->get_node_timers_interface());
+  auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*node);
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock);
+  tf2_ros::Buffer buffer(clock, *node);
   buffer.setCreateTimerInterface(create_timer_interface);
   tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "frame1", 10, node);
   Notification n(1);
@@ -325,12 +313,10 @@ TEST(MessageFilter, setTargetFrame)
 TEST(MessageFilter, multipleTargetFrames)
 {
   auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
-  auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-    node->get_node_base_interface(),
-    node->get_node_timers_interface());
+  auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*node);
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock);
+  tf2_ros::Buffer buffer(clock, *node);
   buffer.setCreateTimerInterface(create_timer_interface);
   tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "", 10, node);
   Notification n(1);
@@ -366,12 +352,10 @@ TEST(MessageFilter, multipleTargetFrames)
 TEST(MessageFilter, tolerance)
 {
   auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
-  auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-    node->get_node_base_interface(),
-    node->get_node_timers_interface());
+  auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*node);
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock);
+  tf2_ros::Buffer buffer(clock, *node);
   buffer.setCreateTimerInterface(create_timer_interface);
   tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "frame1", 10, node);
   Notification n(1);
@@ -497,12 +481,10 @@ TEST(MessageFilter, tolerance)
 TEST(MessageFilter, checkStampPrecisionLoss)
 {
   auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
-  auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-    node->get_node_base_interface(),
-    node->get_node_timers_interface());
+  auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*node);
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock);
+  tf2_ros::Buffer buffer(clock, *node);
   buffer.setCreateTimerInterface(create_timer_interface);
   tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "frame1", 10, node);
   Notification n(1);

--- a/test_tf2/test/test_message_filter.cpp
+++ b/test_tf2/test/test_message_filter.cpp
@@ -82,9 +82,9 @@ TEST(MessageFilter, noTransforms)
   auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*node);
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock, *node);
+  tf2_ros::Buffer buffer(clock);
   buffer.setCreateTimerInterface(create_timer_interface);
-  tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "frame1", 10, node);
+  tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "frame1", 10, *node);
   Notification n(1);
   filter.registerCallback(std::bind(&Notification::notify, &n, std::placeholders::_1));
 
@@ -103,9 +103,9 @@ TEST(MessageFilter, noTransformsSameFrame)
   auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*node);
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock, *node);
+  tf2_ros::Buffer buffer(clock);
   buffer.setCreateTimerInterface(create_timer_interface);
-  tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "frame1", 10, node);
+  tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "frame1", 10, *node);
   Notification n(1);
   filter.registerCallback(std::bind(&Notification::notify, &n, std::placeholders::_1));
 
@@ -144,9 +144,9 @@ TEST(MessageFilter, preexistingTransforms)
   auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*node);
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock, *node);
+  tf2_ros::Buffer buffer(clock);
   buffer.setCreateTimerInterface(create_timer_interface);
-  tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "frame1", 10, node);
+  tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "frame1", 10, *node);
   Notification n(1);
 
   filter.registerCallback(std::bind(&Notification::notify, &n, std::placeholders::_1));
@@ -173,9 +173,9 @@ TEST(MessageFilter, postTransforms)
   auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*node);
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock, *node);
+  tf2_ros::Buffer buffer(clock);
   buffer.setCreateTimerInterface(create_timer_interface);
-  tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "frame1", 10, node);
+  tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "frame1", 10, *node);
   Notification n(1);
 
   filter.registerCallback(std::bind(&Notification::notify, &n, std::placeholders::_1));
@@ -215,11 +215,11 @@ TEST(MessageFilter, concurrentTransforms)
   msg->header.stamp = stamp;
   msg->header.frame_id = "frame2";
 
-  tf2_ros::Buffer buffer(clock, *node);
+  tf2_ros::Buffer buffer(clock);
   for (int i = 0; i < 50; i++) {
     buffer.setCreateTimerInterface(create_timer_interface);
     tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "frame1", buffer_size,
-      node);
+      *node);
     Notification n(1);
     filter.registerCallback(std::bind(&Notification::notify, &n, std::placeholders::_1));
 
@@ -287,9 +287,9 @@ TEST(MessageFilter, setTargetFrame)
   auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*node);
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock, *node);
+  tf2_ros::Buffer buffer(clock);
   buffer.setCreateTimerInterface(create_timer_interface);
-  tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "frame1", 10, node);
+  tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "frame1", 10, *node);
   Notification n(1);
   filter.registerCallback(std::bind(&Notification::notify, &n, std::placeholders::_1));
   filter.setTargetFrame("frame1000");
@@ -316,9 +316,9 @@ TEST(MessageFilter, multipleTargetFrames)
   auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*node);
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock, *node);
+  tf2_ros::Buffer buffer(clock);
   buffer.setCreateTimerInterface(create_timer_interface);
-  tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "", 10, node);
+  tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "", 10, *node);
   Notification n(1);
   filter.registerCallback(std::bind(&Notification::notify, &n, std::placeholders::_1));
 
@@ -355,9 +355,9 @@ TEST(MessageFilter, tolerance)
   auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*node);
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock, *node);
+  tf2_ros::Buffer buffer(clock);
   buffer.setCreateTimerInterface(create_timer_interface);
-  tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "frame1", 10, node);
+  tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "frame1", 10, *node);
   Notification n(1);
   filter.registerCallback(std::bind(&Notification::notify, &n, std::placeholders::_1));
 
@@ -484,9 +484,9 @@ TEST(MessageFilter, checkStampPrecisionLoss)
   auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*node);
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock, *node);
+  tf2_ros::Buffer buffer(clock);
   buffer.setCreateTimerInterface(create_timer_interface);
-  tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "frame1", 10, node);
+  tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "frame1", 10, *node);
   Notification n(1);
   filter.registerCallback(std::bind(&Notification::notify, &n, std::placeholders::_1));
   filter.setTargetFrame("frame1");

--- a/test_tf2/test/test_static_publisher.cpp
+++ b/test_tf2/test/test_static_publisher.cpp
@@ -53,7 +53,7 @@ TEST(StaticTransformPublisher, a_b_different_times)
   auto node = rclcpp::Node::make_shared("StaticTransformPublisher_a_b_different_times_test");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer mB(clock);
+  tf2_ros::Buffer mB(clock, *node);
   tf2_ros::TransformListener tfl(mB, node, false);
 
   rclcpp::executors::SingleThreadedExecutor executor;
@@ -88,7 +88,7 @@ TEST(StaticTransformPublisher, a_c_different_times)
   auto node = rclcpp::Node::make_shared("StaticTransformPublisher_a_c_different_times_test");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer mB(clock);
+  tf2_ros::Buffer mB(clock, *node);
   tf2_ros::TransformListener tfl(mB, node, false);
 
   rclcpp::executors::SingleThreadedExecutor executor;
@@ -122,7 +122,7 @@ TEST(StaticTransformPublisher, a_d_different_times)
   auto node = rclcpp::Node::make_shared("StaticTransformPublisher_a_d_different_times_test");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer mB(clock);
+  tf2_ros::Buffer mB(clock, *node);
   tf2_ros::TransformListener tfl(mB, node, false);
 
   rclcpp::executors::SingleThreadedExecutor executor;
@@ -173,7 +173,7 @@ TEST(StaticTransformPublisher, multiple_parent_test)
   auto node = rclcpp::Node::make_shared("StaticTransformPublisher_a_d_different_times_test");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer mB(clock);
+  tf2_ros::Buffer mB(clock, *node);
   tf2_ros::TransformListener tfl(mB, node, false);
 
   rclcpp::executors::SingleThreadedExecutor executor;

--- a/test_tf2/test/test_static_publisher.cpp
+++ b/test_tf2/test/test_static_publisher.cpp
@@ -53,8 +53,8 @@ TEST(StaticTransformPublisher, a_b_different_times)
   auto node = rclcpp::Node::make_shared("StaticTransformPublisher_a_b_different_times_test");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer mB(clock, *node);
-  tf2_ros::TransformListener tfl(mB, node, false);
+  tf2_ros::Buffer mB(clock);
+  tf2_ros::TransformListener tfl(mB, *node, false);
 
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(node);
@@ -88,8 +88,8 @@ TEST(StaticTransformPublisher, a_c_different_times)
   auto node = rclcpp::Node::make_shared("StaticTransformPublisher_a_c_different_times_test");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer mB(clock, *node);
-  tf2_ros::TransformListener tfl(mB, node, false);
+  tf2_ros::Buffer mB(clock);
+  tf2_ros::TransformListener tfl(mB, *node, false);
 
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(node);
@@ -122,8 +122,8 @@ TEST(StaticTransformPublisher, a_d_different_times)
   auto node = rclcpp::Node::make_shared("StaticTransformPublisher_a_d_different_times_test");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer mB(clock, *node);
-  tf2_ros::TransformListener tfl(mB, node, false);
+  tf2_ros::Buffer mB(clock);
+  tf2_ros::TransformListener tfl(mB, *node, false);
 
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(node);
@@ -173,8 +173,8 @@ TEST(StaticTransformPublisher, multiple_parent_test)
   auto node = rclcpp::Node::make_shared("StaticTransformPublisher_a_d_different_times_test");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer mB(clock, *node);
-  tf2_ros::TransformListener tfl(mB, node, false);
+  tf2_ros::Buffer mB(clock);
+  tf2_ros::TransformListener tfl(mB, *node, false);
 
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(node);
@@ -194,7 +194,7 @@ TEST(StaticTransformPublisher, multiple_parent_test)
     }
   }
 
-  tf2_ros::StaticTransformBroadcaster stb(node);
+  tf2_ros::StaticTransformBroadcaster stb(*node);
   geometry_msgs::msg::TransformStamped ts;
   ts.transform.rotation.w = 1;
   ts.header.frame_id = "c";

--- a/tf2_ros/CMakeLists.txt
+++ b/tf2_ros/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(rcl_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
 find_package(rclcpp_components REQUIRED)
+find_package(rcpputils REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_msgs REQUIRED)
 
@@ -40,6 +41,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   message_filters::message_filters
   rclcpp::rclcpp
   rclcpp_action::rclcpp_action
+  rcpputils::rcpputils
   tf2::tf2
   ${tf2_msgs_TARGETS})
 
@@ -236,6 +238,7 @@ ament_export_dependencies(
   message_filters
   rclcpp
   rclcpp_action
+  rcpputils
   tf2
   tf2_msgs
 )

--- a/tf2_ros/include/tf2_ros/buffer.hpp
+++ b/tf2_ros/include/tf2_ros/buffer.hpp
@@ -51,7 +51,10 @@
 #include "rclcpp/node_interfaces/get_node_base_interface.hpp"
 #include "rclcpp/node_interfaces/get_node_services_interface.hpp"
 #include "rclcpp/node_interfaces/get_node_logging_interface.hpp"
+#include "rclcpp/node_interfaces/node_base_interface.hpp"
+#include "rclcpp/node_interfaces/node_services_interface.hpp"
 #include "rclcpp/node_interfaces/node_logging_interface.hpp"
+#include "rclcpp/node_interfaces/node_interfaces.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 namespace tf2_ros
@@ -69,6 +72,22 @@ public:
   using tf2::BufferCore::lookupTransform;
   using tf2::BufferCore::canTransform;
   using SharedPtr = std::shared_ptr<tf2_ros::Buffer>;
+  
+  /** \brief  Constructor for a Buffer object
+   * \param clock A clock to use for time and sleeping
+   * \param cache_time How long to keep a history of transforms
+   * \param interfaces Advertise the view_frames service that exposes debugging information from the buffer, based on a set of node interfaces
+   * \param  qos If passed change the quality of service of the frames_server_ service
+   */
+  Buffer(
+    rclcpp::Clock::SharedPtr clock,
+    rclcpp::node_interfaces::NodeInterfaces<
+      rclcpp::node_interfaces::NodeBaseInterface,
+      rclcpp::node_interfaces::NodeLoggingInterface,
+      rclcpp::node_interfaces::NodeServicesInterface
+    > node_interfaces,
+    tf2::Duration cache_time = tf2::Duration(tf2::BUFFER_CORE_DEFAULT_CACHE_TIME),
+    const rclcpp::QoS & qos = rclcpp::ServicesQoS());
 
   /** \brief  Constructor for a Buffer object
    * \param clock A clock to use for time and sleeping
@@ -77,6 +96,7 @@ public:
    * \param  qos If passed change the quality of service of the frames_server_ service
    */
   template<typename NodeT = rclcpp::Node::SharedPtr>
+  [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of NoteT")]]
   Buffer(
     rclcpp::Clock::SharedPtr clock,
     tf2::Duration cache_time = tf2::Duration(tf2::BUFFER_CORE_DEFAULT_CACHE_TIME),
@@ -84,32 +104,7 @@ public:
     const rclcpp::QoS & qos = rclcpp::ServicesQoS())
   : BufferCore(cache_time), clock_(clock), timer_interface_(nullptr)
   {
-    if (nullptr == clock_) {
-      throw std::invalid_argument("clock must be a valid instance");
-    }
-
-    auto post_jump_cb = [this](const rcl_time_jump_t & jump_info) {onTimeJump(jump_info);};
-
-    rcl_jump_threshold_t jump_threshold;
-    // Disable forward jump callbacks
-    jump_threshold.min_forward.nanoseconds = 0;
-    // Anything backwards is a jump
-    jump_threshold.min_backward.nanoseconds = -1;
-    // Callback if the clock changes too
-    jump_threshold.on_clock_change = true;
-
-    jump_handler_ = clock_->create_jump_callback(nullptr, post_jump_cb, jump_threshold);
-
-    if (node) {
-      node_logging_interface_ = rclcpp::node_interfaces::get_node_logging_interface(node);
-
-      frames_server_ = rclcpp::create_service<tf2_msgs::srv::FrameGraph>(
-        rclcpp::node_interfaces::get_node_base_interface(node),
-        rclcpp::node_interfaces::get_node_services_interface(node),
-        "tf2_frames", std::bind(
-          &Buffer::getFrames, this, std::placeholders::_1,
-          std::placeholders::_2), qos, nullptr);
-    }
+    Buffer(clock, *node, cache_time, qos);
   }
 
   /** \brief Get the transform between two frames by frame ID.
@@ -331,6 +326,13 @@ private:
 
   /// \brief A clock to use for time and sleeping
   rclcpp::Clock::SharedPtr clock_;
+
+  /// \brief A set of interface to access the buffer's node
+  rclcpp::node_interfaces::NodeInterfaces<
+    rclcpp::node_interfaces::NodeBaseInterface,
+    rclcpp::node_interfaces::NodeLoggingInterface,
+    rclcpp::node_interfaces::NodeServicesInterface
+  > node_interfaces_;
 
   /// \brief A node logging interface to access the buffer node's logger
   rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_interface_;

--- a/tf2_ros/include/tf2_ros/buffer.hpp
+++ b/tf2_ros/include/tf2_ros/buffer.hpp
@@ -86,6 +86,7 @@ public:
    * \param interfaces If passed advertise the view_frames service that exposes debugging information from the buffer, based on a set of node interfaces
    * \param  qos If passed change the quality of service of the frames_server_ service
    */
+  TF2_ROS_PUBLIC
   Buffer(
     rclcpp::Clock::SharedPtr clock,
     tf2::Duration cache_time = tf2::Duration(tf2::BUFFER_CORE_DEFAULT_CACHE_TIME),

--- a/tf2_ros/include/tf2_ros/buffer.hpp
+++ b/tf2_ros/include/tf2_ros/buffer.hpp
@@ -36,6 +36,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <unordered_map>
 
@@ -78,7 +79,6 @@ public:
   using NodeServicesInterface = rclcpp::node_interfaces::NodeServicesInterface;
   using RequiredInterfaces = rclcpp::node_interfaces::NodeInterfaces<NodeBaseInterface,
       NodeLoggingInterface, NodeServicesInterface>;
-
 
   /** \brief  Constructor for a Buffer object
    * \param clock A clock to use for time and sleeping

--- a/tf2_ros/include/tf2_ros/buffer.hpp
+++ b/tf2_ros/include/tf2_ros/buffer.hpp
@@ -72,21 +72,24 @@ public:
   using tf2::BufferCore::lookupTransform;
   using tf2::BufferCore::canTransform;
   using SharedPtr = std::shared_ptr<tf2_ros::Buffer>;
-  
+
+  using NodeBaseInterface = rclcpp::node_interfaces::NodeBaseInterface;
+  using NodeLoggingInterface = rclcpp::node_interfaces::NodeLoggingInterface;
+  using NodeServicesInterface = rclcpp::node_interfaces::NodeServicesInterface;
+  using RequiredInterfaces = rclcpp::node_interfaces::NodeInterfaces<NodeBaseInterface,
+      NodeLoggingInterface, NodeServicesInterface>;
+
+
   /** \brief  Constructor for a Buffer object
    * \param clock A clock to use for time and sleeping
    * \param cache_time How long to keep a history of transforms
-   * \param interfaces Advertise the view_frames service that exposes debugging information from the buffer, based on a set of node interfaces
+   * \param interfaces If passed advertise the view_frames service that exposes debugging information from the buffer, based on a set of node interfaces
    * \param  qos If passed change the quality of service of the frames_server_ service
    */
   Buffer(
     rclcpp::Clock::SharedPtr clock,
-    rclcpp::node_interfaces::NodeInterfaces<
-      rclcpp::node_interfaces::NodeBaseInterface,
-      rclcpp::node_interfaces::NodeLoggingInterface,
-      rclcpp::node_interfaces::NodeServicesInterface
-    > node_interfaces,
     tf2::Duration cache_time = tf2::Duration(tf2::BUFFER_CORE_DEFAULT_CACHE_TIME),
+    RequiredInterfaces node_interfaces = RequiredInterfaces(),
     const rclcpp::QoS & qos = rclcpp::ServicesQoS());
 
   /** \brief  Constructor for a Buffer object
@@ -95,16 +98,16 @@ public:
    * \param node If passed advertise the view_frames service that exposes debugging information from the buffer
    * \param  qos If passed change the quality of service of the frames_server_ service
    */
-  template<typename NodeT = rclcpp::Node::SharedPtr>
+  template<class NodeT = rclcpp::Node::SharedPtr, class AllocatorT = std::allocator<void>,
+    std::enable_if_t<rcpputils::is_pointer<NodeT>::value, bool> = true>
   [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of NoteT")]]
   Buffer(
     rclcpp::Clock::SharedPtr clock,
     tf2::Duration cache_time = tf2::Duration(tf2::BUFFER_CORE_DEFAULT_CACHE_TIME),
     NodeT && node = NodeT(),
     const rclcpp::QoS & qos = rclcpp::ServicesQoS())
-  : BufferCore(cache_time), clock_(clock), timer_interface_(nullptr)
+  : Buffer(clock, cache_time, *node, qos)
   {
-    Buffer(clock, *node, cache_time, qos);
   }
 
   /** \brief Get the transform between two frames by frame ID.
@@ -328,14 +331,10 @@ private:
   rclcpp::Clock::SharedPtr clock_;
 
   /// \brief A set of interface to access the buffer's node
-  rclcpp::node_interfaces::NodeInterfaces<
-    rclcpp::node_interfaces::NodeBaseInterface,
-    rclcpp::node_interfaces::NodeLoggingInterface,
-    rclcpp::node_interfaces::NodeServicesInterface
-  > node_interfaces_;
+  RequiredInterfaces node_interfaces_;
 
   /// \brief A node logging interface to access the buffer node's logger
-  rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_interface_;
+  NodeLoggingInterface::SharedPtr node_logging_interface_;
 
   /// \brief Interface for creating timers
   CreateTimerInterface::SharedPtr timer_interface_;

--- a/tf2_ros/include/tf2_ros/create_timer_ros.hpp
+++ b/tf2_ros/include/tf2_ros/create_timer_ros.hpp
@@ -39,6 +39,8 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/node_interfaces/node_interfaces.hpp"
+#include "rclcpp/node_interfaces/get_node_base_interface.hpp"
+#include "rclcpp/node_interfaces/get_node_timers_interface.hpp"
 
 namespace tf2_ros
 {
@@ -51,17 +53,20 @@ namespace tf2_ros
 class CreateTimerROS : public CreateTimerInterface
 {
 public:
+  using NodeBaseInterface = rclcpp::node_interfaces::NodeBaseInterface;
+  using NodeTimersInterface = rclcpp::node_interfaces::NodeTimersInterface;
+  using RequiredInterfaces = rclcpp::node_interfaces::NodeInterfaces<NodeBaseInterface,
+      NodeTimersInterface>;
+
   CreateTimerROS(
-    rclcpp::node_interfaces::NodeInterfaces<
-      rclcpp::node_interfaces::NodeBaseInterface,
-      rclcpp::node_interfaces::NodeTimersInterface> node_interfaces,
+    RequiredInterfaces node_interfaces,
     rclcpp::CallbackGroup::SharedPtr callback_group = nullptr);
 
   [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of multiple interfaces")]]
   TF2_ROS_PUBLIC
   CreateTimerROS(
-    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
-    rclcpp::node_interfaces::NodeTimersInterface::SharedPtr node_timers,
+    NodeBaseInterface::SharedPtr node_base,
+    NodeTimersInterface::SharedPtr node_timers,
     rclcpp::CallbackGroup::SharedPtr callback_group = nullptr);
 
   virtual ~CreateTimerROS() = default;
@@ -127,9 +132,7 @@ private:
     const TimerHandle & timer_handle,
     TimerCallbackType callback);
 
-  rclcpp::node_interfaces::NodeInterfaces<
-    rclcpp::node_interfaces::NodeBaseInterface,
-    rclcpp::node_interfaces::NodeTimersInterface> node_interfaces_;
+  RequiredInterfaces node_interfaces_;
   TimerHandle next_timer_handle_index_;
   std::unordered_map<TimerHandle, rclcpp::TimerBase::SharedPtr> timers_map_;
   std::mutex timers_map_mutex_;

--- a/tf2_ros/include/tf2_ros/create_timer_ros.hpp
+++ b/tf2_ros/include/tf2_ros/create_timer_ros.hpp
@@ -58,6 +58,7 @@ public:
   using RequiredInterfaces = rclcpp::node_interfaces::NodeInterfaces<NodeBaseInterface,
       NodeTimersInterface>;
 
+  TF2_ROS_PUBLIC
   CreateTimerROS(
     RequiredInterfaces node_interfaces,
     rclcpp::CallbackGroup::SharedPtr callback_group = nullptr);

--- a/tf2_ros/include/tf2_ros/create_timer_ros.hpp
+++ b/tf2_ros/include/tf2_ros/create_timer_ros.hpp
@@ -38,6 +38,7 @@
 #include "tf2/time.hpp"
 
 #include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node_interfaces/node_interfaces.hpp"
 
 namespace tf2_ros
 {
@@ -50,6 +51,13 @@ namespace tf2_ros
 class CreateTimerROS : public CreateTimerInterface
 {
 public:
+  CreateTimerROS(
+    rclcpp::node_interfaces::NodeInterfaces<
+      rclcpp::node_interfaces::NodeBaseInterface,
+      rclcpp::node_interfaces::NodeTimersInterface> node_interfaces,
+    rclcpp::CallbackGroup::SharedPtr callback_group = nullptr);
+
+  [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of multiple interfaces")]]
   TF2_ROS_PUBLIC
   CreateTimerROS(
     rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
@@ -119,8 +127,9 @@ private:
     const TimerHandle & timer_handle,
     TimerCallbackType callback);
 
-  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_;
-  rclcpp::node_interfaces::NodeTimersInterface::SharedPtr node_timers_;
+  rclcpp::node_interfaces::NodeInterfaces<
+    rclcpp::node_interfaces::NodeBaseInterface,
+    rclcpp::node_interfaces::NodeTimersInterface> node_interfaces_;
   TimerHandle next_timer_handle_index_;
   std::unordered_map<TimerHandle, rclcpp::TimerBase::SharedPtr> timers_map_;
   std::mutex timers_map_mutex_;

--- a/tf2_ros/include/tf2_ros/message_filter.hpp
+++ b/tf2_ros/include/tf2_ros/message_filter.hpp
@@ -57,6 +57,7 @@
 
 #include "builtin_interfaces/msg/time.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node_interfaces/node_interfaces.hpp"
 
 #define TF2_ROS_MESSAGEFILTER_DEBUG(fmt, ...) \
   RCUTILS_LOG_DEBUG_NAMED( \
@@ -158,18 +159,21 @@ public:
    * \param buffer The buffer this filter should use
    * \param target_frame The frame this filter should attempt to transform to.  To use multiple frames, pass an empty string here and use the setTargetFrames() function.
    * \param queue_size The number of messages to queue up before throwing away old ones.  0 means infinite (dangerous).
-   * \param node The ros2 node to use for logging and clock operations
+   * \param node_interfaces The ros2 NodeInterfaces to use for logging and clock operations
    * \param buffer_timeout The timeout duration after requesting transforms from the buffer.
    */
   template<typename TimeRepT = int64_t, typename TimeT = std::nano>
   MessageFilter(
     BufferT & buffer, const std::string & target_frame, uint32_t queue_size,
-    const rclcpp::Node::SharedPtr & node,
+    rclcpp::node_interfaces::NodeInterfaces<
+      rclcpp::node_interfaces::NodeLoggingInterface,
+      rclcpp::node_interfaces::NodeClockInterface> node_interfaces,
     std::chrono::duration<TimeRepT, TimeT> buffer_timeout =
     std::chrono::duration<TimeRepT, TimeT>::max())
-  : MessageFilter(
-      buffer, target_frame, queue_size, node->get_node_logging_interface(),
-      node->get_node_clock_interface(), buffer_timeout)
+  : node_interfaces_(std::move(node_interfaces)),
+    buffer_(buffer),
+    queue_size_(queue_size),
+    buffer_timeout_(buffer_timeout)
   {
     static_assert(
       std::is_base_of<tf2::BufferCoreInterface, BufferT>::value,
@@ -177,6 +181,64 @@ public:
     static_assert(
       std::is_base_of<tf2_ros::AsyncBufferInterface, BufferT>::value,
       "Buffer type must implement tf2_ros::AsyncBufferInterface");
+    
+    init();
+    setTargetFrame(target_frame);
+  }
+
+  /**
+   * \brief Constructor
+   *
+   * \param f The filter to connect this filter's input to.  Often will be a message_filters::Subscriber.
+   * \param buffer The buffer this filter should use
+   * \param target_frame The frame this filter should attempt to transform to.  To use multiple frames, pass an empty string here and use the setTargetFrames() function.
+   * \param queue_size The number of messages to queue up before throwing away old ones.  0 means infinite (dangerous).
+   * \param node_interfaces The ros2 NodeInterfaces to use for logging and clock operations
+   * \param buffer_timeout The timeout duration after requesting transforms from the buffer.
+   */
+  template<class F, typename TimeRepT = int64_t, typename TimeT = std::nano>
+  MessageFilter(
+    F & f, BufferT & buffer, const std::string & target_frame, uint32_t queue_size,
+    rclcpp::node_interfaces::NodeInterfaces<
+      rclcpp::node_interfaces::NodeLoggingInterface,
+      rclcpp::node_interfaces::NodeClockInterface> node_interfaces,
+    std::chrono::duration<TimeRepT, TimeT> buffer_timeout =
+    std::chrono::duration<TimeRepT, TimeT>::max())
+  : node_interfaces_(std::move(node_interfaces)),
+    buffer_(buffer),
+    queue_size_(queue_size),
+    buffer_timeout_(buffer_timeout)
+  {
+    init();
+    setTargetFrame(target_frame);
+    connectInput(f);
+  }
+  
+  /**
+   * \brief Constructor
+   *
+   * \param buffer The buffer this filter should use
+   * \param target_frame The frame this filter should attempt to transform to.  To use multiple frames, pass an empty string here and use the setTargetFrames() function.
+   * \param queue_size The number of messages to queue up before throwing away old ones.  0 means infinite (dangerous).
+   * \param node The ros2 node to use for logging and clock operations
+   * \param buffer_timeout The timeout duration after requesting transforms from the buffer.
+   */
+  template<typename TimeRepT = int64_t, typename TimeT = std::nano>
+  [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of Node::SharedPtr&")]]
+  MessageFilter(
+    BufferT & buffer, const std::string & target_frame, uint32_t queue_size,
+    const rclcpp::Node::SharedPtr & node,
+    std::chrono::duration<TimeRepT, TimeT> buffer_timeout =
+    std::chrono::duration<TimeRepT, TimeT>::max())
+  : MessageFilter(
+      buffer, target_frame, queue_size,
+      rclcpp::node_interfaces::NodeInterfaces<
+        rclcpp::node_interfaces::NodeLoggingInterface,
+        rclcpp::node_interfaces::NodeClockInterface>(
+                                node->get_node_logging_interface()
+                                node->get_node_clock_interface()),
+      buffer_timeout)
+  {
   }
 
   /**
@@ -190,20 +252,20 @@ public:
    * \param buffer_timeout The timeout duration after requesting transforms from the buffer.
    */
   template<typename TimeRepT = int64_t, typename TimeT = std::nano>
+  [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of multiple interfaces")]]
   MessageFilter(
     BufferT & buffer, const std::string & target_frame, uint32_t queue_size,
     const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr & node_logging,
     const rclcpp::node_interfaces::NodeClockInterface::SharedPtr & node_clock,
     std::chrono::duration<TimeRepT, TimeT> buffer_timeout =
     std::chrono::duration<TimeRepT, TimeT>::max())
-  : node_logging_(node_logging),
-    node_clock_(node_clock),
-    buffer_(buffer),
-    queue_size_(queue_size),
-    buffer_timeout_(buffer_timeout)
+  : MessageFilter(
+      buffer, target_frame, queue_size,
+      rclcpp::node_interfaces::NodeInterfaces<
+        rclcpp::node_interfaces::NodeLoggingInterface,
+        rclcpp::node_interfaces::NodeClockInterface>(node_logging, node_clock),
+      buffer_timeout)
   {
-    init();
-    setTargetFrame(target_frame);
   }
 
   /**
@@ -217,14 +279,20 @@ public:
    * \param buffer_timeout The timeout duration after requesting transforms from the buffer.
    */
   template<class F, typename TimeRepT = int64_t, typename TimeT = std::nano>
+  [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of Node::SharedPtr&")]]
   MessageFilter(
     F & f, BufferT & buffer, const std::string & target_frame, uint32_t queue_size,
     const rclcpp::Node::SharedPtr & node,
     std::chrono::duration<TimeRepT, TimeT> buffer_timeout =
     std::chrono::duration<TimeRepT, TimeT>::max())
   : MessageFilter(
-      f, buffer, target_frame, queue_size, node->get_node_logging_interface(),
-      node->get_node_clock_interface(), buffer_timeout)
+      f, buffer, target_frame, queue_size,
+      rclcpp::node_interfaces::NodeInterfaces<
+        rclcpp::node_interfaces::NodeLoggingInterface,
+        rclcpp::node_interfaces::NodeClockInterface>(
+                                node->get_node_logging_interface()
+                                node->get_node_clock_interface()),
+      buffer_timeout)
   {
   }
 
@@ -240,21 +308,20 @@ public:
    * \param buffer_timeout The timeout duration after requesting transforms from the buffer.
    */
   template<class F, typename TimeRepT = int64_t, typename TimeT = std::nano>
+  [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of multiple interfaces")]]
   MessageFilter(
     F & f, BufferT & buffer, const std::string & target_frame, uint32_t queue_size,
     const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr & node_logging,
     const rclcpp::node_interfaces::NodeClockInterface::SharedPtr & node_clock,
     std::chrono::duration<TimeRepT, TimeT> buffer_timeout =
     std::chrono::duration<TimeRepT, TimeT>::max())
-  : node_logging_(node_logging),
-    node_clock_(node_clock),
-    buffer_(buffer),
-    queue_size_(queue_size),
-    buffer_timeout_(buffer_timeout)
+  : MessageFilter(
+      f, buffer, target_frame, queue_size,
+      rclcpp::node_interfaces::NodeInterfaces<
+        rclcpp::node_interfaces::NodeLoggingInterface,
+        rclcpp::node_interfaces::NodeClockInterface>(node_logging, node_clock),
+      buffer_timeout)
   {
-    init();
-    setTargetFrame(target_frame);
-    connectInput(f);
   }
 
   /**
@@ -461,7 +528,7 @@ public:
    */
   void add(const MConstPtr & message)
   {
-    auto t = node_clock_->get_clock()->now();
+    auto t = node_interfaces_.get_node_clock_interface()->now();
     add(MEvent(message, t));
   }
 
@@ -611,10 +678,11 @@ private:
   void checkFailures()
   {
     if (!next_failure_warning_.nanoseconds()) {
-      next_failure_warning_ = node_clock_->get_clock()->now() + rclcpp::Duration(15, 0);
+      next_failure_warning_ = node_interfaces_.get_node_clock_interface()->now() +
+        rclcpp::Duration(15, 0);
     }
 
-    if (node_clock_->get_clock()->now() >= next_failure_warning_) {
+    if (node_interfaces_.get_node_clock_interfaecs()->now() >= next_failure_warning_) {
       if (incoming_message_count_ - messages_.size() == 0) {
         return;
       }
@@ -627,7 +695,8 @@ private:
           "[tf2_ros_message_filter.message_notifier] rosconsole logger to DEBUG for more "
           "information.",
           dropped_pct * 100);
-        next_failure_warning_ = node_clock_->get_clock()->now() + rclcpp::Duration(60, 0);
+        next_failure_warning_ = node_interfaces_.get_node_clock_interface()->now() + 
+          rclcpp::Duration(60, 0);
 
         if (static_cast<double>(failed_out_the_back_count_) /
           static_cast<double>(dropped_message_count_) > 0.5)
@@ -709,7 +778,7 @@ private:
     std::string frame_id = stripSlash(mt::FrameId<M>::value(*message));
     rclcpp::Time stamp = mt::TimeStamp<M>::value(*message);
     RCLCPP_INFO(
-      node_logging_->get_logger(),
+      node_interfaces_.get_node_logging_interface->get_logger(),
       "Message Filter dropping message: frame '%s' at time %.3f for reason '%s'",
       frame_id.c_str(), stamp.seconds(), get_filter_failure_reason_string(reason).c_str());
   }
@@ -725,10 +794,10 @@ private:
     return in;
   }
 
-  ///< The node logging interface to use for any log messages
-  const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_;
-  ///< The node clock interface to use to get the clock to use
-  const rclcpp::node_interfaces::NodeClockInterface::SharedPtr node_clock_;
+  ///< The interfaces (logging and clock) to use to get the log messages and clock.
+  rclcpp::node_interfaces::NodeInterfaces<
+    rclcpp::node_interfaces::NodeLoggingInterface,
+    rclcpp::node_interfaces::NodeClockInterface> node_interfaces_;
   ///< The Transformer used to determine if transformation data is available
   BufferT & buffer_;
   ///< The frames we need to be able to transform to before a message is ready

--- a/tf2_ros/include/tf2_ros/message_filter.hpp
+++ b/tf2_ros/include/tf2_ros/message_filter.hpp
@@ -58,6 +58,8 @@
 #include "builtin_interfaces/msg/time.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/node_interfaces/node_interfaces.hpp"
+#include "rclcpp/node_interfaces/get_node_logging_interface.hpp"
+#include "rclcpp/node_interfaces/get_node_clock_interface.hpp"
 
 #define TF2_ROS_MESSAGEFILTER_DEBUG(fmt, ...) \
   RCUTILS_LOG_DEBUG_NAMED( \
@@ -153,6 +155,11 @@ public:
   using MConstPtr = std::shared_ptr<M const>;
   typedef message_filters::MessageEvent<M const> MEvent;
 
+  using NodeLoggingInterface = rclcpp::node_interfaces::NodeLoggingInterface;
+  using NodeClockInterface = rclcpp::node_interfaces::NodeClockInterface;
+  using RequiredInterfaces = rclcpp::node_interfaces::NodeInterfaces<NodeLoggingInterface,
+      NodeClockInterface>;
+
   /**
    * \brief Constructor
    *
@@ -165,9 +172,7 @@ public:
   template<typename TimeRepT = int64_t, typename TimeT = std::nano>
   MessageFilter(
     BufferT & buffer, const std::string & target_frame, uint32_t queue_size,
-    rclcpp::node_interfaces::NodeInterfaces<
-      rclcpp::node_interfaces::NodeLoggingInterface,
-      rclcpp::node_interfaces::NodeClockInterface> node_interfaces,
+    RequiredInterfaces node_interfaces,
     std::chrono::duration<TimeRepT, TimeT> buffer_timeout =
     std::chrono::duration<TimeRepT, TimeT>::max())
   : node_interfaces_(std::move(node_interfaces)),
@@ -181,7 +186,7 @@ public:
     static_assert(
       std::is_base_of<tf2_ros::AsyncBufferInterface, BufferT>::value,
       "Buffer type must implement tf2_ros::AsyncBufferInterface");
-    
+
     init();
     setTargetFrame(target_frame);
   }
@@ -199,9 +204,7 @@ public:
   template<class F, typename TimeRepT = int64_t, typename TimeT = std::nano>
   MessageFilter(
     F & f, BufferT & buffer, const std::string & target_frame, uint32_t queue_size,
-    rclcpp::node_interfaces::NodeInterfaces<
-      rclcpp::node_interfaces::NodeLoggingInterface,
-      rclcpp::node_interfaces::NodeClockInterface> node_interfaces,
+    RequiredInterfaces node_interfaces,
     std::chrono::duration<TimeRepT, TimeT> buffer_timeout =
     std::chrono::duration<TimeRepT, TimeT>::max())
   : node_interfaces_(std::move(node_interfaces)),
@@ -213,7 +216,7 @@ public:
     setTargetFrame(target_frame);
     connectInput(f);
   }
-  
+
   /**
    * \brief Constructor
    *
@@ -232,11 +235,7 @@ public:
     std::chrono::duration<TimeRepT, TimeT>::max())
   : MessageFilter(
       buffer, target_frame, queue_size,
-      rclcpp::node_interfaces::NodeInterfaces<
-        rclcpp::node_interfaces::NodeLoggingInterface,
-        rclcpp::node_interfaces::NodeClockInterface>(
-                                node->get_node_logging_interface()
-                                node->get_node_clock_interface()),
+      RequiredInterfaces(node->get_node_logging_interface(), node->get_node_clock_interface()),
       buffer_timeout)
   {
   }
@@ -255,16 +254,13 @@ public:
   [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of multiple interfaces")]]
   MessageFilter(
     BufferT & buffer, const std::string & target_frame, uint32_t queue_size,
-    const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr & node_logging,
-    const rclcpp::node_interfaces::NodeClockInterface::SharedPtr & node_clock,
+    const NodeLoggingInterface::SharedPtr & node_logging,
+    const NodeClockInterface::SharedPtr & node_clock,
     std::chrono::duration<TimeRepT, TimeT> buffer_timeout =
     std::chrono::duration<TimeRepT, TimeT>::max())
   : MessageFilter(
       buffer, target_frame, queue_size,
-      rclcpp::node_interfaces::NodeInterfaces<
-        rclcpp::node_interfaces::NodeLoggingInterface,
-        rclcpp::node_interfaces::NodeClockInterface>(node_logging, node_clock),
-      buffer_timeout)
+      RequiredInterfaces(node_logging, node_clock), buffer_timeout)
   {
   }
 
@@ -287,11 +283,7 @@ public:
     std::chrono::duration<TimeRepT, TimeT>::max())
   : MessageFilter(
       f, buffer, target_frame, queue_size,
-      rclcpp::node_interfaces::NodeInterfaces<
-        rclcpp::node_interfaces::NodeLoggingInterface,
-        rclcpp::node_interfaces::NodeClockInterface>(
-                                node->get_node_logging_interface()
-                                node->get_node_clock_interface()),
+      RequiredInterfaces(node->get_node_logging_interface(), node->get_node_clock_interface()),
       buffer_timeout)
   {
   }
@@ -311,16 +303,13 @@ public:
   [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of multiple interfaces")]]
   MessageFilter(
     F & f, BufferT & buffer, const std::string & target_frame, uint32_t queue_size,
-    const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr & node_logging,
-    const rclcpp::node_interfaces::NodeClockInterface::SharedPtr & node_clock,
+    const NodeLoggingInterface::SharedPtr & node_logging,
+    const NodeClockInterface::SharedPtr & node_clock,
     std::chrono::duration<TimeRepT, TimeT> buffer_timeout =
     std::chrono::duration<TimeRepT, TimeT>::max())
   : MessageFilter(
       f, buffer, target_frame, queue_size,
-      rclcpp::node_interfaces::NodeInterfaces<
-        rclcpp::node_interfaces::NodeLoggingInterface,
-        rclcpp::node_interfaces::NodeClockInterface>(node_logging, node_clock),
-      buffer_timeout)
+      RequiredInterfaces(node_logging, node_clock), buffer_timeout)
   {
   }
 
@@ -528,7 +517,7 @@ public:
    */
   void add(const MConstPtr & message)
   {
-    auto t = node_interfaces_.get_node_clock_interface()->now();
+    auto t = node_interfaces_.get_node_clock_interface()->get_clock()->now();
     add(MEvent(message, t));
   }
 
@@ -678,11 +667,11 @@ private:
   void checkFailures()
   {
     if (!next_failure_warning_.nanoseconds()) {
-      next_failure_warning_ = node_interfaces_.get_node_clock_interface()->now() +
+      next_failure_warning_ = node_interfaces_.get_node_clock_interface()->get_clock()->now() +
         rclcpp::Duration(15, 0);
     }
 
-    if (node_interfaces_.get_node_clock_interfaecs()->now() >= next_failure_warning_) {
+    if (node_interfaces_.get_node_clock_interface()->get_clock()->now() >= next_failure_warning_) {
       if (incoming_message_count_ - messages_.size() == 0) {
         return;
       }
@@ -695,7 +684,7 @@ private:
           "[tf2_ros_message_filter.message_notifier] rosconsole logger to DEBUG for more "
           "information.",
           dropped_pct * 100);
-        next_failure_warning_ = node_interfaces_.get_node_clock_interface()->now() + 
+        next_failure_warning_ = node_interfaces_.get_node_clock_interface()->get_clock()->now() +
           rclcpp::Duration(60, 0);
 
         if (static_cast<double>(failed_out_the_back_count_) /
@@ -778,7 +767,7 @@ private:
     std::string frame_id = stripSlash(mt::FrameId<M>::value(*message));
     rclcpp::Time stamp = mt::TimeStamp<M>::value(*message);
     RCLCPP_INFO(
-      node_interfaces_.get_node_logging_interface->get_logger(),
+      node_interfaces_.get_node_logging_interface()->get_logger(),
       "Message Filter dropping message: frame '%s' at time %.3f for reason '%s'",
       frame_id.c_str(), stamp.seconds(), get_filter_failure_reason_string(reason).c_str());
   }
@@ -795,9 +784,7 @@ private:
   }
 
   ///< The interfaces (logging and clock) to use to get the log messages and clock.
-  rclcpp::node_interfaces::NodeInterfaces<
-    rclcpp::node_interfaces::NodeLoggingInterface,
-    rclcpp::node_interfaces::NodeClockInterface> node_interfaces_;
+  RequiredInterfaces node_interfaces_;
   ///< The Transformer used to determine if transformation data is available
   BufferT & buffer_;
   ///< The frames we need to be able to transform to before a message is ready

--- a/tf2_ros/include/tf2_ros/message_filter.hpp
+++ b/tf2_ros/include/tf2_ros/message_filter.hpp
@@ -34,6 +34,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
 #include <functional>
 #include <list>
 #include <memory>

--- a/tf2_ros/include/tf2_ros/static_transform_broadcaster.hpp
+++ b/tf2_ros/include/tf2_ros/static_transform_broadcaster.hpp
@@ -40,6 +40,7 @@
 
 #include "rclcpp/node_interfaces/get_node_parameters_interface.hpp"
 #include "rclcpp/node_interfaces/get_node_topics_interface.hpp"
+#include "rclcpp/node_interfaces/node_interfaces.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "tf2_msgs/msg/tf_message.hpp"
@@ -55,8 +56,32 @@ namespace tf2_ros
 class StaticTransformBroadcaster
 {
 public:
+  /** \brief NodeInterfaces constructor */
+  template<class AllocatorT = std::allocator<void>>
+  StaticTransformBroadcaster(
+    rclcpp::node_interfaces::NodeInterfaces<
+      rclcpp::node_interfaces::NodeParametersInterface,
+      rclcpp::node_interfaces::NodeTopicsInterface> node_interfaces,
+    const rclcpp::QoS & qos = StaticBroadcasterQoS(),
+    const rclcpp::PublisherOptionsWithAllocator<AllocatorT> & options = [] () {
+      rclcpp::PublisherOptionsWithAllocator<AllocatorT> options;
+      options.qos_overriding_options = rclcpp::QosOverridingOptions{
+        rclcpp::QosPolicyKind::Depth,
+        rclcpp::QosPolicyKind::History,
+        rclcpp::QosPolicyKind::Reliability};
+      return options;
+    } ())
+  {
+    auto node_parameters = node_interfaces.get_node_parameters_interface();
+    auto node_topics = node_interfaces.get_node_topics_interface();
+
+    publisher_ = rclcpp::create_publisher<tf2_msgs::msg::tfmessage>(
+      node_parameters, node_topics, "/tf_static", qos, options);
+  }
+
   /** \brief Node constructor */
   template<class NodeT, class AllocatorT = std::allocator<void>>
+  [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of NodeT")]]
   StaticTransformBroadcaster(
     NodeT && node,
     const rclcpp::QoS & qos = StaticBroadcasterQoS(),
@@ -69,14 +94,17 @@ public:
       return options;
     } ())
     : StaticTransformBroadcaster(
-      rclcpp::node_interfaces::get_node_parameters_interface(node),
-      rclcpp::node_interfaces::get_node_topics_interface(node),
-      qos,
-      options)
-  {}
+      rclcpp::node_interfaces::NodeInterfaces<
+        rclcpp::node_interfaces::NodeParametersInterface,
+        rclcpp::node_interfaces::NodeTopicsInterface>(
+          node->get_node_parameters_interface(), 
+          node->get_node_topics_interface()), qos, options)
+  {
+  }
 
   /** \brief Node interfaces constructor */
   template<class AllocatorT = std::allocator<void>>
+  [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of multiple interfaces")]]
   StaticTransformBroadcaster(
     rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
     rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics,
@@ -89,9 +117,12 @@ public:
         rclcpp::QosPolicyKind::Reliability};
       return options;
     } ())
+    : StaticTransformBroadcaster(
+      rclcpp::node_interfaces::NodeInterfaces<
+        rclcpp::node_interfaces::NodeParametersInterface,
+        rclcpp::node_interfaces::NodeTopicsInterface>(
+          node_parameters, node_topics), qos, options)
   {
-    publisher_ = rclcpp::create_publisher<tf2_msgs::msg::TFMessage>(
-      node_parameters, node_topics, "/tf_static", qos, options);
   }
 
   /** \brief Send a TransformStamped message

--- a/tf2_ros/include/tf2_ros/static_transform_broadcaster.hpp
+++ b/tf2_ros/include/tf2_ros/static_transform_broadcaster.hpp
@@ -38,10 +38,11 @@
 
 #include "tf2_ros/visibility_control.hpp"
 
+#include "rclcpp/node_interfaces/node_interfaces.hpp"
 #include "rclcpp/node_interfaces/get_node_parameters_interface.hpp"
 #include "rclcpp/node_interfaces/get_node_topics_interface.hpp"
-#include "rclcpp/node_interfaces/node_interfaces.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "rcpputils/pointer_traits.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "tf2_msgs/msg/tf_message.hpp"
 #include "tf2_ros/qos.hpp"
@@ -52,16 +53,18 @@ namespace tf2_ros
 /** \brief This class provides an easy way to publish coordinate frame transform information.
  * It will handle all the messaging and stuffing of messages.  And the function prototypes lay out all the
  * necessary data needed for each message.  */
-
 class StaticTransformBroadcaster
 {
 public:
+  using NodeParametersInterface = rclcpp::node_interfaces::NodeParametersInterface;
+  using NodeTopicsInterface = rclcpp::node_interfaces::NodeTopicsInterface;
+  using RequiredInterfaces = rclcpp::node_interfaces::NodeInterfaces<NodeParametersInterface,
+      NodeTopicsInterface>;
+
   /** \brief NodeInterfaces constructor */
   template<class AllocatorT = std::allocator<void>>
   StaticTransformBroadcaster(
-    rclcpp::node_interfaces::NodeInterfaces<
-      rclcpp::node_interfaces::NodeParametersInterface,
-      rclcpp::node_interfaces::NodeTopicsInterface> node_interfaces,
+    RequiredInterfaces node_interfaces,
     const rclcpp::QoS & qos = StaticBroadcasterQoS(),
     const rclcpp::PublisherOptionsWithAllocator<AllocatorT> & options = [] () {
       rclcpp::PublisherOptionsWithAllocator<AllocatorT> options;
@@ -75,12 +78,13 @@ public:
     auto node_parameters = node_interfaces.get_node_parameters_interface();
     auto node_topics = node_interfaces.get_node_topics_interface();
 
-    publisher_ = rclcpp::create_publisher<tf2_msgs::msg::tfmessage>(
+    publisher_ = rclcpp::create_publisher<tf2_msgs::msg::TFMessage>(
       node_parameters, node_topics, "/tf_static", qos, options);
   }
 
   /** \brief Node constructor */
-  template<class NodeT, class AllocatorT = std::allocator<void>>
+  template<class NodeT, class AllocatorT = std::allocator<void>,
+    std::enable_if_t<rcpputils::is_pointer<NodeT>::value, bool> = true>
   [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of NodeT")]]
   StaticTransformBroadcaster(
     NodeT && node,
@@ -94,11 +98,8 @@ public:
       return options;
     } ())
     : StaticTransformBroadcaster(
-      rclcpp::node_interfaces::NodeInterfaces<
-        rclcpp::node_interfaces::NodeParametersInterface,
-        rclcpp::node_interfaces::NodeTopicsInterface>(
-          node->get_node_parameters_interface(), 
-          node->get_node_topics_interface()), qos, options)
+      RequiredInterfaces(node->get_node_parameters_interface(),
+      node->get_node_topics_interface()), qos, options)
   {
   }
 
@@ -106,8 +107,8 @@ public:
   template<class AllocatorT = std::allocator<void>>
   [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of multiple interfaces")]]
   StaticTransformBroadcaster(
-    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
-    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics,
+    NodeParametersInterface::SharedPtr node_parameters,
+    NodeTopicsInterface::SharedPtr node_topics,
     const rclcpp::QoS & qos = StaticBroadcasterQoS(),
     const rclcpp::PublisherOptionsWithAllocator<AllocatorT> & options = [] () {
       rclcpp::PublisherOptionsWithAllocator<AllocatorT> options;
@@ -118,10 +119,7 @@ public:
       return options;
     } ())
     : StaticTransformBroadcaster(
-      rclcpp::node_interfaces::NodeInterfaces<
-        rclcpp::node_interfaces::NodeParametersInterface,
-        rclcpp::node_interfaces::NodeTopicsInterface>(
-          node_parameters, node_topics), qos, options)
+      RequiredInterfaces(node_parameters, node_topics), qos, options)
   {
   }
 

--- a/tf2_ros/include/tf2_ros/static_transform_broadcaster.hpp
+++ b/tf2_ros/include/tf2_ros/static_transform_broadcaster.hpp
@@ -34,6 +34,7 @@
 #define TF2_ROS__STATIC_TRANSFORM_BROADCASTER_HPP_
 
 #include <memory>
+#include <type_traits>
 #include <vector>
 
 #include "tf2_ros/visibility_control.hpp"

--- a/tf2_ros/include/tf2_ros/transform_broadcaster.hpp
+++ b/tf2_ros/include/tf2_ros/transform_broadcaster.hpp
@@ -38,10 +38,11 @@
 
 #include "tf2_ros/visibility_control.hpp"
 
+#include "rclcpp/node_interfaces/node_interfaces.hpp"
 #include "rclcpp/node_interfaces/get_node_parameters_interface.hpp"
 #include "rclcpp/node_interfaces/get_node_topics_interface.hpp"
-#include "rclcpp/node_interfaces/node_interfaces.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "rcpputils/pointer_traits.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "tf2_msgs/msg/tf_message.hpp"
 #include "tf2_ros/qos.hpp"
@@ -56,12 +57,15 @@ namespace tf2_ros
 class TransformBroadcaster
 {
 public:
+  using NodeParametersInterface = rclcpp::node_interfaces::NodeParametersInterface;
+  using NodeTopicsInterface = rclcpp::node_interfaces::NodeTopicsInterface;
+  using RequiredInterfaces = rclcpp::node_interfaces::NodeInterfaces<NodeParametersInterface,
+      NodeTopicsInterface>;
+
   /** \brief Node interfaces constructor */
   template<class AllocatorT = std::allocator<void>>
   TransformBroadcaster(
-    rclcpp::node_interfaces::NodeInterfaces<
-      rclcpp::node_interfaces::NodeParametersInterface,
-      rclcpp::node_interfaces::NodeTopicsInterface> node_interfaces,
+    RequiredInterfaces node_interfaces,
     const rclcpp::QoS & qos = DynamicBroadcasterQoS(),
     const rclcpp::PublisherOptionsWithAllocator<AllocatorT> & options = [] () {
       rclcpp::PublisherOptionsWithAllocator<AllocatorT> options;
@@ -81,7 +85,8 @@ public:
   }
 
   /** \brief Node constructor */
-  template<class NodeT, class AllocatorT = std::allocator<void>>
+  template<class NodeT, class AllocatorT = std::allocator<void>,
+    std::enable_if_t<rcpputils::is_pointer<NodeT>::value, bool> = true>
   [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of NodeT")]]
   TransformBroadcaster(
     NodeT && node,
@@ -96,19 +101,17 @@ public:
       return options;
     } ())
     : TransformBroadcaster(
-      rclcpp::node_interfaces::NodeInterfaces<
-        rclcpp::node_interfaces::NodeParametersInterface,
-        rclcpp::node_interfaces::NodeTopicsInterface>(
-          node->get_node_parameters_interface(), 
-          node->get_node_topics_interface()), qos, options)
-  {}
+      RequiredInterfaces(node->get_node_parameters_interface(),
+      node->get_node_topics_interface()), qos, options)
+  {
+  }
 
   /** \brief Node interfaces constructor */
   template<class AllocatorT = std::allocator<void>>
   [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of multiple interfaces")]]
   TransformBroadcaster(
-    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
-    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics,
+    NodeParametersInterface::SharedPtr node_parameters,
+    NodeTopicsInterface::SharedPtr node_topics,
     const rclcpp::QoS & qos = DynamicBroadcasterQoS(),
     const rclcpp::PublisherOptionsWithAllocator<AllocatorT> & options = [] () {
       rclcpp::PublisherOptionsWithAllocator<AllocatorT> options;
@@ -119,11 +122,7 @@ public:
         rclcpp::QosPolicyKind::Reliability};
       return options;
     } ())
-    : TransformBroadcaster(
-      rclcpp::node_interfaces::NodeInterfaces<
-        rclcpp::node_interfaces::NodeParametersInterface,
-        rclcpp::node_interfaces::NodeTopicsInterface>(
-          node_parameters, node_topics), qos, options)
+    : TransformBroadcaster(RequiredInterfaces(node_parameters, node_topics), qos, options)
   {
   }
 

--- a/tf2_ros/include/tf2_ros/transform_broadcaster.hpp
+++ b/tf2_ros/include/tf2_ros/transform_broadcaster.hpp
@@ -40,6 +40,7 @@
 
 #include "rclcpp/node_interfaces/get_node_parameters_interface.hpp"
 #include "rclcpp/node_interfaces/get_node_topics_interface.hpp"
+#include "rclcpp/node_interfaces/node_interfaces.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "tf2_msgs/msg/tf_message.hpp"
@@ -55,8 +56,33 @@ namespace tf2_ros
 class TransformBroadcaster
 {
 public:
+  /** \brief Node interfaces constructor */
+  template<class AllocatorT = std::allocator<void>>
+  TransformBroadcaster(
+    rclcpp::node_interfaces::NodeInterfaces<
+      rclcpp::node_interfaces::NodeParametersInterface,
+      rclcpp::node_interfaces::NodeTopicsInterface> node_interfaces,
+    const rclcpp::QoS & qos = DynamicBroadcasterQoS(),
+    const rclcpp::PublisherOptionsWithAllocator<AllocatorT> & options = [] () {
+      rclcpp::PublisherOptionsWithAllocator<AllocatorT> options;
+      options.qos_overriding_options = rclcpp::QosOverridingOptions{
+        rclcpp::QosPolicyKind::Depth,
+        rclcpp::QosPolicyKind::Durability,
+        rclcpp::QosPolicyKind::History,
+        rclcpp::QosPolicyKind::Reliability};
+      return options;
+    } ())
+  {
+    auto node_parameters = node_interfaces.get_node_parameters_interface();
+    auto node_topics = node_interfaces.get_node_topics_interface();
+
+    publisher_ = rclcpp::create_publisher<tf2_msgs::msg::TFMessage>(
+      node_parameters, node_topics, "/tf", qos, options);
+  }
+
   /** \brief Node constructor */
   template<class NodeT, class AllocatorT = std::allocator<void>>
+  [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of NodeT")]]
   TransformBroadcaster(
     NodeT && node,
     const rclcpp::QoS & qos = DynamicBroadcasterQoS(),
@@ -70,14 +96,16 @@ public:
       return options;
     } ())
     : TransformBroadcaster(
-      rclcpp::node_interfaces::get_node_parameters_interface(node),
-      rclcpp::node_interfaces::get_node_topics_interface(node),
-      qos,
-      options)
+      rclcpp::node_interfaces::NodeInterfaces<
+        rclcpp::node_interfaces::NodeParametersInterface,
+        rclcpp::node_interfaces::NodeTopicsInterface>(
+          node->get_node_parameters_interface(), 
+          node->get_node_topics_interface()), qos, options)
   {}
 
   /** \brief Node interfaces constructor */
   template<class AllocatorT = std::allocator<void>>
+  [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of multiple interfaces")]]
   TransformBroadcaster(
     rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
     rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics,
@@ -91,9 +119,12 @@ public:
         rclcpp::QosPolicyKind::Reliability};
       return options;
     } ())
+    : TransformBroadcaster(
+      rclcpp::node_interfaces::NodeInterfaces<
+        rclcpp::node_interfaces::NodeParametersInterface,
+        rclcpp::node_interfaces::NodeTopicsInterface>(
+          node_parameters, node_topics), qos, options)
   {
-    publisher_ = rclcpp::create_publisher<tf2_msgs::msg::TFMessage>(
-      node_parameters, node_topics, "/tf", qos, options);
   }
 
   /** \brief Send a TransformStamped message

--- a/tf2_ros/include/tf2_ros/transform_broadcaster.hpp
+++ b/tf2_ros/include/tf2_ros/transform_broadcaster.hpp
@@ -34,6 +34,7 @@
 #define TF2_ROS__TRANSFORM_BROADCASTER_HPP_
 
 #include <memory>
+#include <type_traits>
 #include <vector>
 
 #include "tf2_ros/visibility_control.hpp"

--- a/tf2_ros/include/tf2_ros/transform_listener.hpp
+++ b/tf2_ros/include/tf2_ros/transform_listener.hpp
@@ -34,6 +34,7 @@
 
 #include <functional>
 #include <memory>
+#include <type_traits>
 #include <thread>
 #include <utility>
 
@@ -43,7 +44,12 @@
 
 #include "tf2_msgs/msg/tf_message.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "rcpputils/pointer_traits.hpp"
 #include "rclcpp/node_interfaces/node_interfaces.hpp"
+#include "rclcpp/node_interfaces/get_node_base_interface.hpp"
+#include "rclcpp/node_interfaces/get_node_logging_interface.hpp"
+#include "rclcpp/node_interfaces/get_node_parameters_interface.hpp"
+#include "rclcpp/node_interfaces/get_node_topics_interface.hpp"
 
 #include "tf2_ros/qos.hpp"
 
@@ -76,6 +82,7 @@ get_default_transform_listener_static_sub_options()
     rclcpp::QosPolicyKind::Reliability};
   return options;
 }
+
 }  // namespace detail
 
 /** \brief This class provides an easy way to request and receive coordinate frame transform information.
@@ -83,6 +90,13 @@ get_default_transform_listener_static_sub_options()
 class TransformListener
 {
 public:
+  using NodeBaseInterface = rclcpp::node_interfaces::NodeBaseInterface;
+  using NodeLoggingInterface = rclcpp::node_interfaces::NodeLoggingInterface;
+  using NodeParametersInterface = rclcpp::node_interfaces::NodeParametersInterface;
+  using NodeTopicsInterface = rclcpp::node_interfaces::NodeTopicsInterface;
+  using RequiredInterfaces = rclcpp::node_interfaces::NodeInterfaces<NodeBaseInterface,
+      NodeLoggingInterface, NodeParametersInterface, NodeTopicsInterface>;
+
   /** \brief Simplified constructor for transform listener.
    *
    * This constructor will create a new ROS 2 node under the hood.
@@ -94,16 +108,12 @@ public:
     tf2::BufferCore & buffer,
     bool spin_thread = true,
     bool static_only = false);
-  
+
   /** \brief NodeInterfaces constructor */
   template<class AllocatorT = std::allocator<void>>
   TransformListener(
     tf2::BufferCore & buffer,
-    rclcpp::node_interfaces::NodeInterfaces<
-      rclcpp::node_interfaces::NodeBaseInterface,
-      rclcpp::node_interfaces::NodeLoggingInterface,
-      rclcpp::node_interfaces::NodeParametersInterface,
-      rclcpp::node_interfaces::NodeTopicsInterface> node_interfaces,
+    RequiredInterfaces node_interfaces,
     bool spin_thread = true,
     const rclcpp::QoS & qos = DynamicListenerQoS(),
     const rclcpp::QoS & static_qos = StaticListenerQoS(),
@@ -125,7 +135,8 @@ public:
   }
 
   /** \brief Node constructor */
-  template<class NodeT, class AllocatorT = std::allocator<void>>
+  template<class NodeT, class AllocatorT = std::allocator<void>,
+    std::enable_if_t<rcpputils::is_pointer<NodeT>::value, bool> = true>
   [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of NodeT")]]
   TransformListener(
     tf2::BufferCore & buffer,
@@ -140,15 +151,8 @@ public:
     bool static_only = false)
   : TransformListener(
       buffer,
-      rclcpp::node_interfaces::NodeInterfaces<
-        rclcpp::node_interfaces::NodeBaseInterface,
-        rclcpp::node_interfaces::NodeLoggingInterface,
-        rclcpp::node_interfaces::NodeParametersInterface,
-        rclcpp::node_interfaces::NodeTopicsInterface> node_interfaces(
-          node->get_node_base_interface(),
-          node->get_node_logging_interface(),
-          node->get_node_parameters_interface(),
-          node->get_node_topics_interface()),
+      RequiredInterfaces(node->get_node_base_interface(), node->get_node_logging_interface(),
+      node->get_node_parameters_interface(), node->get_node_topics_interface()),
       spin_thread,
       qos,
       static_qos,
@@ -163,10 +167,10 @@ public:
   [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of multiple interfaces")]]
   TransformListener(
     tf2::BufferCore & buffer,
-    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
-    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
-    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
-    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics,
+    NodeBaseInterface::SharedPtr node_base,
+    NodeLoggingInterface::SharedPtr node_logging,
+    NodeParametersInterface::SharedPtr node_parameters,
+    NodeTopicsInterface::SharedPtr node_topics,
     bool spin_thread = true,
     const rclcpp::QoS & qos = DynamicListenerQoS(),
     const rclcpp::QoS & static_qos = StaticListenerQoS(),
@@ -177,15 +181,7 @@ public:
     bool static_only = false)
   : TransformListener(
       buffer,
-      rclcpp::node_interfaces::NodeInterfaces<
-        rclcpp::node_interfaces::NodeBaseInterface,
-        rclcpp::node_interfaces::NodeLoggingInterface,
-        rclcpp::node_interfaces::NodeParametersInterface,
-        rclcpp::node_interfaces::NodeTopicsInterface> node_interfaces(
-          node_base,
-          node_logging,
-          node_parameters,
-          node_topics),
+      RequiredInterfaces(node_base, node_logging, node_parameters, node_topics),
       spin_thread,
       qos,
       static_qos,
@@ -205,11 +201,7 @@ public:
 private:
   template<class AllocatorT = std::allocator<void>>
   void init(
-    rclcpp::node_interfaces::NodeInterfaces<
-      rclcpp::node_interfaces::NodeBaseInterface,
-      rclcpp::node_interfaces::NodeLoggingInterface,
-      rclcpp::node_interfaces::NodeParametersInterface,
-      rclcpp::node_interfaces::NodeTopicsInterface> node_interfaces,
+    RequiredInterfaces node_interfaces,
     bool spin_thread,
     const rclcpp::QoS & qos,
     const rclcpp::QoS & static_qos,
@@ -219,6 +211,9 @@ private:
   {
     spin_thread_ = spin_thread;
     node_interfaces_ = std::move(node_interfaces);
+
+    auto node_parameters = node_interfaces_.get_node_parameters_interface();
+    auto node_topics = node_interfaces_.get_node_topics_interface();
 
     using callback_t = std::function<void (tf2_msgs::msg::TFMessage::ConstSharedPtr)>;
     callback_t cb = std::bind(
@@ -237,8 +232,7 @@ private:
         tf_options.callback_group = callback_group_;
 
         message_subscription_tf_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
-          node_interfaces_.get_node_parameters_interface(),
-          node_interfaces_.get_node_topics_interface(),
+          node_parameters, node_topics,
           "/tf", qos, std::move(cb), tf_options);
       }
 
@@ -246,8 +240,7 @@ private:
       tf_static_options.callback_group = callback_group_;
 
       message_subscription_tf_static_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
-        node_interfaces_.get_node_parameters_interface(),
-        node_interfaces_.get_node_topics_interface(),
+        node_parameters, node_topics,
         "/tf_static",
         static_qos,
         std::move(static_cb),
@@ -262,13 +255,11 @@ private:
     } else {
       if (!static_only) {
         message_subscription_tf_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
-          node_interfaces_.get_node_parameters_interface(),
-          node_interfaces_.get_node_topics_interface(),
+          node_parameters, node_topics,
           "/tf", qos, std::move(cb), options);
       }
       message_subscription_tf_static_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
-        node_interfaces_.get_node_parameters_interface(),
-        node_interfaces_.get_node_topics_interface(),
+        node_parameters, node_topics,
         "/tf_static",
         static_qos,
         std::move(static_cb),
@@ -287,11 +278,7 @@ private:
     message_subscription_tf_static_ {nullptr};
   tf2::BufferCore & buffer_;
   tf2::TimePoint last_update_;
-    rclcpp::node_interfaces::NodeInterfaces<
-      rclcpp::node_interfaces::NodeBaseInterface,
-      rclcpp::node_interfaces::NodeLoggingInterface,
-      rclcpp::node_interfaces::NodeParametersInterface,
-      rclcpp::node_interfaces::NodeTopicsInterface> node_interfaces;
+  RequiredInterfaces node_interfaces_;
   rclcpp::CallbackGroup::SharedPtr callback_group_{nullptr};
 };
 
@@ -303,6 +290,13 @@ private:
 class StaticTransformListener : public TransformListener
 {
 public:
+  using NodeBaseInterface = rclcpp::node_interfaces::NodeBaseInterface;
+  using NodeLoggingInterface = rclcpp::node_interfaces::NodeLoggingInterface;
+  using NodeParametersInterface = rclcpp::node_interfaces::NodeParametersInterface;
+  using NodeTopicsInterface = rclcpp::node_interfaces::NodeTopicsInterface;
+  using RequiredInterfaces = rclcpp::node_interfaces::NodeInterfaces<NodeBaseInterface,
+      NodeLoggingInterface, NodeParametersInterface, NodeTopicsInterface>;
+
   /** \brief Simplified constructor for a static transform listener
    * \see the simplified TransformListener documentation
    */
@@ -311,16 +305,12 @@ public:
   : TransformListener(buffer, spin_thread, true)
   {
   }
-  
+
   /** \brief NodeInterfaces constructor */
   template<class AllocatorT = std::allocator<void>>
   StaticTransformListener(
     tf2::BufferCore & buffer,
-    rclcpp::node_interfaces::NodeInterfaces<
-      rclcpp::node_interfaces::NodeBaseInterface,
-      rclcpp::node_interfaces::NodeLoggingInterface,
-      rclcpp::node_interfaces::NodeParametersInterface,
-      rclcpp::node_interfaces::NodeTopicsInterface> node_interfaces;
+    RequiredInterfaces node_interfaces,
     bool spin_thread = true,
     const rclcpp::QoS & static_qos = StaticListenerQoS(),
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options =
@@ -338,7 +328,8 @@ public:
   }
 
   /** \brief Node constructor */
-  template<class NodeT, class AllocatorT = std::allocator<void>>
+  template<class NodeT, class AllocatorT = std::allocator<void>,
+    std::enable_if_t<rcpputils::is_pointer<NodeT>::value, bool> = true>
   [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of NodeT")]]
   StaticTransformListener(
     tf2::BufferCore & buffer,
@@ -349,15 +340,8 @@ public:
     detail::get_default_transform_listener_static_sub_options<AllocatorT>())
   : TransformListener(
       buffer,
-      rclcpp::node_interfaces::NodeInterfaces<
-        rclcpp::node_interfaces::NodeBaseInterface,
-        rclcpp::node_interfaces::NodeLoggingInterface,
-        rclcpp::node_interfaces::NodeParametersInterface,
-        rclcpp::node_interfaces::NodeTopicsInterface> node_interfaces(
-          node->get_node_base_interface(),
-          node->get_node_logging_interface(),
-          node->get_node_parameters_interface(),
-          node->get_node_topics_interface()),
+      RequiredInterfaces(node->get_node_base_interface(), node->get_node_logging_interface(),
+      node->get_node_parameters_interface(), node->get_node_topics_interface()),
       spin_thread,
       rclcpp::QoS(1),
       static_qos,
@@ -372,25 +356,17 @@ public:
   [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of multiple interfaces")]]
   StaticTransformListener(
     tf2::BufferCore & buffer,
-    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
-    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
-    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
-    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics,
+    NodeBaseInterface::SharedPtr node_base,
+    NodeLoggingInterface::SharedPtr node_logging,
+    NodeParametersInterface::SharedPtr node_parameters,
+    NodeTopicsInterface::SharedPtr node_topics,
     bool spin_thread = true,
     const rclcpp::QoS & static_qos = StaticListenerQoS(),
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options =
     detail::get_default_transform_listener_static_sub_options<AllocatorT>())
   : TransformListener(
       buffer,
-      rclcpp::node_interfaces::NodeInterfaces<
-        rclcpp::node_interfaces::NodeBaseInterface,
-        rclcpp::node_interfaces::NodeLoggingInterface,
-        rclcpp::node_interfaces::NodeParametersInterface,
-        rclcpp::node_interfaces::NodeTopicsInterface> node_interfaces(
-          node_base,
-          node_logging,
-          node_parameters,
-          node_topics),
+      RequiredInterfaces(node_base, node_logging, node_parameters, node_topics),
       spin_thread,
       rclcpp::QoS(1),
       static_qos,

--- a/tf2_ros/include/tf2_ros/transform_listener.hpp
+++ b/tf2_ros/include/tf2_ros/transform_listener.hpp
@@ -82,7 +82,6 @@ get_default_transform_listener_static_sub_options()
     rclcpp::QosPolicyKind::Reliability};
   return options;
 }
-
 }  // namespace detail
 
 /** \brief This class provides an easy way to request and receive coordinate frame transform information.

--- a/tf2_ros/include/tf2_ros/transform_listener.hpp
+++ b/tf2_ros/include/tf2_ros/transform_listener.hpp
@@ -43,6 +43,7 @@
 
 #include "tf2_msgs/msg/tf_message.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node_interfaces/node_interfaces.hpp"
 
 #include "tf2_ros/qos.hpp"
 
@@ -93,9 +94,39 @@ public:
     tf2::BufferCore & buffer,
     bool spin_thread = true,
     bool static_only = false);
+  
+  /** \brief NodeInterfaces constructor */
+  template<class AllocatorT = std::allocator<void>>
+  TransformListener(
+    tf2::BufferCore & buffer,
+    rclcpp::node_interfaces::NodeInterfaces<
+      rclcpp::node_interfaces::NodeBaseInterface,
+      rclcpp::node_interfaces::NodeLoggingInterface,
+      rclcpp::node_interfaces::NodeParametersInterface,
+      rclcpp::node_interfaces::NodeTopicsInterface> node_interfaces,
+    bool spin_thread = true,
+    const rclcpp::QoS & qos = DynamicListenerQoS(),
+    const rclcpp::QoS & static_qos = StaticListenerQoS(),
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options =
+    detail::get_default_transform_listener_sub_options<AllocatorT>(),
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options =
+    detail::get_default_transform_listener_static_sub_options<AllocatorT>(),
+    bool static_only = false)
+  : buffer_(buffer)
+  {
+    init(
+      node_interfaces,
+      spin_thread,
+      qos,
+      static_qos,
+      options,
+      static_options,
+      static_only);
+  }
 
   /** \brief Node constructor */
   template<class NodeT, class AllocatorT = std::allocator<void>>
+  [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of NodeT")]]
   TransformListener(
     tf2::BufferCore & buffer,
     NodeT && node,
@@ -109,20 +140,27 @@ public:
     bool static_only = false)
   : TransformListener(
       buffer,
-      node->get_node_base_interface(),
-      node->get_node_logging_interface(),
-      node->get_node_parameters_interface(),
-      node->get_node_topics_interface(),
+      rclcpp::node_interfaces::NodeInterfaces<
+        rclcpp::node_interfaces::NodeBaseInterface,
+        rclcpp::node_interfaces::NodeLoggingInterface,
+        rclcpp::node_interfaces::NodeParametersInterface,
+        rclcpp::node_interfaces::NodeTopicsInterface> node_interfaces(
+          node->get_node_base_interface(),
+          node->get_node_logging_interface(),
+          node->get_node_parameters_interface(),
+          node->get_node_topics_interface()),
       spin_thread,
       qos,
       static_qos,
       options,
       static_options,
       static_only)
-  {}
+  {
+  }
 
   /** \brief Node interface constructor */
   template<class AllocatorT = std::allocator<void>>
+  [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of multiple interfaces")]]
   TransformListener(
     tf2::BufferCore & buffer,
     rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
@@ -137,19 +175,24 @@ public:
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options =
     detail::get_default_transform_listener_static_sub_options<AllocatorT>(),
     bool static_only = false)
-  : buffer_(buffer)
-  {
-    init(
-      node_base,
-      node_logging,
-      node_parameters,
-      node_topics,
+  : TransformListener(
+      buffer,
+      rclcpp::node_interfaces::NodeInterfaces<
+        rclcpp::node_interfaces::NodeBaseInterface,
+        rclcpp::node_interfaces::NodeLoggingInterface,
+        rclcpp::node_interfaces::NodeParametersInterface,
+        rclcpp::node_interfaces::NodeTopicsInterface> node_interfaces(
+          node_base,
+          node_logging,
+          node_parameters,
+          node_topics),
       spin_thread,
       qos,
       static_qos,
       options,
       static_options,
-      static_only);
+      static_only)
+  {
   }
 
   TF2_ROS_PUBLIC
@@ -162,10 +205,11 @@ public:
 private:
   template<class AllocatorT = std::allocator<void>>
   void init(
-    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
-    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
-    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
-    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics,
+    rclcpp::node_interfaces::NodeInterfaces<
+      rclcpp::node_interfaces::NodeBaseInterface,
+      rclcpp::node_interfaces::NodeLoggingInterface,
+      rclcpp::node_interfaces::NodeParametersInterface,
+      rclcpp::node_interfaces::NodeTopicsInterface> node_interfaces,
     bool spin_thread,
     const rclcpp::QoS & qos,
     const rclcpp::QoS & static_qos,
@@ -174,8 +218,7 @@ private:
     bool static_only = false)
   {
     spin_thread_ = spin_thread;
-    node_base_interface_ = node_base;
-    node_logging_interface_ = node_logging;
+    node_interfaces_ = std::move(node_interfaces);
 
     using callback_t = std::function<void (tf2_msgs::msg::TFMessage::ConstSharedPtr)>;
     callback_t cb = std::bind(
@@ -185,7 +228,7 @@ private:
 
     if (spin_thread_) {
       // Create new callback group for message_subscription of tf and tf_static
-      callback_group_ = node_base_interface_->create_callback_group(
+      callback_group_ = node_interfaces_.get_node_base_interface()->create_callback_group(
         rclcpp::CallbackGroupType::MutuallyExclusive, false);
 
       if (!static_only) {
@@ -194,15 +237,17 @@ private:
         tf_options.callback_group = callback_group_;
 
         message_subscription_tf_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
-          node_parameters, node_topics, "/tf", qos, std::move(cb), tf_options);
+          node_interfaces_.get_node_parameters_interface(),
+          node_interfaces_.get_node_topics_interface(),
+          "/tf", qos, std::move(cb), tf_options);
       }
 
       rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> tf_static_options = static_options;
       tf_static_options.callback_group = callback_group_;
 
       message_subscription_tf_static_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
-        node_parameters,
-        node_topics,
+        node_interfaces_.get_node_parameters_interface(),
+        node_interfaces_.get_node_topics_interface(),
         "/tf_static",
         static_qos,
         std::move(static_cb),
@@ -210,18 +255,20 @@ private:
 
       // Create executor with dedicated thread to spin.
       executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
-      executor_->add_callback_group(callback_group_, node_base_interface_);
+      executor_->add_callback_group(callback_group_, node_interfaces_.get_node_base_interface());
       dedicated_listener_thread_ = std::make_unique<std::thread>([&]() {executor_->spin();});
       // Tell the buffer we have a dedicated thread to enable timeouts
       buffer_.setUsingDedicatedThread(true);
     } else {
       if (!static_only) {
         message_subscription_tf_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
-          node_parameters, node_topics, "/tf", qos, std::move(cb), options);
+          node_interfaces_.get_node_parameters_interface(),
+          node_interfaces_.get_node_topics_interface(),
+          "/tf", qos, std::move(cb), options);
       }
       message_subscription_tf_static_ = rclcpp::create_subscription<tf2_msgs::msg::TFMessage>(
-        node_parameters,
-        node_topics,
+        node_interfaces_.get_node_parameters_interface(),
+        node_interfaces_.get_node_topics_interface(),
         "/tf_static",
         static_qos,
         std::move(static_cb),
@@ -240,8 +287,11 @@ private:
     message_subscription_tf_static_ {nullptr};
   tf2::BufferCore & buffer_;
   tf2::TimePoint last_update_;
-  rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_interface_ {nullptr};
-  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface_ {nullptr};
+    rclcpp::node_interfaces::NodeInterfaces<
+      rclcpp::node_interfaces::NodeBaseInterface,
+      rclcpp::node_interfaces::NodeLoggingInterface,
+      rclcpp::node_interfaces::NodeParametersInterface,
+      rclcpp::node_interfaces::NodeTopicsInterface> node_interfaces;
   rclcpp::CallbackGroup::SharedPtr callback_group_{nullptr};
 };
 
@@ -261,9 +311,35 @@ public:
   : TransformListener(buffer, spin_thread, true)
   {
   }
+  
+  /** \brief NodeInterfaces constructor */
+  template<class AllocatorT = std::allocator<void>>
+  StaticTransformListener(
+    tf2::BufferCore & buffer,
+    rclcpp::node_interfaces::NodeInterfaces<
+      rclcpp::node_interfaces::NodeBaseInterface,
+      rclcpp::node_interfaces::NodeLoggingInterface,
+      rclcpp::node_interfaces::NodeParametersInterface,
+      rclcpp::node_interfaces::NodeTopicsInterface> node_interfaces;
+    bool spin_thread = true,
+    const rclcpp::QoS & static_qos = StaticListenerQoS(),
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & static_options =
+    detail::get_default_transform_listener_static_sub_options<AllocatorT>())
+  : TransformListener(
+      buffer,
+      node_interfaces,
+      spin_thread,
+      rclcpp::QoS(1),
+      static_qos,
+      rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>(),
+      static_options,
+      true)
+  {
+  }
 
   /** \brief Node constructor */
   template<class NodeT, class AllocatorT = std::allocator<void>>
+  [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of NodeT")]]
   StaticTransformListener(
     tf2::BufferCore & buffer,
     NodeT && node,
@@ -273,7 +349,15 @@ public:
     detail::get_default_transform_listener_static_sub_options<AllocatorT>())
   : TransformListener(
       buffer,
-      node,
+      rclcpp::node_interfaces::NodeInterfaces<
+        rclcpp::node_interfaces::NodeBaseInterface,
+        rclcpp::node_interfaces::NodeLoggingInterface,
+        rclcpp::node_interfaces::NodeParametersInterface,
+        rclcpp::node_interfaces::NodeTopicsInterface> node_interfaces(
+          node->get_node_base_interface(),
+          node->get_node_logging_interface(),
+          node->get_node_parameters_interface(),
+          node->get_node_topics_interface()),
       spin_thread,
       rclcpp::QoS(1),
       static_qos,
@@ -285,6 +369,7 @@ public:
 
   /** \brief Node interface constructor */
   template<class AllocatorT = std::allocator<void>>
+  [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of multiple interfaces")]]
   StaticTransformListener(
     tf2::BufferCore & buffer,
     rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
@@ -297,10 +382,15 @@ public:
     detail::get_default_transform_listener_static_sub_options<AllocatorT>())
   : TransformListener(
       buffer,
-      node_base,
-      node_logging,
-      node_parameters,
-      node_topics,
+      rclcpp::node_interfaces::NodeInterfaces<
+        rclcpp::node_interfaces::NodeBaseInterface,
+        rclcpp::node_interfaces::NodeLoggingInterface,
+        rclcpp::node_interfaces::NodeParametersInterface,
+        rclcpp::node_interfaces::NodeTopicsInterface> node_interfaces(
+          node_base,
+          node_logging,
+          node_parameters,
+          node_topics),
       spin_thread,
       rclcpp::QoS(1),
       static_qos,

--- a/tf2_ros/package.xml
+++ b/tf2_ros/package.xml
@@ -24,6 +24,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_action</depend>
   <depend>rclcpp_components</depend>
+  <depend>rcpputils</depend>
   <depend>tf2</depend>
   <depend>tf2_msgs</depend>
 

--- a/tf2_ros/src/buffer.cpp
+++ b/tf2_ros/src/buffer.cpp
@@ -33,6 +33,7 @@
 #include "tf2_ros/buffer.hpp"
 
 #include <exception>
+#include <functional>
 #include <limits>
 #include <memory>
 #include <mutex>

--- a/tf2_ros/src/buffer.cpp
+++ b/tf2_ros/src/buffer.cpp
@@ -58,12 +58,8 @@ to_rclcpp(const tf2::Duration & duration)
 
 Buffer::Buffer(
   rclcpp::Clock::SharedPtr clock,
-  rclcpp::node_interfaces::NodeInterfaces<
-    rclcpp::node_interfaces::NodeBaseInterface,
-    rclcpp::node_interfaces::NodeLoggingInterface,
-    rclcpp::node_interfaces::NodeServicesInterface
-  > node_interfaces,
   tf2::Duration cache_time,
+  RequiredInterfaces node_interfaces,
   const rclcpp::QoS & qos)
 : BufferCore(cache_time), clock_(clock), node_interfaces_(std::move(node_interfaces)),
   timer_interface_(nullptr)
@@ -84,15 +80,17 @@ Buffer::Buffer(
 
   jump_handler_ = clock_->create_jump_callback(nullptr, post_jump_cb, jump_threshold);
 
-  auto node_base = node_interfaces_.get_node_base_interface();
-  auto node_services = node_interfaces_.get_node_services_interface();
+  if (node_interfaces.get<NodeBaseInterface>()) {
+    auto node_base = node_interfaces_.get_node_base_interface();
+    auto node_services = node_interfaces_.get_node_services_interface();
 
-  node_logging_interface_ = node_interfaces_.get_node_logging_interface();
+    node_logging_interface_ = node_interfaces_.get_node_logging_interface();
 
-  frames_server_ = rclcpp::create_service<tf2_msgs::srv::FrameGraph>(
-    node_base, node_services, "tf2_frames", std::bind(
-      &Buffer::getFrames, this, std::placeholders::_1,
-      std::placeholders::_2), qos, nullptr);
+    frames_server_ = rclcpp::create_service<tf2_msgs::srv::FrameGraph>(
+      node_base, node_services, "tf2_frames", std::bind(
+        &Buffer::getFrames, this, std::placeholders::_1,
+        std::placeholders::_2), qos, nullptr);
+  }
 }
 
 geometry_msgs::msg::TransformStamped

--- a/tf2_ros/src/buffer_server_main.cpp
+++ b/tf2_ros/src/buffer_server_main.cpp
@@ -49,7 +49,7 @@ int main(int argc, char ** argv)
   auto node = std::make_shared<rclcpp::Node>("tf_buffer");
   double buffer_size = node->declare_parameter("buffer_size", 120.0);
 
-  tf2_ros::Buffer buffer(node->get_clock(), tf2::durationFromSec(buffer_size));
+  tf2_ros::Buffer buffer(node->get_clock(), *node, tf2::durationFromSec(buffer_size));
   tf2_ros::TransformListener listener(buffer);
   tf2_ros::BufferServer buffer_server(buffer, node, "tf2_buffer_server");
 

--- a/tf2_ros/src/buffer_server_main.cpp
+++ b/tf2_ros/src/buffer_server_main.cpp
@@ -49,7 +49,7 @@ int main(int argc, char ** argv)
   auto node = std::make_shared<rclcpp::Node>("tf_buffer");
   double buffer_size = node->declare_parameter("buffer_size", 120.0);
 
-  tf2_ros::Buffer buffer(node->get_clock(), *node, tf2::durationFromSec(buffer_size));
+  tf2_ros::Buffer buffer(node->get_clock(), tf2::durationFromSec(buffer_size), *node);
   tf2_ros::TransformListener listener(buffer);
   tf2_ros::BufferServer buffer_server(buffer, node, "tf2_buffer_server");
 

--- a/tf2_ros/src/static_transform_broadcaster_node.cpp
+++ b/tf2_ros/src/static_transform_broadcaster_node.cpp
@@ -92,7 +92,7 @@ StaticTransformBroadcasterNode::StaticTransformBroadcasterNode(const rclcpp::Nod
     throw std::runtime_error("child_frame_id cannot equal frame_id");
   }
 
-  broadcaster_ = std::make_unique<tf2_ros::StaticTransformBroadcaster>(this);
+  broadcaster_ = std::make_unique<tf2_ros::StaticTransformBroadcaster>(*this);
 
   // send transform
   broadcaster_->sendTransform(tf_msg);

--- a/tf2_ros/src/tf2_echo.cpp
+++ b/tf2_ros/src/tf2_echo.cpp
@@ -55,7 +55,7 @@ public:
   std::shared_ptr<tf2_ros::TransformListener> tfl_;
 
   explicit echoListener(rclcpp::Clock::SharedPtr clock)
-  : buffer_(clock)
+  : buffer_(clock, *std::make_shared<rclcpp::Node>("default_node"))
   {
     tfl_ = std::make_shared<tf2_ros::TransformListener>(buffer_);
   }

--- a/tf2_ros/src/tf2_echo.cpp
+++ b/tf2_ros/src/tf2_echo.cpp
@@ -55,7 +55,7 @@ public:
   std::shared_ptr<tf2_ros::TransformListener> tfl_;
 
   explicit echoListener(rclcpp::Clock::SharedPtr clock)
-  : buffer_(clock, *std::make_shared<rclcpp::Node>("default_node"))
+  : buffer_(clock)
   {
     tfl_ = std::make_shared<tf2_ros::TransformListener>(buffer_);
   }

--- a/tf2_ros/src/tf2_monitor.cpp
+++ b/tf2_ros/src/tf2_monitor.cpp
@@ -126,7 +126,7 @@ public:
     using_specific_chain_(using_specific_chain),
     node_(node),
     clock_(node->get_clock()),
-    buffer_(clock_, tf2::Duration(tf2::BUFFER_CORE_DEFAULT_CACHE_TIME), node)
+    buffer_(clock_, *node, tf2::Duration(tf2::BUFFER_CORE_DEFAULT_CACHE_TIME))
   {
     tf_ = std::make_shared<tf2_ros::TransformListener>(buffer_);
 

--- a/tf2_ros/src/tf2_monitor.cpp
+++ b/tf2_ros/src/tf2_monitor.cpp
@@ -126,7 +126,7 @@ public:
     using_specific_chain_(using_specific_chain),
     node_(node),
     clock_(node->get_clock()),
-    buffer_(clock_, *node, tf2::Duration(tf2::BUFFER_CORE_DEFAULT_CACHE_TIME))
+    buffer_(clock_, tf2::Duration(tf2::BUFFER_CORE_DEFAULT_CACHE_TIME), *node)
   {
     tf_ = std::make_shared<tf2_ros::TransformListener>(buffer_);
 

--- a/tf2_ros/src/transform_listener.cpp
+++ b/tf2_ros/src/transform_listener.cpp
@@ -58,10 +58,7 @@ TransformListener::TransformListener(tf2::BufferCore & buffer, bool spin_thread,
   options.start_parameter_services(false);
   optional_default_node_ = rclcpp::Node::make_shared("_", options);
   init(
-    optional_default_node_->get_node_base_interface(),
-    optional_default_node_->get_node_logging_interface(),
-    optional_default_node_->get_node_parameters_interface(),
-    optional_default_node_->get_node_topics_interface(),
+    *optional_default_node_,
     spin_thread, DynamicListenerQoS(), StaticListenerQoS(),
     detail::get_default_transform_listener_sub_options(),
     detail::get_default_transform_listener_static_sub_options(),
@@ -90,7 +87,7 @@ void TransformListener::subscription_callback(
       // /\todo Use error reporting
       std::string temp = ex.what();
       RCLCPP_ERROR(
-        node_logging_interface_->get_logger(),
+        node_interfaces_.get_node_logging_interface()->get_logger(),
         "Failure to set received transform from %s to %s with error: %s\n",
         msg_in.transforms[i].child_frame_id.c_str(),
         msg_in.transforms[i].header.frame_id.c_str(), temp.c_str());

--- a/tf2_ros/test/listener_unittest.cpp
+++ b/tf2_ros/test/listener_unittest.cpp
@@ -46,8 +46,8 @@ TEST(tf2_ros_test_listener, transform_listener)
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
 
-  tf2_ros::Buffer buffer(clock);
-  tf2_ros::TransformListener tfl(buffer, node, false);
+  tf2_ros::Buffer buffer(clock, *node);
+  tf2_ros::TransformListener tfl(buffer, *node, false);
 
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(node);

--- a/tf2_ros/test/listener_unittest.cpp
+++ b/tf2_ros/test/listener_unittest.cpp
@@ -40,13 +40,75 @@
 #include "rclcpp/rclcpp.hpp"
 #include "builtin_interfaces/msg/time.hpp"
 
+TEST(tf2_ros_test_listener, transform_listener_deprecated)
+{
+  auto node = rclcpp::Node::make_shared("tf2_ros_test_listener_transform_listener");
+
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+
+  #ifdef _MSC_VER
+  #pragma warning(push)
+  #pragma warning(disable : 4996)
+  #else
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  #endif
+
+  tf2_ros::Buffer buffer(clock);
+  tf2_ros::TransformListener tfl(buffer, node, false);
+
+  #ifdef _MSC_VER
+  #pragma warning(pop)
+  #else
+  #pragma GCC diagnostic pop
+  #endif
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+  // Start spinning in a thread
+  std::thread spin_thread = std::thread([&executor] () {
+        executor.spin();
+  });
+
+  geometry_msgs::msg::TransformStamped ts;
+  ts.transform.rotation.w = 1;
+  ts.header.frame_id = "a";
+  ts.header.stamp = rclcpp::Time(10, 0);
+  ts.child_frame_id = "b";
+  ts.transform.translation.x = 1;
+  ts.transform.translation.y = 2;
+  ts.transform.translation.z = 3;
+
+  buffer.setTransform(ts, "authority");
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+  EXPECT_TRUE(buffer.canTransform("a", "b", tf2::timeFromSec(0)));
+
+  geometry_msgs::msg::TransformStamped out_rootc = buffer.lookupTransform(
+    "a", "b",
+    rclcpp::Time());
+
+  EXPECT_EQ(1, out_rootc.transform.translation.x);
+  EXPECT_EQ(2, out_rootc.transform.translation.y);
+  EXPECT_EQ(3, out_rootc.transform.translation.z);
+  EXPECT_EQ(1, out_rootc.transform.rotation.w);
+  EXPECT_EQ(0, out_rootc.transform.rotation.x);
+  EXPECT_EQ(0, out_rootc.transform.rotation.y);
+  EXPECT_EQ(0, out_rootc.transform.rotation.z);
+
+  executor.cancel();
+  spin_thread.join();
+  node.reset();
+}
+
 TEST(tf2_ros_test_listener, transform_listener)
 {
   auto node = rclcpp::Node::make_shared("tf2_ros_test_listener_transform_listener");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
 
-  tf2_ros::Buffer buffer(clock, *node);
+  tf2_ros::Buffer buffer(clock, tf2::Duration(tf2::BUFFER_CORE_DEFAULT_CACHE_TIME), *node);
   tf2_ros::TransformListener tfl(buffer, *node, false);
 
   rclcpp::executors::SingleThreadedExecutor executor;

--- a/tf2_ros/test/message_filter_test.cpp
+++ b/tf2_ros/test/message_filter_test.cpp
@@ -55,11 +55,83 @@ void filter_callback(const geometry_msgs::msg::PointStamped & msg)
   filter_callback_fired++;
 }
 
+TEST(tf2_ros_message_filter, construction_and_destruction_deprecated)
+{
+  auto node = rclcpp::Node::make_shared("test_message_filter_node");
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+
+  #ifdef _MSC_VER
+  #pragma warning(push)
+  #pragma warning(disable : 4996)
+  #else
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  #endif
+
+  tf2_ros::Buffer buffer(clock);
+
+  // Node constructor with defaults
+  {
+    tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "map", 10, node);
+  }
+
+  // Node constructor no defaults
+  {
+    tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(
+      buffer, "map", 10, node, std::chrono::milliseconds(100));
+  }
+
+  // Node interface constructor with defaults
+  {
+    tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(
+      buffer, "map", 10, node->get_node_logging_interface(), node->get_node_clock_interface());
+   }
+
+  // Node interface constructor no defaults
+  {
+    tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(
+      buffer, "map", 10, node->get_node_logging_interface(), node->get_node_clock_interface(),
+      std::chrono::seconds(42));
+  }
+
+  message_filters::Subscriber<geometry_msgs::msg::PointStamped> sub;
+  // Filter + node constructor with defaults
+  {
+    tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(sub, buffer, "map", 10, node);
+  }
+
+  // Filter + node constructor no defaults
+  {
+    tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(
+      sub, buffer, "map", 10, node, std::chrono::hours(1));
+  }
+
+  // Filter + node interface constructor with defaults
+  {
+    tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(
+      sub, buffer, "map", 10, node->get_node_logging_interface(),
+      node->get_node_clock_interface());
+  }
+
+  // Filter + node interface constructor no defaults
+  {
+    tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(
+      sub, buffer, "map", 10, node->get_node_logging_interface(), node->get_node_clock_interface(),
+      std::chrono::microseconds(0));
+  }
+
+  #ifdef _MSC_VER
+  #pragma warning(pop)
+  #else
+  #pragma GCC diagnostic pop
+  #endif
+}
+
 TEST(tf2_ros_message_filter, construction_and_destruction)
 {
   auto node = rclcpp::Node::make_shared("test_message_filter_node");
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock, *node);
+  tf2_ros::Buffer buffer(clock, tf2::Duration(tf2::BUFFER_CORE_DEFAULT_CACHE_TIME), *node);
 
   // Node constructor with defaults
   {
@@ -123,13 +195,27 @@ TEST(tf2_ros_message_filter, construction_and_destruction)
   }
 }
 
-TEST(tf2_ros_message_filter, get_target_frames)
+TEST(tf2_ros_message_filter, get_target_frames_deprecated)
 {
   auto node = rclcpp::Node::make_shared("test_message_filter_node");
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock);
 
+  #ifdef _MSC_VER
+  #pragma warning(push)
+  #pragma warning(disable : 4996)
+  #else
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  #endif
+
+  tf2_ros::Buffer buffer(clock);
   tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "map", 10, node);
+
+  #ifdef _MSC_VER
+  #pragma warning(pop)
+  #else
+  #pragma GCC diagnostic pop
+  #endif
   ASSERT_STREQ(filter.getTargetFramesString().c_str(), "map");
 
   std::vector<std::string> frames;
@@ -137,6 +223,117 @@ TEST(tf2_ros_message_filter, get_target_frames)
   frames.push_back("map");
   filter.setTargetFrames(frames);
   ASSERT_STREQ(filter.getTargetFramesString().c_str(), "odom, map");
+}
+
+TEST(tf2_ros_message_filter, get_target_frames)
+{
+  auto node = rclcpp::Node::make_shared("test_message_filter_node");
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+  tf2_ros::Buffer buffer(clock, tf2::Duration(tf2::BUFFER_CORE_DEFAULT_CACHE_TIME), *node);
+
+  tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "map", 10, *node);
+  ASSERT_STREQ(filter.getTargetFramesString().c_str(), "map");
+
+  std::vector<std::string> frames;
+  frames.push_back("odom");
+  frames.push_back("map");
+  filter.setTargetFrames(frames);
+  ASSERT_STREQ(filter.getTargetFramesString().c_str(), "odom, map");
+}
+
+TEST(tf2_ros_message_filter, multiple_frames_and_time_tolerance_deprecated)
+{
+  auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
+
+  #ifdef _MSC_VER
+  #pragma warning(push)
+  #pragma warning(disable : 4996)
+  #else
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  #endif
+
+  auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
+    node->get_node_base_interface(),
+    node->get_node_timers_interface());
+
+  rclcpp::QoS default_qos =
+    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default));
+  message_filters::Subscriber<geometry_msgs::msg::PointStamped> sub;
+  sub.subscribe(node, "point", default_qos);
+
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+  tf2_ros::Buffer buffer(clock);
+  buffer.setCreateTimerInterface(create_timer_interface);
+  tf2_ros::TransformListener tfl(buffer);
+  tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "map", 10, node);
+  filter.connectInput(sub);
+  filter.registerCallback(&filter_callback);
+
+  // Register multiple target frames
+  std::vector<std::string> frames;
+  frames.push_back("odom");
+  frames.push_back("map");
+  filter.setTargetFrames(frames);
+  // Set a non-zero time tolerance
+  filter.setTolerance(rclcpp::Duration(1, 0));
+
+  // Publish static transforms so the frame transformations will always be valid
+  tf2_ros::StaticTransformBroadcaster tfb(node);
+
+  #ifdef _MSC_VER
+  #pragma warning(pop)
+  #else
+  #pragma GCC diagnostic pop
+  #endif
+
+  geometry_msgs::msg::TransformStamped map_to_odom;
+  map_to_odom.header.stamp = rclcpp::Time(0, 0);
+  map_to_odom.header.frame_id = "map";
+  map_to_odom.child_frame_id = "odom";
+  map_to_odom.transform.translation.x = 0.0;
+  map_to_odom.transform.translation.y = 0.0;
+  map_to_odom.transform.translation.z = 0.0;
+  map_to_odom.transform.rotation.x = 0.0;
+  map_to_odom.transform.rotation.y = 0.0;
+  map_to_odom.transform.rotation.z = 0.0;
+  map_to_odom.transform.rotation.w = 1.0;
+  tfb.sendTransform(map_to_odom);
+
+  geometry_msgs::msg::TransformStamped odom_to_base;
+  odom_to_base.header.stamp = rclcpp::Time(0, 0);
+  odom_to_base.header.frame_id = "odom";
+  odom_to_base.child_frame_id = "base";
+  odom_to_base.transform.translation.x = 0.0;
+  odom_to_base.transform.translation.y = 0.0;
+  odom_to_base.transform.translation.z = 0.0;
+  odom_to_base.transform.rotation.x = 0.0;
+  odom_to_base.transform.rotation.y = 0.0;
+  odom_to_base.transform.rotation.z = 0.0;
+  odom_to_base.transform.rotation.w = 1.0;
+  tfb.sendTransform(odom_to_base);
+
+  rclcpp::Publisher<geometry_msgs::msg::PointStamped>::SharedPtr pub;
+  pub = node->create_publisher<geometry_msgs::msg::PointStamped>("point", 10);
+  geometry_msgs::msg::PointStamped point;
+  point.header.stamp = rclcpp::Clock().now();
+  point.header.frame_id = "base";
+  point.point.x = 0.1;
+  point.point.y = 0.2;
+  point.point.z = 0.3;
+
+  rclcpp::WallRate loop_rate(1);
+  while (rclcpp::ok()) {
+    pub->publish(point);
+    rclcpp::spin_some(node);
+    loop_rate.sleep();
+    RCLCPP_INFO(node->get_logger(), "filter callback: trigger(%d)", filter_callback_fired.load());
+    if (filter_callback_fired.load() > 5) {
+      break;
+    }
+  }
+
+  ASSERT_TRUE(filter_callback_fired);
 }
 
 TEST(tf2_ros_message_filter, multiple_frames_and_time_tolerance)
@@ -151,7 +348,7 @@ TEST(tf2_ros_message_filter, multiple_frames_and_time_tolerance)
   sub.subscribe(node, "point", default_qos);
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock, *node);
+  tf2_ros::Buffer buffer(clock);
   buffer.setCreateTimerInterface(create_timer_interface);
   tf2_ros::TransformListener tfl(buffer);
   tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "map", 10, *node);
@@ -214,7 +411,6 @@ TEST(tf2_ros_message_filter, multiple_frames_and_time_tolerance)
     }
   }
 
-  rclcpp::shutdown();
   ASSERT_TRUE(filter_callback_fired);
 }
 

--- a/tf2_ros/test/message_filter_test.cpp
+++ b/tf2_ros/test/message_filter_test.cpp
@@ -59,63 +59,66 @@ TEST(tf2_ros_message_filter, construction_and_destruction)
 {
   auto node = rclcpp::Node::make_shared("test_message_filter_node");
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock);
+  tf2_ros::Buffer buffer(clock, *node);
 
   // Node constructor with defaults
   {
-    tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "map", 10, node);
+    tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "map", 10, *node);
   }
 
   // Node constructor no defaults
   {
     tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(
-      buffer, "map", 10, node, std::chrono::milliseconds(100));
+      buffer, "map", 10, *node, std::chrono::milliseconds(100));
   }
 
   // Node interface constructor with defaults
   {
     tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(
-      buffer, "map", 10, node->get_node_logging_interface(), node->get_node_clock_interface());
-  }
+      buffer, "map", 10, rclcpp::node_interfaces::NodeInterfaces<
+        rclcpp::node_interfaces::NodeLoggingInterface,
+        rclcpp::node_interfaces::NodeClockInterface>(
+        node->get_node_logging_interface(), node->get_node_clock_interface()));
+   }
 
   // Node interface constructor no defaults
   {
     tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(
-      buffer,
-      "map",
-      10,
-      node->get_node_logging_interface(),
-      node->get_node_clock_interface(),
+      buffer, "map", 10, rclcpp::node_interfaces::NodeInterfaces<
+        rclcpp::node_interfaces::NodeLoggingInterface,
+        rclcpp::node_interfaces::NodeClockInterface>(
+        node->get_node_logging_interface(), node->get_node_clock_interface()),
       std::chrono::seconds(42));
   }
 
   message_filters::Subscriber<geometry_msgs::msg::PointStamped> sub;
   // Filter + node constructor with defaults
   {
-    tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(sub, buffer, "map", 10, node);
+    tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(sub, buffer, "map", 10, *node);
   }
 
   // Filter + node constructor no defaults
   {
     tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(
-      sub, buffer, "map", 10, node, std::chrono::hours(1));
+      sub, buffer, "map", 10, *node, std::chrono::hours(1));
   }
 
   // Filter + node interface constructor with defaults
   {
     tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(
-      sub, buffer, "map", 10, node->get_node_logging_interface(), node->get_node_clock_interface());
+      sub, buffer, "map", 10, rclcpp::node_interfaces::NodeInterfaces<
+        rclcpp::node_interfaces::NodeLoggingInterface,
+        rclcpp::node_interfaces::NodeClockInterface>(
+        node->get_node_logging_interface(), node->get_node_clock_interface()));
   }
 
   // Filter + node interface constructor no defaults
   {
     tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(
-      sub,
-      buffer,
-      "map",
-      10,
-      node->get_node_logging_interface(),
-      node->get_node_clock_interface(),
+      sub, buffer, "map", 10, rclcpp::node_interfaces::NodeInterfaces<
+        rclcpp::node_interfaces::NodeLoggingInterface,
+        rclcpp::node_interfaces::NodeClockInterface>(
+        node->get_node_logging_interface(), node->get_node_clock_interface()),
       std::chrono::microseconds(0));
   }
 }
@@ -140,9 +143,7 @@ TEST(tf2_ros_message_filter, multiple_frames_and_time_tolerance)
 {
   auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
 
-  auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-    node->get_node_base_interface(),
-    node->get_node_timers_interface());
+  auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(*node);
 
   rclcpp::QoS default_qos =
     rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default));
@@ -150,10 +151,10 @@ TEST(tf2_ros_message_filter, multiple_frames_and_time_tolerance)
   sub.subscribe(node, "point", default_qos);
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock);
+  tf2_ros::Buffer buffer(clock, *node);
   buffer.setCreateTimerInterface(create_timer_interface);
   tf2_ros::TransformListener tfl(buffer);
-  tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "map", 10, node);
+  tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "map", 10, *node);
   filter.connectInput(sub);
   filter.registerCallback(&filter_callback);
 
@@ -166,7 +167,7 @@ TEST(tf2_ros_message_filter, multiple_frames_and_time_tolerance)
   filter.setTolerance(rclcpp::Duration(1, 0));
 
   // Publish static transforms so the frame transformations will always be valid
-  tf2_ros::StaticTransformBroadcaster tfb(node);
+  tf2_ros::StaticTransformBroadcaster tfb(*node);
   geometry_msgs::msg::TransformStamped map_to_odom;
   map_to_odom.header.stamp = rclcpp::Time(0, 0);
   map_to_odom.header.frame_id = "map";

--- a/tf2_ros/test/message_filter_test.cpp
+++ b/tf2_ros/test/message_filter_test.cpp
@@ -28,6 +28,7 @@
  */
 
 #include <atomic>
+#include <chrono>
 #include <memory>
 #include <string>
 #include <vector>
@@ -85,7 +86,7 @@ TEST(tf2_ros_message_filter, construction_and_destruction_deprecated)
   {
     tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(
       buffer, "map", 10, node->get_node_logging_interface(), node->get_node_clock_interface());
-   }
+  }
 
   // Node interface constructor no defaults
   {

--- a/tf2_ros/test/node_wrapper.hpp
+++ b/tf2_ros/test/node_wrapper.hpp
@@ -55,6 +55,9 @@ public:
   rclcpp::node_interfaces::NodeParametersInterface::SharedPtr
   get_node_parameters_interface() {return this->node->get_node_parameters_interface();}
 
+  rclcpp::node_interfaces::NodeServicesInterface::SharedPtr
+  get_node_services_interface() {return this->node->get_node_services_interface();}
+
 private:
   rclcpp::Node::SharedPtr node;
 };

--- a/tf2_ros/test/test_buffer.cpp
+++ b/tf2_ros/test/test_buffer.cpp
@@ -142,17 +142,13 @@ private:
 
 TEST(test_buffer, construct_with_null_clock)
 {
-  std::shared_ptr<rclcpp::Node> node = std::make_shared<rclcpp::Node>("default_node");
-
-  EXPECT_THROW(tf2_ros::Buffer(nullptr, *node), std::invalid_argument);
+  EXPECT_THROW(tf2_ros::Buffer(nullptr), std::invalid_argument);
 }
 
 TEST(test_buffer, can_transform_valid_transform)
 {
-  std::shared_ptr<rclcpp::Node> node = std::make_shared<rclcpp::Node>("default_node");
-
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock, *node);
+  tf2_ros::Buffer buffer(clock);
   // Silence error about dedicated thread's being necessary
   buffer.setUsingDedicatedThread(true);
 
@@ -191,10 +187,8 @@ TEST(test_buffer, can_transform_valid_transform)
 
 TEST(test_buffer, velocity_transform)
 {
-  std::shared_ptr<rclcpp::Node> node = std::make_shared<rclcpp::Node>("default_node");
-
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock, *node);
+  tf2_ros::Buffer buffer(clock);
   // Silence error about dedicated thread's being necessary
   buffer.setUsingDedicatedThread(true);
 
@@ -254,10 +248,8 @@ TEST(test_buffer, velocity_transform)
 
 TEST(test_buffer, test_twist)
 {
-  std::shared_ptr<rclcpp::Node> node = std::make_shared<rclcpp::Node>("default_node");
-
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock, *node);
+  tf2_ros::Buffer buffer(clock);
   // Silence error about dedicated thread's being necessary
   buffer.setUsingDedicatedThread(true);
 
@@ -303,10 +295,8 @@ TEST(test_buffer, test_twist)
 
 TEST(test_buffer, can_transform_without_dedicated_thread)
 {
-  std::shared_ptr<rclcpp::Node> node = std::make_shared<rclcpp::Node>("default_node");
-
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock, *node);
+  tf2_ros::Buffer buffer(clock);
   buffer.setUsingDedicatedThread(false);
 
   rclcpp::Time rclcpp_time = clock->now();
@@ -348,10 +338,8 @@ TEST(test_buffer, can_transform_without_dedicated_thread)
 
 TEST(test_buffer, wait_for_transform_valid)
 {
-  std::shared_ptr<rclcpp::Node> node = std::make_shared<rclcpp::Node>("default_node");
-
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock, *node);
+  tf2_ros::Buffer buffer(clock);
   // Silence error about dedicated thread's being necessary
   buffer.setUsingDedicatedThread(true);
   auto mock_create_timer = std::make_shared<MockCreateTimer>();
@@ -411,10 +399,8 @@ TEST(test_buffer, wait_for_transform_valid)
 
 TEST(test_buffer, wait_for_transform_timeout)
 {
-  std::shared_ptr<rclcpp::Node> node = std::make_shared<rclcpp::Node>("default_node");
-
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock, *node);
+  tf2_ros::Buffer buffer(clock);
   // Silence error about dedicated thread's being necessary
   buffer.setUsingDedicatedThread(true);
   auto mock_create_timer = std::make_shared<MockCreateTimer>();
@@ -462,10 +448,8 @@ TEST(test_buffer, wait_for_transform_timeout)
 // Regression test for https://github.com/ros2/geometry2/issues/141
 TEST(test_buffer, wait_for_transform_race)
 {
-  std::shared_ptr<rclcpp::Node> node = std::make_shared<rclcpp::Node>("default_node");
-
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock, *node);
+  tf2_ros::Buffer buffer(clock);
   // Silence error about dedicated thread's being necessary
   buffer.setUsingDedicatedThread(true);
   auto mock_create_timer = std::make_shared<MockCreateTimer>();
@@ -512,14 +496,11 @@ TEST(test_buffer, wait_for_transform_race)
 
 TEST(test_buffer, timer_ros_wait_for_transform_race)
 {
-  int argc = 1;
-  char const * const argv[] = {"timer_ros_wait_for_transform_race"};
-  rclcpp::init(argc, argv);
   std::shared_ptr<rclcpp::Node> rclcpp_node_ = std::make_shared<rclcpp::Node>(
     "timer_ros_wait_for_transform_race");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock, *rclcpp_node_);
+  tf2_ros::Buffer buffer(clock);
   // Silence error about dedicated thread's being necessary
   buffer.setUsingDedicatedThread(true);
   auto mock_create_timer_ros = std::make_shared<MockCreateTimerROS>(*rclcpp_node_);
@@ -568,6 +549,7 @@ TEST(test_buffer, timer_ros_wait_for_transform_race)
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
   auto ret = RUN_ALL_TESTS();
   rclcpp::shutdown();
   return ret;

--- a/tf2_ros/test/test_static_transform_broadcaster.cpp
+++ b/tf2_ros/test/test_static_transform_broadcaster.cpp
@@ -82,8 +82,11 @@ TEST(tf2_test_static_transform_broadcaster, transform_broadcaster_rclcpp_node)
   // Construct static tf broadcaster from node interfaces
   {
     tf2_ros::StaticTransformBroadcaster tfb(
+      rclcpp::node_interfaces::NodeInterfaces<
+        rclcpp::node_interfaces::NodeParametersInterface,
+        rclcpp::node_interfaces::NodeTopicsInterface>(
       node->get_node_parameters_interface(),
-      node->get_node_topics_interface());
+      node->get_node_topics_interface()));
   }
 }
 
@@ -111,8 +114,11 @@ TEST(tf2_test_static_transform_broadcaster, transform_broadcaster_custom_rclcpp_
   // Construct static tf broadcaster from node interfaces
   {
     tf2_ros::StaticTransformBroadcaster tfb(
+      rclcpp::node_interfaces::NodeInterfaces<
+        rclcpp::node_interfaces::NodeParametersInterface,
+        rclcpp::node_interfaces::NodeTopicsInterface>(
       node->get_node_parameters_interface(),
-      node->get_node_topics_interface());
+      node->get_node_topics_interface()));
   }
 }
 

--- a/tf2_ros/test/test_static_transform_broadcaster.cpp
+++ b/tf2_ros/test/test_static_transform_broadcaster.cpp
@@ -44,7 +44,7 @@ public:
 
   void init_tf_broadcaster()
   {
-    tf_broadcaster_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(shared_from_this());
+    tf_broadcaster_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(*shared_from_this());
   }
 
 private:
@@ -60,26 +60,52 @@ public:
 
   void init_tf_broadcaster()
   {
-    tf_broadcaster_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(shared_from_this());
+    tf_broadcaster_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(*shared_from_this());
   }
 
 private:
   std::shared_ptr<tf2_ros::StaticTransformBroadcaster> tf_broadcaster_;
 };
 
-TEST(tf2_test_static_transform_broadcaster, transform_broadcaster_rclcpp_node)
+TEST(tf2_test_static_transform_broadcaster, transform_broadcaster_rclcpp_node_deprecated)
 {
   auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
+
+  #ifdef _MSC_VER
+  #pragma warning(push)
+  #pragma warning(disable : 4996)
+  #else
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  #endif
 
   // Construct static tf broadcaster from node pointer
   {
     tf2_ros::StaticTransformBroadcaster tfb(node);
   }
+  // Construct static tf broadcaster from node interfaces
+  {
+    tf2_ros::StaticTransformBroadcaster tfb(
+      node->get_node_parameters_interface(),
+      node->get_node_topics_interface());
+  }
+
+  #ifdef _MSC_VER
+  #pragma warning(pop)
+  #else
+  #pragma GCC diagnostic pop
+  #endif
+}
+
+TEST(tf2_test_static_transform_broadcaster, transform_broadcaster_rclcpp_node)
+{
+  auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
+
   // Construct static tf broadcaster from node object
   {
     tf2_ros::StaticTransformBroadcaster tfb(*node);
   }
-  // Construct static tf broadcaster from node interfaces
+  // Construct static tf broadcaster from NodeInterfaces
   {
     tf2_ros::StaticTransformBroadcaster tfb(
       rclcpp::node_interfaces::NodeInterfaces<
@@ -99,14 +125,40 @@ TEST(tf2_test_static_transform_broadcaster, transform_broadcaster_with_intraproc
   custom_node->init_tf_broadcaster();
 }
 
-TEST(tf2_test_static_transform_broadcaster, transform_broadcaster_custom_rclcpp_node)
+TEST(tf2_test_static_transform_broadcaster, transform_broadcaster_custom_rclcpp_node_deprecated)
 {
   auto node = std::make_shared<NodeWrapper>("tf2_ros_message_filter");
+
+  #ifdef _MSC_VER
+  #pragma warning(push)
+  #pragma warning(disable : 4996)
+  #else
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  #endif
 
   // Construct static tf broadcaster from node pointer
   {
     tf2_ros::StaticTransformBroadcaster tfb(node);
   }
+  // Construct static tf broadcaster from node interfaces
+  {
+    tf2_ros::StaticTransformBroadcaster tfb(
+      node->get_node_parameters_interface(),
+      node->get_node_topics_interface());
+  }
+
+  #ifdef _MSC_VER
+  #pragma warning(pop)
+  #else
+  #pragma GCC diagnostic pop
+  #endif
+}
+
+TEST(tf2_test_static_transform_broadcaster, transform_broadcaster_custom_rclcpp_node)
+{
+  auto node = std::make_shared<NodeWrapper>("tf2_ros_message_filter");
+
   // Construct static tf broadcaster from node object
   {
     tf2_ros::StaticTransformBroadcaster tfb(*node);

--- a/tf2_ros/test/test_transform_broadcaster.cpp
+++ b/tf2_ros/test/test_transform_broadcaster.cpp
@@ -65,8 +65,11 @@ TEST(tf2_test_transform_broadcaster, transform_broadcaster_rclcpp_node)
   // Construct tf broadcaster from node interfaces
   {
     tf2_ros::TransformBroadcaster tfb(
+      rclcpp::node_interfaces::NodeInterfaces<
+        rclcpp::node_interfaces::NodeParametersInterface,
+        rclcpp::node_interfaces::NodeTopicsInterface>(
       node->get_node_parameters_interface(),
-      node->get_node_topics_interface());
+      node->get_node_topics_interface()));
   }
 }
 
@@ -85,8 +88,11 @@ TEST(tf2_test_transform_broadcaster, transform_broadcaster_custom_rclcpp_node)
   // Construct tf broadcaster from node interfaces
   {
     tf2_ros::TransformBroadcaster tfb(
+      rclcpp::node_interfaces::NodeInterfaces<
+        rclcpp::node_interfaces::NodeParametersInterface,
+        rclcpp::node_interfaces::NodeTopicsInterface>(
       node->get_node_parameters_interface(),
-      node->get_node_topics_interface());
+      node->get_node_topics_interface()));
   }
 }
 

--- a/tf2_ros/test/test_transform_broadcaster.cpp
+++ b/tf2_ros/test/test_transform_broadcaster.cpp
@@ -51,13 +51,39 @@ private:
   std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
 };
 
-TEST(tf2_test_transform_broadcaster, transform_broadcaster_rclcpp_node)
+TEST(tf2_test_transform_broadcaster, transform_broadcaster_rclcpp_node_deprecated)
 {
   auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
+
+  #ifdef _MSC_VER
+  #pragma warning(push)
+  #pragma warning(disable : 4996)
+  #else
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  #endif
+
   // Construct tf broadcaster from node pointer
   {
     tf2_ros::TransformBroadcaster tfb(node);
   }
+  // Construct tf broadcaster from node interfaces
+  {
+    tf2_ros::TransformBroadcaster tfb(
+      node->get_node_parameters_interface(),
+      node->get_node_topics_interface());
+  }
+
+  #ifdef _MSC_VER
+  #pragma warning(pop)
+  #else
+  #pragma GCC diagnostic pop
+  #endif
+}
+
+TEST(tf2_test_transform_broadcaster, transform_broadcaster_rclcpp_node)
+{
+  auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
   // Construct tf broadcaster from node object
   {
     tf2_ros::TransformBroadcaster tfb(*node);
@@ -73,14 +99,39 @@ TEST(tf2_test_transform_broadcaster, transform_broadcaster_rclcpp_node)
   }
 }
 
-TEST(tf2_test_transform_broadcaster, transform_broadcaster_custom_rclcpp_node)
+TEST(tf2_test_transform_broadcaster, transform_broadcaster_custom_rclcpp_node_deprecated)
 {
   auto node = std::make_shared<NodeWrapper>("tf2_ros_message_filter");
+
+  #ifdef _MSC_VER
+  #pragma warning(push)
+  #pragma warning(disable : 4996)
+  #else
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  #endif
 
   // Construct tf broadcaster from node pointer
   {
     tf2_ros::TransformBroadcaster tfb(node);
   }
+  // Construct tf broadcaster from node interfaces
+  {
+    tf2_ros::TransformBroadcaster tfb(
+      node->get_node_parameters_interface(),
+      node->get_node_topics_interface());
+  }
+
+  #ifdef _MSC_VER
+  #pragma warning(pop)
+  #else
+  #pragma GCC diagnostic pop
+  #endif
+}
+
+TEST(tf2_test_transform_broadcaster, transform_broadcaster_custom_rclcpp_node)
+{
+  auto node = std::make_shared<NodeWrapper>("tf2_ros_message_filter");
   // Construct tf broadcaster from node object
   {
     tf2_ros::TransformBroadcaster tfb(*node);

--- a/tf2_ros/test/test_transform_broadcaster.cpp
+++ b/tf2_ros/test/test_transform_broadcaster.cpp
@@ -44,7 +44,7 @@ public:
 
   void init_tf_broadcaster()
   {
-    tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(shared_from_this());
+    tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(*this);
   }
 
 private:

--- a/tf2_ros/test/test_transform_listener.cpp
+++ b/tf2_ros/test/test_transform_listener.cpp
@@ -50,14 +50,14 @@ public:
   void init_tf_listener()
   {
     rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-    tf2_ros::Buffer buffer(clock, *this);
+    tf2_ros::Buffer buffer(clock);
     tf_listener_ = std::make_shared<tf2_ros::TransformListener>(buffer, *this, false);
   }
 
   void init_static_tf_listener()
   {
     rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-    tf2_ros::Buffer buffer(clock, *this);
+    tf2_ros::Buffer buffer(clock);
     tf_listener_ =
       std::make_shared<tf2_ros::StaticTransformListener>(buffer, *this, false);
   }
@@ -76,14 +76,14 @@ public:
   void init_tf_listener()
   {
     rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-    tf2_ros::Buffer buffer(clock, *this);
+    tf2_ros::Buffer buffer(clock);
     tf_listener_ = std::make_shared<tf2_ros::TransformListener>(buffer, *this, false);
   }
 
   void init_static_tf_listener()
   {
     rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-    tf2_ros::Buffer buffer(clock, *this);
+    tf2_ros::Buffer buffer(clock);
     tf_listener_ =
       std::make_shared<tf2_ros::StaticTransformListener>(buffer, *this, false);
   }
@@ -92,13 +92,61 @@ private:
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
 };
 
+TEST(tf2_test_transform_listener, transform_listener_rclcpp_node_deprecated)
+{
+  auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
+
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+  tf2_ros::Buffer buffer(clock);
+
+  #ifdef _MSC_VER
+  #pragma warning(push)
+  #pragma warning(disable : 4996)
+  #else
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  #endif
+
+  tf2_ros::TransformListener tfl(buffer, node, false);
+
+  #ifdef _MSC_VER
+  #pragma warning(pop)
+  #else
+  #pragma GCC diagnostic pop
+  #endif
+}
+
 TEST(tf2_test_transform_listener, transform_listener_rclcpp_node)
 {
   auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock, *node);
+  tf2_ros::Buffer buffer(clock);
   tf2_ros::TransformListener tfl(buffer, *node, false);
+}
+
+TEST(tf2_test_transform_listener, transform_listener_custom_rclcpp_node_deprecated)
+{
+  auto node = std::make_shared<NodeWrapper>("tf2_ros_message_filter");
+
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+  tf2_ros::Buffer buffer(clock);
+
+  #ifdef _MSC_VER
+  #pragma warning(push)
+  #pragma warning(disable : 4996)
+  #else
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  #endif
+
+  tf2_ros::TransformListener tfl(buffer, node, false);
+
+  #ifdef _MSC_VER
+  #pragma warning(pop)
+  #else
+  #pragma GCC diagnostic pop
+  #endif
 }
 
 TEST(tf2_test_transform_listener, transform_listener_custom_rclcpp_node)
@@ -106,7 +154,7 @@ TEST(tf2_test_transform_listener, transform_listener_custom_rclcpp_node)
   auto node = std::make_shared<NodeWrapper>("tf2_ros_message_filter");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock, *node);
+  tf2_ros::Buffer buffer(clock);
   tf2_ros::TransformListener tfl(buffer, *node, false);
 }
 
@@ -130,7 +178,31 @@ TEST(tf2_test_static_transform_listener, static_transform_listener_rclcpp_node)
   auto node = rclcpp::Node::make_shared("tf2_ros_static_transform_listener");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock, *node);
+  tf2_ros::Buffer buffer(clock);
+}
+
+TEST(tf2_test_static_transform_listener, static_transform_listener_custom_rclcpp_node_deprecated)
+{
+  auto node = std::make_shared<NodeWrapper>("tf2_ros_static_transform_listener");
+
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+  tf2_ros::Buffer buffer(clock);
+
+  #ifdef _MSC_VER
+  #pragma warning(push)
+  #pragma warning(disable : 4996)
+  #else
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  #endif
+
+  tf2_ros::StaticTransformListener tfl(buffer, node, false);
+
+  #ifdef _MSC_VER
+  #pragma warning(pop)
+  #else
+  #pragma GCC diagnostic pop
+  #endif
 }
 
 TEST(tf2_test_static_transform_listener, static_transform_listener_custom_rclcpp_node)
@@ -138,7 +210,7 @@ TEST(tf2_test_static_transform_listener, static_transform_listener_custom_rclcpp
   auto node = std::make_shared<NodeWrapper>("tf2_ros_static_transform_listener");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock, *node);
+  tf2_ros::Buffer buffer(clock);
   tf2_ros::StaticTransformListener tfl(buffer, *node, false);
 }
 
@@ -157,13 +229,71 @@ TEST(tf2_test_static_transform_listener, static_transform_listener_with_intrapro
   custom_node->init_static_tf_listener();
 }
 
+TEST(tf2_test_listeners, static_vs_dynamic_deprecated)
+{
+  auto node = rclcpp::Node::make_shared("tf2_ros_static_transform_listener");
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+
+  #ifdef _MSC_VER
+  #pragma warning(push)
+  #pragma warning(disable : 4996)
+  #else
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  #endif
+
+  tf2_ros::Buffer dynamic_buffer(clock);
+  tf2_ros::Buffer static_buffer(clock);
+  tf2_ros::TransformListener tfl(dynamic_buffer, node, true);
+  tf2_ros::StaticTransformListener stfl(static_buffer, node, true);
+  tf2_ros::TransformBroadcaster broadcaster(node);
+  tf2_ros::StaticTransformBroadcaster static_broadcaster(node);
+
+  #ifdef _MSC_VER
+  #pragma warning(pop)
+  #else
+  #pragma GCC diagnostic pop
+  #endif
+
+  geometry_msgs::msg::TransformStamped static_trans;
+  static_trans.header.stamp = clock->now();
+  static_trans.header.frame_id = "parent_static";
+  static_trans.child_frame_id = "child_static";
+  static_trans.transform.rotation.w = 1.0;
+  static_broadcaster.sendTransform(static_trans);
+
+  geometry_msgs::msg::TransformStamped dynamic_trans;
+  dynamic_trans.header.frame_id = "parent_dynamic";
+  dynamic_trans.child_frame_id = "child_dynamic";
+  dynamic_trans.transform.rotation.w = 1.0;
+
+  for (int i = 0; i < 10; ++i) {
+    dynamic_trans.header.stamp = clock->now();
+    broadcaster.sendTransform(dynamic_trans);
+
+    rclcpp::spin_some(node);
+    rclcpp::sleep_for(std::chrono::milliseconds(10));
+  }
+
+  // Dynamic buffer should have both dynamic and static transforms available
+  EXPECT_NO_THROW(
+    dynamic_buffer.lookupTransform("parent_dynamic", "child_dynamic", tf2::TimePointZero));
+  EXPECT_NO_THROW(dynamic_buffer.lookupTransform("parent_static", "child_static", clock->now()));
+
+  // Static buffer should have only static transforms available
+  EXPECT_THROW(
+    static_buffer.lookupTransform("parent_dynamic", "child_dynamic", tf2::TimePointZero),
+    tf2::LookupException);
+  EXPECT_NO_THROW(static_buffer.lookupTransform("parent_static", "child_static", clock->now()));
+}
+
 TEST(tf2_test_listeners, static_vs_dynamic)
 {
   auto node = rclcpp::Node::make_shared("tf2_ros_static_transform_listener");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer dynamic_buffer(clock, *node);
-  tf2_ros::Buffer static_buffer(clock, *node);
+  tf2_ros::Buffer dynamic_buffer(clock);
+  tf2_ros::Buffer static_buffer(clock);
   tf2_ros::TransformListener tfl(dynamic_buffer, *node, true);
   tf2_ros::StaticTransformListener stfl(static_buffer, *node, true);
   tf2_ros::TransformBroadcaster broadcaster(*node);

--- a/tf2_ros/test/test_transform_listener.cpp
+++ b/tf2_ros/test/test_transform_listener.cpp
@@ -50,8 +50,8 @@ public:
   void init_tf_listener()
   {
     rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-    tf2_ros::Buffer buffer(clock);
-    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(buffer, shared_from_this(), false);
+    tf2_ros::Buffer buffer(clock, *this);
+    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(buffer, *shared_from_this(), false);
   }
 
   void init_static_tf_listener()
@@ -76,8 +76,8 @@ public:
   void init_tf_listener()
   {
     rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-    tf2_ros::Buffer buffer(clock);
-    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(buffer, shared_from_this(), false);
+    tf2_ros::Buffer buffer(clock, *this);
+    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(buffer, *shared_from_this(), false);
   }
 
   void init_static_tf_listener()
@@ -97,8 +97,8 @@ TEST(tf2_test_transform_listener, transform_listener_rclcpp_node)
   auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock);
-  tf2_ros::TransformListener tfl(buffer, node, false);
+  tf2_ros::Buffer buffer(clock, *node);
+  tf2_ros::TransformListener tfl(buffer, *node, false);
 }
 
 TEST(tf2_test_transform_listener, transform_listener_custom_rclcpp_node)
@@ -106,8 +106,8 @@ TEST(tf2_test_transform_listener, transform_listener_custom_rclcpp_node)
   auto node = std::make_shared<NodeWrapper>("tf2_ros_message_filter");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock);
-  tf2_ros::TransformListener tfl(buffer, node, false);
+  tf2_ros::Buffer buffer(clock, *node);
+  tf2_ros::TransformListener tfl(buffer, *node, false);
 }
 
 TEST(tf2_test_transform_listener, transform_listener_as_member)

--- a/tf2_ros/test/test_transform_listener.cpp
+++ b/tf2_ros/test/test_transform_listener.cpp
@@ -51,15 +51,15 @@ public:
   {
     rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
     tf2_ros::Buffer buffer(clock, *this);
-    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(buffer, *shared_from_this(), false);
+    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(buffer, *this, false);
   }
 
   void init_static_tf_listener()
   {
     rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-    tf2_ros::Buffer buffer(clock);
+    tf2_ros::Buffer buffer(clock, *this);
     tf_listener_ =
-      std::make_shared<tf2_ros::StaticTransformListener>(buffer, shared_from_this(), false);
+      std::make_shared<tf2_ros::StaticTransformListener>(buffer, *this, false);
   }
 
 private:
@@ -77,15 +77,15 @@ public:
   {
     rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
     tf2_ros::Buffer buffer(clock, *this);
-    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(buffer, *shared_from_this(), false);
+    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(buffer, *this, false);
   }
 
   void init_static_tf_listener()
   {
     rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-    tf2_ros::Buffer buffer(clock);
+    tf2_ros::Buffer buffer(clock, *this);
     tf_listener_ =
-      std::make_shared<tf2_ros::StaticTransformListener>(buffer, shared_from_this(), false);
+      std::make_shared<tf2_ros::StaticTransformListener>(buffer, *this, false);
   }
 
 private:
@@ -130,7 +130,7 @@ TEST(tf2_test_static_transform_listener, static_transform_listener_rclcpp_node)
   auto node = rclcpp::Node::make_shared("tf2_ros_static_transform_listener");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock);
+  tf2_ros::Buffer buffer(clock, *node);
 }
 
 TEST(tf2_test_static_transform_listener, static_transform_listener_custom_rclcpp_node)
@@ -138,8 +138,8 @@ TEST(tf2_test_static_transform_listener, static_transform_listener_custom_rclcpp
   auto node = std::make_shared<NodeWrapper>("tf2_ros_static_transform_listener");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer buffer(clock);
-  tf2_ros::StaticTransformListener tfl(buffer, node, false);
+  tf2_ros::Buffer buffer(clock, *node);
+  tf2_ros::StaticTransformListener tfl(buffer, *node, false);
 }
 
 TEST(tf2_test_static_transform_listener, static_transform_listener_as_member)
@@ -162,12 +162,12 @@ TEST(tf2_test_listeners, static_vs_dynamic)
   auto node = rclcpp::Node::make_shared("tf2_ros_static_transform_listener");
 
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-  tf2_ros::Buffer dynamic_buffer(clock);
-  tf2_ros::Buffer static_buffer(clock);
-  tf2_ros::TransformListener tfl(dynamic_buffer, node, true);
-  tf2_ros::StaticTransformListener stfl(static_buffer, node, true);
-  tf2_ros::TransformBroadcaster broadcaster(node);
-  tf2_ros::StaticTransformBroadcaster static_broadcaster(node);
+  tf2_ros::Buffer dynamic_buffer(clock, *node);
+  tf2_ros::Buffer static_buffer(clock, *node);
+  tf2_ros::TransformListener tfl(dynamic_buffer, *node, true);
+  tf2_ros::StaticTransformListener stfl(static_buffer, *node, true);
+  tf2_ros::TransformBroadcaster broadcaster(*node);
+  tf2_ros::StaticTransformBroadcaster static_broadcaster(*node);
 
   geometry_msgs::msg::TransformStamped static_trans;
   static_trans.header.stamp = clock->now();

--- a/tf2_ros/test/time_reset_test.cpp
+++ b/tf2_ros/test/time_reset_test.cpp
@@ -56,9 +56,9 @@ TEST(tf2_ros_time_reset_test, time_backwards)
     "transform_listener_backwards_reset");
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
 
-  tf2_ros::Buffer buffer(clock);
-  tf2_ros::TransformListener tfl(buffer);
-  tf2_ros::TransformBroadcaster tfb(node_);
+  tf2_ros::Buffer buffer(clock, *node_);
+  tf2_ros::TransformListener tfl(buffer, *node_);
+  tf2_ros::TransformBroadcaster tfb(*node_);
 
   auto clock_pub = node_->create_publisher<rosgraph_msgs::msg::Clock>("/clock", 1);
 

--- a/tf2_ros/test/time_reset_test.cpp
+++ b/tf2_ros/test/time_reset_test.cpp
@@ -50,13 +50,92 @@ void spin_for_a_second(std::shared_ptr<rclcpp::Node> & node)
   }
 }
 
+TEST(tf2_ros_time_reset_test, time_backwards_deprecated)
+{
+  std::shared_ptr<rclcpp::Node> node_ = std::make_shared<rclcpp::Node>(
+    "transform_listener_backwards_reset");
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+
+  #ifdef _MSC_VER
+  #pragma warning(push)
+  #pragma warning(disable : 4996)
+  #else
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  #endif
+
+  tf2_ros::Buffer buffer(clock);
+  tf2_ros::TransformListener tfl(buffer, node_);
+  tf2_ros::TransformBroadcaster tfb(node_);
+
+  #ifdef _MSC_VER
+  #pragma warning(pop)
+  #else
+  #pragma GCC diagnostic pop
+  #endif
+
+  auto clock_pub = node_->create_publisher<rosgraph_msgs::msg::Clock>("/clock", 1);
+
+  // basic test
+  ASSERT_FALSE(buffer.canTransform("foo", "bar", rclcpp::Time(101, 0)));
+
+  // make sure endpoints have discovered each other
+  spin_for_a_second(node_);
+
+  rosgraph_msgs::msg::Clock c;
+  c.clock = rclcpp::Time(100, 0);
+  clock_pub->publish(c);
+
+  // set the transform
+  geometry_msgs::msg::TransformStamped msg;
+  msg.header.stamp = rclcpp::Time(100, 0);
+  msg.header.frame_id = "foo";
+  msg.child_frame_id = "bar";
+  msg.transform.rotation.w = 0.0;
+  msg.transform.rotation.x = 1.0;
+  msg.transform.rotation.y = 0.0;
+  msg.transform.rotation.z = 0.0;
+  tfb.sendTransform(msg);
+  msg.header.stamp = rclcpp::Time(102, 0);
+  tfb.sendTransform(msg);
+
+  // make sure it arrives
+  spin_for_a_second(node_);
+
+  // verify it's been set
+  ASSERT_TRUE(buffer.canTransform("foo", "bar", rclcpp::Time(101, 0)));
+
+  // TODO(ahcorde): review this
+  // c.clock.sec = 90;
+  // c.clock.nanosec = 0;
+  // clock_pub->publish(c);
+  //
+  // // make sure it arrives
+  // rclcpp::spin_some(node_);
+  // sleep(1);
+  //
+  // //Send anoterh message to trigger clock test on an unrelated frame
+  // msg.header.stamp.sec = 110;
+  // msg.header.stamp.nanosec = 0;
+  // msg.header.frame_id = "foo2";
+  // msg.child_frame_id = "bar2";
+  // tfb.sendTransform(msg);
+  //
+  // // make sure it arrives
+  // rclcpp::spin_some(node_);
+  // sleep(1);
+  //
+  // //verify the data's been cleared
+  // ASSERT_FALSE(buffer.canTransform("foo", "bar", tf2::timeFromSec(101)));
+}
+
 TEST(tf2_ros_time_reset_test, time_backwards)
 {
   std::shared_ptr<rclcpp::Node> node_ = std::make_shared<rclcpp::Node>(
     "transform_listener_backwards_reset");
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
 
-  tf2_ros::Buffer buffer(clock, *node_);
+  tf2_ros::Buffer buffer(clock);
   tf2_ros::TransformListener tfl(buffer, *node_);
   tf2_ros::TransformBroadcaster tfb(*node_);
 

--- a/tf2_ros/test/velocity_test.cpp
+++ b/tf2_ros/test/velocity_test.cpp
@@ -48,6 +48,7 @@ protected:
 
   LinearVelocitySquareTest()
   {
+    auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
     rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
     buffer_ = std::make_shared<tf2_ros::Buffer>(clock);
 
@@ -158,6 +159,7 @@ protected:
 
   AngularVelocitySquareTest()
   {
+    auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");
     rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
     buffer_ = std::make_shared<tf2_ros::Buffer>(clock);
 
@@ -541,6 +543,7 @@ TEST_F(AngularVelocitySquareTest, AngularVelocityOffsetParentFrameInZ)
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
   auto ret = RUN_ALL_TESTS();
   rclcpp::shutdown();
   return ret;


### PR DESCRIPTION
Meant to resolve #698 this pull request deprecates and replaces all instances of `NodeT` within the `geometry2` repo with [`rclcpp::node_interfaces::NodeInterfaces`](https://github.com/ros2/rclcpp/blob/rolling/rclcpp/include/rclcpp/node_interfaces/node_interfaces.hpp). This PR also replaces #661 to close #95.

While the key is to deprecate the old templated node methods there are some kinks, particularly in the [`StaticTransformBroadcaster`](https://github.com/ros2/geometry2/blob/6e5f0433119b19b71c57fab06906cdf92e8c49c8/tf2_ros/include/tf2_ros/static_transform_broadcaster.h#L84-#L98) and [`TransformBroadcaster`](https://github.com/ros2/geometry2/blob/6e5f0433119b19b71c57fab06906cdf92e8c49c8/tf2_ros/include/tf2_ros/transform_broadcaster.h#L84-#L99) classes in which a dereferenced node will prefer this templated version opposed to an implicit conversion. This is fine if we decide to keep the `NodeT` constructors in addition to the `NodeInterfaces` ones, but I feel that's pointless as we're trying to remove as template code here as we can.