### PR TITLE
Jazzy remove python cmake and python-dev update (backport #651 #733) 

### DIFF
--- a/tf2_geometry_msgs/CMakeLists.txt
+++ b/tf2_geometry_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(tf2_geometry_msgs)
 
 # Default to C++17
@@ -10,14 +10,22 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -Wnon-virtual-dtor -Woverloaded-virtual)
 endif()
 
-# Figure out Python3 debug/release before anything else can find_package it
-if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
-  find_package(python_cmake_module REQUIRED)
-  find_package(PythonExtra REQUIRED)
-  # Force FindPython3 to use the debug interpretter where ROS 2 expects it
-  set(Python3_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
-endif()
-find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+# By default, without the settings below, find_package(Python3) will attempt
+# to find the newest python version it can, and additionally will find the
+# most specific version.  For instance, on a system that has
+# /usr/bin/python3.10, /usr/bin/python3.11, and /usr/bin/python3, it will find
+# /usr/bin/python3.11, even if /usr/bin/python3 points to /usr/bin/python3.10.
+# The behavior we want is to prefer the "system" installed version unless the
+# user specifically tells us othewise through the Python3_EXECUTABLE hint.
+# Setting CMP0094 to NEW means that the search will stop after the first
+# python version is found.  Setting Python3_FIND_UNVERSIONED_NAMES means that
+# the search will prefer /usr/bin/python3 over /usr/bin/python3.11.  And that
+# latter functionality is only available in CMake 3.20 or later, so we need
+# at least that version.
+cmake_policy(SET CMP0094 NEW)
+set(Python3_FIND_UNVERSIONED_NAMES FIRST)
+
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
 find_package(geometry_msgs REQUIRED)
 find_package(orocos_kdl_vendor REQUIRED)

--- a/tf2_geometry_msgs/package.xml
+++ b/tf2_geometry_msgs/package.xml
@@ -15,7 +15,6 @@
   <author>Wim Meeussen</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>python_cmake_module</buildtool_depend>
 
   <depend>geometry_msgs</depend>
   <depend>orocos_kdl_vendor</depend>

--- a/tf2_py/CMakeLists.txt
+++ b/tf2_py/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(tf2_py)
 
 # Default to C++17
@@ -21,13 +21,21 @@ if(CMAKE_COMPILER_IS_GNUCXX)
   add_compile_options(-Wno-cast-function-type)
 endif()
 
-# Figure out Python3 debug/release before anything else can find_package it
-if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
-  find_package(python_cmake_module REQUIRED)
-  find_package(PythonExtra REQUIRED)
-  # Force FindPython3 to use the debug interpretter where ROS 2 expects it
-  set(Python3_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
-endif()
+# By default, without the settings below, find_package(Python3) will attempt
+# to find the newest python version it can, and additionally will find the
+# most specific version.  For instance, on a system that has
+# /usr/bin/python3.10, /usr/bin/python3.11, and /usr/bin/python3, it will find
+# /usr/bin/python3.11, even if /usr/bin/python3 points to /usr/bin/python3.10.
+# The behavior we want is to prefer the "system" installed version unless the
+# user specifically tells us othewise through the Python3_EXECUTABLE hint.
+# Setting CMP0094 to NEW means that the search will stop after the first
+# python version is found.  Setting Python3_FIND_UNVERSIONED_NAMES means that
+# the search will prefer /usr/bin/python3 over /usr/bin/python3.11.  And that
+# latter functionality is only available in CMake 3.20 or later, so we need
+# at least that version.
+cmake_policy(SET CMP0094 NEW)
+set(Python3_FIND_UNVERSIONED_NAMES FIRST)
+
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
 
 find_package(ament_cmake REQUIRED)
@@ -41,7 +49,7 @@ python3_add_library(_tf2_py src/tf2_py.cpp)
 
 if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
   # python3_add_library should really take care of this for us, but it doesn't
-  set_property(TARGET _tf2_py PROPERTY SUFFIX "_d.pyd")
+  set_target_properties(_tf2_py PROPERTIES DEBUG_POSTFIX "_d")
 endif()
 
 # Set output directories to import module from the build directory

--- a/tf2_py/package.xml
+++ b/tf2_py/package.xml
@@ -14,7 +14,6 @@
   <author email="tfoote@osrfoundation.org">Tully Foote</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>python_cmake_module</buildtool_depend>
 
   <build_depend>geometry_msgs</build_depend>
 

--- a/tf2_py/package.xml
+++ b/tf2_py/package.xml
@@ -16,6 +16,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>geometry_msgs</build_depend>
+  <build_depend>python3-dev</build_depend>
 
   <depend>tf2</depend>
 

--- a/tf2_sensor_msgs/CMakeLists.txt
+++ b/tf2_sensor_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(tf2_sensor_msgs)
 
 # Default to C++17
@@ -10,14 +10,22 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -Wnon-virtual-dtor -Woverloaded-virtual)
 endif()
 
-# Figure out Python3 debug/release before anything else can find_package it
-if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
-  find_package(python_cmake_module REQUIRED)
-  find_package(PythonExtra REQUIRED)
-  # Force FindPython3 to use the debug interpretter where ROS 2 expects it
-  set(Python3_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
-endif()
-find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+# By default, without the settings below, find_package(Python3) will attempt
+# to find the newest python version it can, and additionally will find the
+# most specific version.  For instance, on a system that has
+# /usr/bin/python3.10, /usr/bin/python3.11, and /usr/bin/python3, it will find
+# /usr/bin/python3.11, even if /usr/bin/python3 points to /usr/bin/python3.10.
+# The behavior we want is to prefer the "system" installed version unless the
+# user specifically tells us othewise through the Python3_EXECUTABLE hint.
+# Setting CMP0094 to NEW means that the search will stop after the first
+# python version is found.  Setting Python3_FIND_UNVERSIONED_NAMES means that
+# the search will prefer /usr/bin/python3 over /usr/bin/python3.11.  And that
+# latter functionality is only available in CMake 3.20 or later, so we need
+# at least that version.
+cmake_policy(SET CMP0094 NEW)
+set(Python3_FIND_UNVERSIONED_NAMES FIRST)
+
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
 find_package(eigen3_cmake_module REQUIRED)
 find_package(Eigen3 REQUIRED)

--- a/tf2_sensor_msgs/package.xml
+++ b/tf2_sensor_msgs/package.xml
@@ -16,7 +16,6 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
-  <buildtool_depend>python_cmake_module</buildtool_depend>
 
   <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>
 


### PR DESCRIPTION
When building Jazzy on windows I noticed that the new cmake changes for python where necessary for it to build (#651). I've also included the python-dev update PR (#733) that weren't backported as well.

Since this is my first PR in this repo doing a backport, I'd like to see if I have done this according to the contributing rules (I've followed the [developer guide here](https://docs.ros.org/en/jazzy/The-ROS2-Project/Contributing/Developer-Guide.html)). If it all checks out I could also backport these PRs to to Humble. 