### PR TITLE
Fixed deadlock in destructor in TransformListener

### DIFF
--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -32,6 +32,7 @@
 #ifndef TF2_ROS__TRANSFORM_LISTENER_H_
 #define TF2_ROS__TRANSFORM_LISTENER_H_
 
+#include <atomic>
 #include <functional>
 #include <memory>
 #include <thread>
@@ -211,7 +212,13 @@ private:
       // Create executor with dedicated thread to spin.
       executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
       executor_->add_callback_group(callback_group_, node_base_interface_);
-      dedicated_listener_thread_ = std::make_unique<std::thread>([&]() {executor_->spin();});
+      running_.store(true);
+      dedicated_listener_thread_ = std::make_unique<std::thread>(
+        [&]() {
+          while (running_.load()) {
+            executor_->spin_once();
+          }
+        });
       // Tell the buffer we have a dedicated thread to enable timeouts
       buffer_.setUsingDedicatedThread(true);
     } else {
@@ -229,6 +236,7 @@ private:
     }
   }
 
+  std::atomic<bool> running_;
   bool spin_thread_{false};
   std::unique_ptr<std::thread> dedicated_listener_thread_ {nullptr};
   rclcpp::Executor::SharedPtr executor_ {nullptr};

--- a/tf2_ros/src/transform_listener.cpp
+++ b/tf2_ros/src/transform_listener.cpp
@@ -71,6 +71,7 @@ TransformListener::TransformListener(tf2::BufferCore & buffer, bool spin_thread,
 TransformListener::~TransformListener()
 {
   if (spin_thread_) {
+    running_.store(false);
     executor_->cancel();
     dedicated_listener_thread_->join();
   }


### PR DESCRIPTION
Updated patch of merge request https://github.com/ros2/geometry2/pull/518
Related issue: https://github.com/ros2/geometry2/issues/517

This is issue is still affecting Humble and causes, for example, timeouts in unit tests. The linked merge request provides an example of how to reproduce this issue. 