### PR TITLE
Adding explicit handling for normalization of zero-quaternions for tf2

### DIFF
--- a/tf2/include/tf2/LinearMath/Quaternion.hpp
+++ b/tf2/include/tf2/LinearMath/Quaternion.hpp
@@ -207,6 +207,14 @@ public:
 	Quaternion& operator/=(const tf2Scalar& s) 
 	{
 		tf2Assert(s != tf2Scalar(0.0));
+		if(s == tf2Scalar(0.0))
+		{
+			this->setValue(tf2Scalar(std::numeric_limits<tf2Scalar>::quiet_NaN()),
+						   tf2Scalar(std::numeric_limits<tf2Scalar>::quiet_NaN()),
+						   tf2Scalar(std::numeric_limits<tf2Scalar>::quiet_NaN()),
+						   tf2Scalar(std::numeric_limits<tf2Scalar>::quiet_NaN()));
+			return *this;
+		}
 		return *this *= tf2Scalar(1.0) / s;
 	}
 

--- a/tf2/test/simple_tf2_core.cpp
+++ b/tf2/test/simple_tf2_core.cpp
@@ -40,6 +40,7 @@
 
 #include "tf2/buffer_core.hpp"
 #include "tf2/convert.hpp"
+#include "tf2/LinearMath/Quaternion.hpp"
 #include "tf2/LinearMath/Vector3.hpp"
 #include "tf2/exceptions.hpp"
 #include "tf2/time.hpp"
@@ -407,6 +408,16 @@ TEST(tf2_convert, Covariance_RowMajor_To_Nested)
 
   // check the result
   ASSERT_EQ(expected, result);
+}
+
+TEST(tf2_quaternion, Normalize_Quaternion)
+{
+  tf2::Quaternion zero_value_q(-0, -0, -0, 0);
+  zero_value_q.normalize();
+  EXPECT_TRUE(std::isnan(zero_value_q.x()));
+  EXPECT_TRUE(std::isnan(zero_value_q.y()));
+  EXPECT_TRUE(std::isnan(zero_value_q.z()));
+  EXPECT_TRUE(std::isnan(zero_value_q.w()));
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

Now explicitly setting the resulting quaternion to all NaN values if normalizing a zero quaternion. Previously behavior would depend on implementation specific behavior.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #825 

### Is this user-facing behavior change?

No
<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
