### PR TITLE
Fix message filter target frames string

### DIFF
--- a/tf2_ros/include/tf2_ros/message_filter.h
+++ b/tf2_ros/include/tf2_ros/message_filter.h
@@ -309,8 +309,7 @@ public:
     expected_success_count_ = target_frames_.size() * (time_tolerance_.nanoseconds() ? 2 : 1);
 
     std::stringstream ss;
-      it != target_frames_.end(); ++it)
-    {
+    for (V_string::iterator it = target_frames_.begin(); it != target_frames_.end(); ++it) {
       ss << *it;
       if (std::next(it) != target_frames_.end()) {
         ss << ", ";

--- a/tf2_ros/include/tf2_ros/message_filter.h
+++ b/tf2_ros/include/tf2_ros/message_filter.h
@@ -309,8 +309,8 @@ public:
     expected_success_count_ = target_frames_.size() * (time_tolerance_.nanoseconds() ? 2 : 1);
 
     std::stringstream ss;
-    for (V_string::iterator it = target_frames_.begin();
-         it != target_frames_.end(); ++it) {
+      it != target_frames_.end(); ++it)
+    {
       ss << *it;
       if (std::next(it) != target_frames_.end()) {
         ss << ", ";

--- a/tf2_ros/include/tf2_ros/message_filter.h
+++ b/tf2_ros/include/tf2_ros/message_filter.h
@@ -309,8 +309,12 @@ public:
     expected_success_count_ = target_frames_.size() * (time_tolerance_.nanoseconds() ? 2 : 1);
 
     std::stringstream ss;
-    for (V_string::iterator it = target_frames_.begin(); it != target_frames_.end(); ++it) {
-      ss << *it << " ";
+    for (V_string::iterator it = target_frames_.begin();
+         it != target_frames_.end(); ++it) {
+      ss << *it;
+      if (std::next(it) != target_frames_.end()) {
+        ss << ", ";
+      }
     }
     target_frames_string_ = ss.str();
   }

--- a/tf2_ros/test/message_filter_test.cpp
+++ b/tf2_ros/test/message_filter_test.cpp
@@ -119,6 +119,23 @@ TEST(tf2_ros_message_filter, construction_and_destruction)
   }
 }
 
+TEST(tf2_ros_message_filter, get_target_frames)
+{
+  auto node = rclcpp::Node::make_shared("test_message_filter_node");
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+  tf2_ros::Buffer buffer(clock);
+
+  tf2_ros::MessageFilter<geometry_msgs::msg::PointStamped> filter(buffer, "map", 10, node);
+  ASSERT_STREQ(filter.getTargetFramesString().c_str(), "map");
+
+  std::vector<std::string> frames;
+  frames.push_back("odom");
+  frames.push_back("map");
+  filter.setTargetFrames(frames);
+  ASSERT_STREQ(filter.getTargetFramesString().c_str(), "odom, map");
+}
+
+
 TEST(tf2_ros_message_filter, multiple_frames_and_time_tolerance)
 {
   auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");

--- a/tf2_ros/test/message_filter_test.cpp
+++ b/tf2_ros/test/message_filter_test.cpp
@@ -135,7 +135,6 @@ TEST(tf2_ros_message_filter, get_target_frames)
   ASSERT_STREQ(filter.getTargetFramesString().c_str(), "odom, map");
 }
 
-
 TEST(tf2_ros_message_filter, multiple_frames_and_time_tolerance)
 {
   auto node = rclcpp::Node::make_shared("tf2_ros_message_filter");


### PR DESCRIPTION
## Description

Before this change, the call of `getTargetFramesString()` was returning
extra trailing whitespace.
I faced it while using `PointCloudOctomapUpdater` from `moveit2`,
because it [was showing](https://github.com/moveit/moveit2/blob/main/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp#L136C38-L136C59):
```
[move_group.moveit.moveit.ros.pointcloud_octomap_updater]: Listening to '/point_cloud' using message filter with target frame 'base '
```
even though `base`  was set in the configuration.

After this change, it will be:

```
[move_group.moveit.moveit.ros.pointcloud_octomap_updater]: Listening to '/point_cloud' using message filter with target frame 'base'
```
or `base, map` in case of several target frames.

### Is this user-facing behavior change?

It reduces the confusion of an incorrect set of `target_frame` while debugging issues.

### Did you use Generative AI?

Grammarly to check the grammar issues with the description of this PR.
