### PR TITLE
Add Tf2 versions of lookupTransform, lookupVelocity, setTransform

### DIFF
--- a/tf2/include/tf2/buffer_core.h
+++ b/tf2/include/tf2/buffer_core.h
@@ -124,11 +124,28 @@ public:
 
   /*********** Accessors *************/
 
+  /**
+   * \brief Get the transform between two frames by frame ID.
+   * \param target_frame The frame to which data should be transformed.
+   * \param source_frame The frame where the data originated.
+   * \param time The time at which the value of the transform is desired (0 will get the latest).
+   * \return The transform between the frames.
+   *
+   * Possible exceptions tf2::LookupException, tf2::ConnectivityException,
+   * tf2::ExtrapolationException, tf2::InvalidArgumentException
+   */
+  TF2_PUBLIC
+  virtual tf2::Stamped<tf2::Transform>
+  lookupTransformTf2(
+    const std::string & target_frame,
+    const std::string & source_frame,
+    const tf2::TimePoint & time) const override;
+
   /** \brief Get the transform between two frames by frame ID.
    * \param target_frame The frame to which data should be transformed
    * \param source_frame The frame where the data originated
    * \param time The time at which the value of the transform is desired. (0 will get the latest)
-   * \return The transform between the frames
+   * \return The transform between the frames as a ROS type.
    *
    * Possible exceptions tf2::LookupException, tf2::ConnectivityException,
    * tf2::ExtrapolationException, tf2::InvalidArgumentException
@@ -139,13 +156,35 @@ public:
     const std::string & target_frame, const std::string & source_frame,
     const TimePoint & time) const override;
 
+  /**
+   * \brief Get the transform between two frames by frame ID assuming fixed frame.
+   * \param target_frame The frame to which data should be transformed.
+   * \param target_time The time to which the data should be transformed (0 will get the latest).
+   * \param source_frame The frame where the data originated.
+   * \param source_time The time at which the source_frame should be evaluated
+   *   (0 will get the latest).
+   * \param fixed_frame The frame in which to assume the transform is constant in time.
+   * \return The transform between the frames.
+   *
+   * Possible exceptions tf2::LookupException, tf2::ConnectivityException,
+   * tf2::ExtrapolationException, tf2::InvalidArgumentException
+   */
+  TF2_PUBLIC
+  virtual tf2::Stamped<tf2::Transform>
+  lookupTransformTf2(
+    const std::string & target_frame,
+    const tf2::TimePoint & target_time,
+    const std::string & source_frame,
+    const tf2::TimePoint & source_time,
+    const std::string & fixed_frame) const override;
+
   /** \brief Get the transform between two frames by frame ID assuming fixed frame.
    * \param target_frame The frame to which data should be transformed
    * \param target_time The time to which the data should be transformed. (0 will get the latest)
    * \param source_frame The frame where the data originated
    * \param source_time The time at which the source_frame should be evaluated. (0 will get the latest)
    * \param fixed_frame The frame in which to assume the transform is constant in time.
-   * \return The transform between the frames
+   * \return The transform between the frames as a ROS type.
    *
    * Possible exceptions tf2::LookupException, tf2::ConnectivityException,
    * tf2::ExtrapolationException, tf2::InvalidArgumentException
@@ -159,9 +198,31 @@ public:
     const std::string & fixed_frame) const override;
 
   TF2_PUBLIC
+  tf2::Stamped<std::pair<tf2::Vector3, tf2::Vector3>> lookupVelocityTf2(
+    const std::string & tracking_frame, const std::string & observation_frame,
+    const TimePoint & time, const tf2::Duration & averaging_interval) const;
+
+  TF2_PUBLIC
   geometry_msgs::msg::VelocityStamped lookupVelocity(
     const std::string & tracking_frame, const std::string & observation_frame,
     const TimePoint & time, const tf2::Duration & averaging_interval) const;
+
+  /** \brief Lookup the velocity of the moving_frame in the reference_frame
+   * \param reference_frame The frame in which to track
+   * \param moving_frame The frame to track
+   * \param time The time at which to get the velocity
+   * \param duration The period over which to average
+   * \param velocity The velocity output
+   *
+   * Possible exceptions TransformReference::LookupException, TransformReference::ConnectivityException,
+   * TransformReference::MaxDepthException
+   */
+  TF2_PUBLIC
+  tf2::Stamped<std::pair<tf2::Vector3, tf2::Vector3>> lookupVelocityTf2(
+    const std::string & tracking_frame, const std::string & observation_frame,
+    const std::string & reference_frame, const tf2::Vector3 & reference_point,
+    const std::string & reference_point_frame,
+    const TimePoint & time, const tf2::Duration & duration) const;
 
   /** \brief Lookup the velocity of the moving_frame in the reference_frame
    * \param reference_frame The frame in which to track

--- a/tf2/include/tf2/buffer_core.h
+++ b/tf2/include/tf2/buffer_core.h
@@ -135,7 +135,7 @@ public:
    * tf2::ExtrapolationException, tf2::InvalidArgumentException
    */
   TF2_PUBLIC
-  virtual tf2::Stamped<tf2::Transform>
+  tf2::Stamped<tf2::Transform>
   lookupTransformTf2(
     const std::string & target_frame,
     const std::string & source_frame,
@@ -170,7 +170,7 @@ public:
    * tf2::ExtrapolationException, tf2::InvalidArgumentException
    */
   TF2_PUBLIC
-  virtual tf2::Stamped<tf2::Transform>
+  tf2::Stamped<tf2::Transform>
   lookupTransformTf2(
     const std::string & target_frame,
     const tf2::TimePoint & target_time,

--- a/tf2/include/tf2/buffer_core.h
+++ b/tf2/include/tf2/buffer_core.h
@@ -229,7 +229,7 @@ public:
    * \param moving_frame The frame to track
    * \param time The time at which to get the velocity
    * \param duration The period over which to average
-   * \param velocity The velocity output
+   * \param velocity The velocity output as a ROS type
    *
    * Possible exceptions TransformReference::LookupException, TransformReference::ConnectivityException,
    * TransformReference::MaxDepthException

--- a/tf2/include/tf2/buffer_core_interface.h
+++ b/tf2/include/tf2/buffer_core_interface.h
@@ -67,6 +67,20 @@ public:
    * \return The transform between the frames.
    */
   TF2_PUBLIC
+  virtual tf2::Transform
+  lookupTransformTf2(
+    const std::string & target_frame,
+    const std::string & source_frame,
+    const tf2::TimePoint & time) const = 0;
+
+  /**
+   * \brief Get the transform between two frames by frame ID.
+   * \param target_frame The frame to which data should be transformed.
+   * \param source_frame The frame where the data originated.
+   * \param time The time at which the value of the transform is desired (0 will get the latest).
+   * \return The transform between the frames as a ROS type.
+   */
+  TF2_PUBLIC
   virtual geometry_msgs::msg::TransformStamped
   lookupTransform(
     const std::string & target_frame,
@@ -82,6 +96,25 @@ public:
    *   (0 will get the latest).
    * \param fixed_frame The frame in which to assume the transform is constant in time.
    * \return The transform between the frames.
+   */
+  TF2_PUBLIC
+  virtual tf2::Transform
+  lookupTransformTf2(
+    const std::string & target_frame,
+    const tf2::TimePoint & target_time,
+    const std::string & source_frame,
+    const tf2::TimePoint & source_time,
+    const std::string & fixed_frame) const = 0;
+
+  /**
+   * \brief Get the transform between two frames by frame ID assuming fixed frame.
+   * \param target_frame The frame to which data should be transformed.
+   * \param target_time The time to which the data should be transformed (0 will get the latest).
+   * \param source_frame The frame where the data originated.
+   * \param source_time The time at which the source_frame should be evaluated
+   *   (0 will get the latest).
+   * \param fixed_frame The frame in which to assume the transform is constant in time.
+   * \return The transform between the frames as a ROS type.
    */
   TF2_PUBLIC
   virtual geometry_msgs::msg::TransformStamped

--- a/tf2/include/tf2/buffer_core_interface.h
+++ b/tf2/include/tf2/buffer_core_interface.h
@@ -34,6 +34,7 @@
 #include "geometry_msgs/msg/transform_stamped.hpp"
 
 #include "tf2/time.h"
+#include "tf2/transform_datatypes.h"
 #include "tf2/visibility_control.h"
 
 namespace tf2
@@ -67,7 +68,7 @@ public:
    * \return The transform between the frames.
    */
   TF2_PUBLIC
-  virtual tf2::Transform
+  virtual tf2::Stamped<tf2::Transform>
   lookupTransformTf2(
     const std::string & target_frame,
     const std::string & source_frame,
@@ -98,7 +99,7 @@ public:
    * \return The transform between the frames.
    */
   TF2_PUBLIC
-  virtual tf2::Transform
+  virtual tf2::Stamped<tf2::Transform>
   lookupTransformTf2(
     const std::string & target_frame,
     const tf2::TimePoint & target_time,

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -710,7 +710,9 @@ tf2::Stamped<std::pair<tf2::Vector3, tf2::Vector3>> BufferCore::lookupVelocityTf
 
   const tf2::TimePoint out_time = tf2::timeFromSec(start_time + averaging_interval_seconds * 0.5);
 
-  return tf2::Stamped<std::pair<tf2::Vector3, tf2::Vector3>>({out_vel, out_rot}, out_time, reference_frame);
+  return tf2::Stamped<std::pair<tf2::Vector3, tf2::Vector3>>(
+    {out_vel, out_rot}, out_time,
+    reference_frame);
 }
 
 geometry_msgs::msg::VelocityStamped BufferCore::lookupVelocity(
@@ -719,7 +721,8 @@ geometry_msgs::msg::VelocityStamped BufferCore::lookupVelocity(
   const std::string & reference_point_frame,
   const TimePoint & time, const tf2::Duration & averaging_interval) const
 {
-  const tf2::Stamped<std::pair<tf2::Vector3, tf2::Vector3>> stamped_velocity = lookupVelocityTf2(tracking_frame, observation_frame, reference_frame,
+  const tf2::Stamped<std::pair<tf2::Vector3, tf2::Vector3>> stamped_velocity = lookupVelocityTf2(
+    tracking_frame, observation_frame, reference_frame,
     reference_point, reference_point_frame, time, averaging_interval);
 
   geometry_msgs::msg::VelocityStamped msg;
@@ -748,7 +751,9 @@ BufferCore::lookupTransformTf2(
   const TimePoint & time) const
 {
   tf2::Stamped<tf2::Transform> stamped_transform;
-  lookupTransformImpl(target_frame, source_frame, time, stamped_transform, stamped_transform.stamp_);
+  lookupTransformImpl(
+    target_frame, source_frame, time, stamped_transform,
+    stamped_transform.stamp_);
   stamped_transform.frame_id_ = target_frame;
   return stamped_transform;
 }
@@ -759,7 +764,9 @@ BufferCore::lookupTransform(
   const std::string & target_frame, const std::string & source_frame,
   const TimePoint & time) const
 {
-  const tf2::Stamped<tf2::Transform> stamped_transform = lookupTransformTf2(target_frame, source_frame, time);
+  const tf2::Stamped<tf2::Transform> stamped_transform = lookupTransformTf2(
+    target_frame,
+    source_frame, time);
 
   geometry_msgs::msg::TransformStamped msg = toMsg(stamped_transform);
   msg.child_frame_id = source_frame;
@@ -790,7 +797,12 @@ BufferCore::lookupTransform(
   const std::string & source_frame, const TimePoint & source_time,
   const std::string & fixed_frame) const
 {
-  const tf2::Stamped<tf2::Transform> stamped_transform = lookupTransformTf2(target_frame, target_time, source_frame, source_time, fixed_frame);
+  const tf2::Stamped<tf2::Transform> stamped_transform = lookupTransformTf2(
+    target_frame,
+    target_time,
+    source_frame,
+    source_time,
+    fixed_frame);
 
   geometry_msgs::msg::TransformStamped msg = toMsg(stamped_transform);
   msg.child_frame_id = source_frame;

--- a/tf2/test/cache_benchmark.cpp
+++ b/tf2/test/cache_benchmark.cpp
@@ -74,10 +74,10 @@ static void benchmark_insertion(benchmark::State & state)
   // First, fill the cache with max storage amount (the limit).
   tf2::TimeCache fill_cache(max_storage_time);
   const auto [fill_timestamp, fill_timestep] = insert_data(
-      fill_cache,
-      tf2::TimePointZero,
-      0,
-      tf2::TimePointZero + max_storage_time);
+    fill_cache,
+    tf2::TimePointZero,
+    0,
+    tf2::TimePointZero + max_storage_time);
 
   // Now profile adding new data to the copied cache.
   const tf2::TimePoint target_timestamp = fill_timestamp + max_storage_time;
@@ -88,10 +88,10 @@ static void benchmark_insertion(benchmark::State & state)
     state.ResumeTiming();
 
     insert_data(
-        cache,
-        fill_timestamp,
-        fill_timestep,
-        target_timestamp);
+      cache,
+      fill_timestamp,
+      fill_timestep,
+      target_timestamp);
   }
 }
 

--- a/tf2/test/cache_unittest.cpp
+++ b/tf2/test/cache_unittest.cpp
@@ -137,8 +137,8 @@ TEST(TimeCache, GetAllItems)
   // Note that the difference between the oldest and newest timestamp is exactly equal
   // to the max storage duration.
   EXPECT_EQ(
-      cache.getLatestTimestamp() - cache.getOldestTimestamp(),
-      max_storage_time);
+    cache.getLatestTimestamp() - cache.getOldestTimestamp(),
+    max_storage_time);
 
   // Expect that storage is descending.
   const std::list<tf2::TransformStorage> & storage_expected{


### PR DESCRIPTION
This PR implements #726 - see there for initial discussion.

Some notes:
 * No response was given for naming, so I went with `*Tf2`.
 * I'm not totally pleased with `lookupVelocity` - tf2 doesn't have a dual vector type that I can find, and I didn't really want to implement a new `Velocity` for this PR. I'm happy to back that part of the change out - the function can be moved wholesale into `tf2_ros` when the time comes, instead, as it's not part of `BufferCoreInterface`.
 * I combined the two manual reimplementations of `toMsg` into one reimplementation - it really shows that the interface is wrong here in the first place - the helper methods that should be used would cause a depedency loop.
 * tf2::Transform doesn't have a `child_frame_id` - I think I did the correct thing, but it might be worth introducing somehow.
 * ~~I'm unable to actually run the tests - I get an error on `colcon build`~~
 * My version of colcon doesn't appear to have filter support, testing is a little hard. I think the solution here is to use an underlay, will experiment
