### PR TITLE
uniform cmake min version

### DIFF
--- a/geometry2/CMakeLists.txt
+++ b/geometry2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(geometry2 NONE)
 find_package(ament_cmake REQUIRED)
 ament_package()

--- a/test_tf2/CMakeLists.txt
+++ b/test_tf2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 
 project(test_tf2)
 

--- a/tf2/CMakeLists.txt
+++ b/tf2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(tf2)
 
 # Default to C++17

--- a/tf2_bullet/CMakeLists.txt
+++ b/tf2_bullet/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(tf2_bullet)
 
 # Default to C++17

--- a/tf2_eigen/CMakeLists.txt
+++ b/tf2_eigen/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(tf2_eigen)
 
 # Default to C++17

--- a/tf2_eigen_kdl/CMakeLists.txt
+++ b/tf2_eigen_kdl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(tf2_eigen_kdl)
 
 # Default to C++17

--- a/tf2_kdl/CMakeLists.txt
+++ b/tf2_kdl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(tf2_kdl)
 
 # Default to C++17

--- a/tf2_msgs/CMakeLists.txt
+++ b/tf2_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(tf2_msgs)
 
 # Default to C++17

--- a/tf2_ros/CMakeLists.txt
+++ b/tf2_ros/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(tf2_ros)
 
 # Default to C++17


### PR DESCRIPTION
cmake <3.10 is deprecated.
Uniform minimum cmake version to the same version used in the tf2/CMakeLists.txt test library