### PR TITLE
Error String Filled

### DIFF
--- a/tf2/src/cache.cpp
+++ b/tf2/src/cache.cpp
@@ -122,9 +122,7 @@ uint8_t TimeCache::findClosest(
 
   // No values stored
   if (storage_.empty()) {
-    if (error_code) {
-      *error_code = TF2Error::TF2_NO_DATA_FOR_EXTRAPOLATION_ERROR;
-    }
+    cache::createExtrapolationException1(target_time, TimePoint(), error_str, error_code);
     return 0;
   }
 


### PR DESCRIPTION
This pull request is meant to close #706 since it seems to be a quick resolve and isolated to just the one `error_code`. The only difference within this call to `createExtrapolationException1` would be the second argument as there shouldn't be a second time to compare it to. So, I went with our current defined behavior seen in the [`getLatestTimestamp`](https://github.com/ros2/geometry2/blob/efc784597ccbd8d246794e72b20358deab4ab114/tf2/src/cache.cpp#L319-#L321) function.

While we're here I will say there's no location where these functions are stress tested, should there be a class for tests among the cache functons?