### PR TITLE
ger rid of deprecated rclcpp::spin_some().

### DIFF
--- a/tf2_ros/test/message_filter_test.cpp
+++ b/tf2_ros/test/message_filter_test.cpp
@@ -202,10 +202,12 @@ TEST(tf2_ros_message_filter, multiple_frames_and_time_tolerance)
   point.point.y = 0.2;
   point.point.z = 0.3;
 
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
   rclcpp::WallRate loop_rate(1);
   while (rclcpp::ok()) {
     pub->publish(point);
-    rclcpp::spin_some(node);
+    executor.spin_some();
     loop_rate.sleep();
     RCLCPP_INFO(node->get_logger(), "filter callback: trigger(%d)", filter_callback_fired.load());
     if (filter_callback_fired.load() > 5) {

--- a/tf2_ros/test/test_transform_listener.cpp
+++ b/tf2_ros/test/test_transform_listener.cpp
@@ -181,11 +181,13 @@ TEST(tf2_test_listeners, static_vs_dynamic)
   dynamic_trans.child_frame_id = "child_dynamic";
   dynamic_trans.transform.rotation.w = 1.0;
 
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
   for (int i = 0; i < 10; ++i) {
     dynamic_trans.header.stamp = clock->now();
     broadcaster.sendTransform(dynamic_trans);
 
-    rclcpp::spin_some(node);
+    executor.spin_some();
     rclcpp::sleep_for(std::chrono::milliseconds(10));
   }
 

--- a/tf2_ros/test/time_reset_test.cpp
+++ b/tf2_ros/test/time_reset_test.cpp
@@ -42,11 +42,13 @@
 
 void spin_for_a_second(std::shared_ptr<rclcpp::Node> & node)
 {
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
   rclcpp::Rate r(10);
-  rclcpp::spin_some(node);
+  executor.spin_some();
   for (int i = 0; i < 10; ++i) {
     r.sleep();
-    rclcpp::spin_some(node);
+    executor.spin_some();
   }
 }
 
@@ -97,7 +99,9 @@ TEST(tf2_ros_time_reset_test, time_backwards)
   // clock_pub->publish(c);
   //
   // // make sure it arrives
-  // rclcpp::spin_some(node_);
+  // rclcpp::executors::SingleThreadedExecutor executor;
+  // executor.add_node(node_);
+  // executor.spin_some();
   // sleep(1);
   //
   // //Send anoterh message to trigger clock test on an unrelated frame
@@ -108,7 +112,7 @@ TEST(tf2_ros_time_reset_test, time_backwards)
   // tfb.sendTransform(msg);
   //
   // // make sure it arrives
-  // rclcpp::spin_some(node_);
+  // executor.spin_some();
   // sleep(1);
   //
   // //verify the data's been cleared


### PR DESCRIPTION
## Description

This depends on https://github.com/ros2/rclcpp/pull/2848

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

No

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
