### PR TITLE
Cleanup TF2 dependencies

### DIFF
--- a/tf2/CMakeLists.txt
+++ b/tf2/CMakeLists.txt
@@ -122,7 +122,7 @@ if(BUILD_TESTING)
   endif()
 endif()
 
-ament_export_dependencies(geometry_msgs rcutils rosidl_runtime_cpp)
+ament_export_dependencies(geometry_msgs rosidl_runtime_cpp)
 
 # Export old-style CMake variables
 ament_export_include_directories("include/${PROJECT_NAME}")

--- a/tf2/include/tf2/buffer_core.hpp
+++ b/tf2/include/tf2/buffer_core.hpp
@@ -47,7 +47,6 @@
 #include "LinearMath/Transform.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "geometry_msgs/msg/velocity_stamped.hpp"
-#include "rcutils/logging_macros.h"
 #include "tf2/buffer_core_interface.hpp"
 #include "tf2/exceptions.hpp"
 #include "tf2/transform_storage.hpp"

--- a/tf2/package.xml
+++ b/tf2/package.xml
@@ -27,9 +27,11 @@
   <build_depend>rosidl_runtime_cpp</build_depend>
   <build_export_depend>rosidl_runtime_cpp</build_export_depend>
 
+  <build_depend>rcutils</build_depend>
+  <exec_depend>rcutils</exec_depend>
+
   <depend>builtin_interfaces</depend>
   <depend>geometry_msgs</depend>
-  <depend>rcutils</depend>
 
   <test_depend>ament_cmake_google_benchmark</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -31,14 +31,18 @@
 #include <algorithm>
 #include <cassert>
 #include <chrono>
+#include <cmath>
+#include <ios>
 #include <map>
 #include <memory>
 #include <mutex>
+#include <ostream>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
 
-#include <iostream>
+#include "rcutils/logging_macros.h"
 
 #include "tf2/buffer_core.hpp"
 #include "tf2/time_cache.hpp"

--- a/tf2_py/CMakeLists.txt
+++ b/tf2_py/CMakeLists.txt
@@ -40,6 +40,7 @@ find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
+find_package(builtin_interfaces REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 
@@ -61,6 +62,7 @@ set_target_properties(_tf2_py PROPERTIES
 )
 
 target_link_libraries(_tf2_py PRIVATE
+  ${builtin_interfaces_TARGETS}
   ${geometry_msgs_TARGETS}
   tf2::tf2
 )

--- a/tf2_py/package.xml
+++ b/tf2_py/package.xml
@@ -3,27 +3,29 @@
 <package format="2">
   <name>tf2_py</name>
   <version>0.45.1</version>
-  <description>The tf2_py package</description>
+  <description>Python bindings for the tf2 library</description>
 
   <maintainer email="alejandro@openrobotics.org">Alejandro Hernandez Cordero</maintainer>
   <maintainer email="clalancette@openrobotics.org">Chris Lalancette</maintainer>
 
   <license>BSD</license>
-  <url type="website">http://ros.org/wiki/tf2_py</url>
+  <url type="website">http://index.ros.org/p/tf2_py</url>
 
   <author email="tfoote@osrfoundation.org">Tully Foote</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
 
+  <build_depend>builtin_interfaces</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>python3-dev</build_depend>
-
-  <depend>tf2</depend>
+  <build_depend>tf2</build_depend>
 
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rpyutils</exec_depend>
+  <exec_depend>tf2</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>

--- a/tf2_ros_py/package.xml
+++ b/tf2_ros_py/package.xml
@@ -15,7 +15,6 @@
   <author email="tfoote@osrfoundation.org">Tully Foote</author>
   <author>Wim Meeussen</author>
 
-  <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
@@ -23,9 +22,11 @@
   <exec_depend>tf2_msgs</exec_depend>
   <exec_depend>tf2_py</exec_depend>
 
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
   <test_depend>python3-pytest</test_depend>
-  <test_depend>sensor_msgs</test_depend>
 
   <export>
     <build_type>ament_python</build_type>


### PR DESCRIPTION
## Description

While working on some other things, I realized that some of the dependencies here in the tf2 packages weren't quite right:

1.  `tf2` does not need to export `rcutils` as a dependency; it can just be a private dependency
2.  Minor cleanup of the standard includes for tf2 buffer_core.cpp
3.  `tf2_py` depends on `builtin_interfaces`, so it should properly declare a dependency on it.
4.  Update the description and URL for `tf2_py`.
5.  `tf2_ros_py` does *not* depend on `builtin_interfaces`, so we don't need a dependency on it.
6.  `tf2_ros_py` already has an `exec_depend` on `sensor_msgs`, so it should not also have a `test_depend`.
7.  `tf2_ros_py` needs dependencies for its tests.

### Is this user-facing behavior change?

Probably not.  There is a minor possibility that a downstream package was relying on `tf2` to export `rcutils` for it, but a) most downstream packages don't use `rcutils` directly, and b) many other packages in the ROS ecosystem indirectly depend on `rcutils`, so they probably won't notice anyway.

### Did you use Generative AI?

No.

### Additional Information
