### PR TITLE
Removed deprecation rclcpp::spin_some(node)

### DIFF
--- a/tf2_ros/test/message_filter_test.cpp
+++ b/tf2_ros/test/message_filter_test.cpp
@@ -324,9 +324,11 @@ TEST(tf2_ros_message_filter, multiple_frames_and_time_tolerance_deprecated)
   point.point.z = 0.3;
 
   rclcpp::WallRate loop_rate(1);
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
   while (rclcpp::ok()) {
     pub->publish(point);
-    rclcpp::spin_some(node);
+    executor.spin_some();
     loop_rate.sleep();
     RCLCPP_INFO(node->get_logger(), "filter callback: trigger(%d)", filter_callback_fired.load());
     if (filter_callback_fired.load() > 5) {

--- a/tf2_ros/test/test_transform_listener.cpp
+++ b/tf2_ros/test/test_transform_listener.cpp
@@ -267,11 +267,14 @@ TEST(tf2_test_listeners, static_vs_dynamic_deprecated)
   dynamic_trans.child_frame_id = "child_dynamic";
   dynamic_trans.transform.rotation.w = 1.0;
 
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+
   for (int i = 0; i < 10; ++i) {
     dynamic_trans.header.stamp = clock->now();
     broadcaster.sendTransform(dynamic_trans);
 
-    rclcpp::spin_some(node);
+    executor.spin_some();
     rclcpp::sleep_for(std::chrono::milliseconds(10));
   }
 


### PR DESCRIPTION
Related with https://ci.ros2.org/job/ci_linux-aarch64/18727/clang/
Removed deprecation rclcpp::spin_some(node)