### PR TITLE
Ensure variable is considered volatile in message_filter_test

### DIFF
--- a/tf2_ros/test/message_filter_test.cpp
+++ b/tf2_ros/test/message_filter_test.cpp
@@ -27,6 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <atomic>
 #include <memory>
 #include <string>
 #include <vector>
@@ -47,7 +48,7 @@
 #include "geometry_msgs/msg/point_stamped.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
 
-uint8_t filter_callback_fired = 0;
+std::atomic<uint8_t> filter_callback_fired = 0;
 void filter_callback(const geometry_msgs::msg::PointStamped & msg)
 {
   (void)msg;
@@ -206,8 +207,8 @@ TEST(tf2_ros_message_filter, multiple_frames_and_time_tolerance)
     pub->publish(point);
     rclcpp::spin_some(node);
     loop_rate.sleep();
-    RCLCPP_INFO(node->get_logger(), "filter callback: trigger(%d)", filter_callback_fired);
-    if (filter_callback_fired > 5) {
+    RCLCPP_INFO(node->get_logger(), "filter callback: trigger(%d)", filter_callback_fired.load());
+    if (filter_callback_fired.load() > 5) {
       break;
     }
   }


### PR DESCRIPTION
Fixes a test never ending due to compiler optimizing away the variable if considered constant

## Description

A failure in CI was reported https://build.ros2.org/job/Rci__nightly-connext_ubuntu_noble_amd64/465/testReport/junit/(root)/projectroot/tf2_ros_test_message_filter/ and the log show a never-ending loop where the counter that is supposed to increase from 0 to 5 stays at 0. 

https://godbolt.org/z/bPqnaEheh here the different compiled asm can be seen with and without the atomic/volatile keyword. In particular the comparison with 5 is removed when not using volatile. 

### Is this user-facing behavior change?

No 

### Did you use Generative AI?

No need

### Additional Information

I applied the fix by code inspection, did not run any test to prove it works. But see my reasoning above