### PR TITLE
tf2_echo: specifies quaternion order to be xyzw

### DIFF
--- a/tf2_ros/src/tf2_echo.cpp
+++ b/tf2_ros/src/tf2_echo.cpp
@@ -150,8 +150,8 @@ int main(int argc, char ** argv)
       auto rotation = echo_transform.transform.rotation;
       std::cout << "- Translation: [" << translation.x << ", " << translation.y << ", " <<
         translation.z << "]" << std::endl;
-      std::cout << "- Rotation: in Quaternion [" << rotation.x << ", " << rotation.y << ", " <<
-        rotation.z << ", " << rotation.w << "]" << std::endl;
+      std::cout << "- Rotation: in Quaternion (xyzw) [" << rotation.x << ", " << rotation.y <<
+        ", " << rotation.z << ", " << rotation.w << "]" << std::endl;
 
       tf2::Matrix3x3 mat(tf2::Quaternion{rotation.x, rotation.y, rotation.z, rotation.w});
 


### PR DESCRIPTION
Resolves #717

Targets `rolling` but can be backported to earlier distros that haven't reached EOL (`jazzy`, `iron`, `humble`) because the change is only a single `std::cout`.