### PR TITLE
Add a python3-dev dependency to tf2_py.

### DIFF
--- a/tf2_geometry_msgs/CMakeLists.txt
+++ b/tf2_geometry_msgs/CMakeLists.txt
@@ -25,7 +25,7 @@ endif()
 cmake_policy(SET CMP0094 NEW)
 set(Python3_FIND_UNVERSIONED_NAMES FIRST)
 
-find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
 find_package(geometry_msgs REQUIRED)
 find_package(orocos_kdl_vendor REQUIRED)

--- a/tf2_py/package.xml
+++ b/tf2_py/package.xml
@@ -16,6 +16,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>geometry_msgs</build_depend>
+  <build_depend>python3-dev</build_depend>
 
   <depend>tf2</depend>
 

--- a/tf2_sensor_msgs/CMakeLists.txt
+++ b/tf2_sensor_msgs/CMakeLists.txt
@@ -25,7 +25,7 @@ endif()
 cmake_policy(SET CMP0094 NEW)
 set(Python3_FIND_UNVERSIONED_NAMES FIRST)
 
-find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
 find_package(eigen3_cmake_module REQUIRED)
 find_package(Eigen3 REQUIRED)


### PR DESCRIPTION
This is needed because it depends on Python.h being available, and it also calls find_package(Python3 Development).

While we are in here, we also remove "Development" from the find_package(Python3) calls in tf2_geometry_msgs and tf2_sensor_msgs. In both of those cases, we only need the interpreter, not the header files.

Also see https://github.com/ros2/ros2_tracing/pull/146#issuecomment-2492724725 for a long explanation of why we need this.