### PR TITLE
tf2_kdl: add python_orocos_kdl_vendor dependency

### DIFF
--- a/tf2_kdl/CMakeLists.txt
+++ b/tf2_kdl/CMakeLists.txt
@@ -45,7 +45,6 @@ install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(rclcpp REQUIRED)
-  find_package(tf2_msgs REQUIRED)
 
   ament_add_gtest(test_kdl test/test_tf2_kdl.cpp)
   target_link_libraries(test_kdl

--- a/tf2_kdl/package.xml
+++ b/tf2_kdl/package.xml
@@ -22,6 +22,7 @@
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
 
+  <exec_depend>python_orocos_kdl_vendor</exec_depend>
   <exec_depend>tf2_ros_py</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>

--- a/tf2_kdl/package.xml
+++ b/tf2_kdl/package.xml
@@ -27,7 +27,6 @@
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>rclcpp</test_depend>
-  <test_depend>tf2_msgs</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
The tf2_kdl Python API depends on PyKDL, which is provided by python_orocos_kdl_vendor.