### PR TITLE
Add RPY quaternion constructor

### DIFF
--- a/tf2/include/tf2/LinearMath/Quaternion.hpp
+++ b/tf2/include/tf2/LinearMath/Quaternion.hpp
@@ -48,6 +48,15 @@ public:
 	{ 
 		setRotation(axis, angle); 
 	}
+  /**@brief Constructor from fixed axis RPY
+   * @param roll Angle around X
+   * @param pitch Angle around Y
+   * @param yaw Angle around Z */
+        TF2_PUBLIC
+	Quaternion(const tf2Scalar& roll, const tf2Scalar& pitch, const tf2Scalar& yaw) 
+	{
+		setRPY(roll, pitch, yaw);
+	}
   /**@brief Set the rotation using axis angle notation 
    * @param axis The axis around which to rotate
    * @param angle The magnitude of the rotation in Radians */


### PR DESCRIPTION
## Description

I was trying to migrate a ROS 1 code to ROS 2 for a 2D application where it was necessary to create Quaternion msgs from yaw. This was possible back then with [createQuaternionMsgFromYaw](https://docs.ros.org/en/noetic/api/tf/html/c++/namespacetf.html#a09ddb5ff50f5032761feaa6a760f7344). I see a similar [utility function also in nav2_util](https://github.com/ros-navigation/navigation2/blob/ee2d7789e70a968e6194af08030b425f3c591084/nav2_util/include/nav2_util/geometry_utils.hpp#L40).

To keep it a one liner in `tf2` I thought a constructor from RPY could help alot. This way, the abovementioned can be achieved with the following:

`geometry_msgs::msg::Quaternion quaternion_msg = tf2::toMsg(tf2::Quaternion(r,p,y))` 
