### PR TITLE
Fix deprecation warning

### DIFF
--- a/tf2_ros_py/setup.py
+++ b/tf2_ros_py/setup.py
@@ -21,7 +21,6 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
@@ -29,5 +28,9 @@ setup(
         'This package contains the ROS Python bindings for the tf2 library.'
     ),
     license='BSD',
-    tests_require=['pytest'],
+    extras_require={
+        'test' : [
+            'pytest'
+        ]
+    },
 )

--- a/tf2_ros_py/setup.py
+++ b/tf2_ros_py/setup.py
@@ -29,7 +29,7 @@ setup(
     ),
     license='BSD',
     extras_require={
-        'test' : [
+        'test': [
             'pytest'
         ]
     },


### PR DESCRIPTION


## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

**FIX:**

#UserWarning: Unknown distribution option: 'tests_require'

**and**

#SetuptoolsDeprecationWarning: License classifiers are deprecated. !!

    ********************************************************************************
    Please consider removing the following classifiers in favor of a SPDX license expression:

    License :: OSI Approved :: BSD License

    See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
    ********************************************************************************
### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
