### PR TITLE
Overflow Issue in durationFromSec() Function when Handling Extremely Large or Small Values

### DIFF
--- a/tf2/src/time.cpp
+++ b/tf2/src/time.cpp
@@ -43,8 +43,7 @@ tf2::TimePoint tf2::get_now()
 
 tf2::Duration tf2::durationFromSec(double t_sec)
 {
-  if (t_sec > std::numeric_limits<int32_t>::max() || t_sec < std::numeric_limits<int32_t>::min())
-  {
+  if (t_sec > std::numeric_limits<int32_t>::max() || t_sec < std::numeric_limits<int32_t>::min()) {
     throw std::overflow_error("Input t_sec is too large or too small for tf2::Duration");
   }
   int32_t sec, nsec;

--- a/tf2/src/time.cpp
+++ b/tf2/src/time.cpp
@@ -43,6 +43,10 @@ tf2::TimePoint tf2::get_now()
 
 tf2::Duration tf2::durationFromSec(double t_sec)
 {
+  if (t_sec > std::numeric_limits<int32_t>::max() || t_sec < std::numeric_limits<int32_t>::min())
+  {
+    throw std::overflow_error("Input t_sec is too large or too small for tf2::Duration");
+  }
   int32_t sec, nsec;
   sec = static_cast<int32_t>(floor(t_sec));
   nsec = static_cast<int32_t>(std::round((t_sec - sec) * 1e9));

--- a/tf2/test/test_time.cpp
+++ b/tf2/test/test_time.cpp
@@ -97,3 +97,21 @@ TEST(TestTime, displayTimePoint) {
   EXPECT_EQ(tf2::displayTimePoint(tf2::TimePoint(1000ns)), "0.000001");
   EXPECT_EQ(tf2::displayTimePoint(tf2::TimePoint(-1000ns)), "-0.000001");
 }
+
+TEST(TestTime, durationFromSec_LargeNegativeValues) {
+  int32_t large_negative = std::numeric_limits<int32_t>::min();
+  EXPECT_EQ(tf2::durationFromSec(large_negative), large_negative * 1s);
+}
+
+TEST(TestTime, durationFromSec_LargePositiveValues) {
+  int32_t large_positive = std::numeric_limits<int32_t>::max();
+  EXPECT_EQ(tf2::durationFromSec(large_positive), large_positive * 1s);
+}
+
+TEST(TestTime, durationFromSec_OverflowNegativeValues) {
+  EXPECT_THROW(tf2::durationFromSec(-1e308), std::overflow_error);
+}
+
+TEST(TestTime, durationFromSec_OverflowPositiveValues) {
+  EXPECT_THROW(tf2::durationFromSec(1e308), std::overflow_error);
+}


### PR DESCRIPTION
Closes #770 

Adds a check to throw an overflow_error to avoid failing silently when input is extremly large or small. 