### PR TITLE
Add conversions for Accel and Eigen

### DIFF
--- a/tf2_eigen/include/tf2_eigen/tf2_eigen.hpp
+++ b/tf2_eigen/include/tf2_eigen/tf2_eigen.hpp
@@ -31,6 +31,7 @@
 
 #include <Eigen/Geometry>
 
+#include "geometry_msgs/msg/accel.hpp"
 #include "geometry_msgs/msg/point.hpp"
 #include "geometry_msgs/msg/point_stamped.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
@@ -534,6 +535,22 @@ void fromMsg(const geometry_msgs::msg::Twist & msg, Eigen::Matrix<double, 6, 1> 
   out[5] = msg.angular.z;
 }
 
+/** \brief Convert an Accel message transform type to an Eigen 6x1 Matrix.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param msg The Accel message to convert.
+ * \param out The accel converted to an Eigen 6x1 Matrix.
+ */
+inline
+void fromMsg(const geometry_msgs::msg::Accel & msg, Eigen::Matrix<double, 6, 1> & out)
+{
+  out[0] = msg.linear.x;
+  out[1] = msg.linear.y;
+  out[2] = msg.linear.z;
+  out[3] = msg.angular.x;
+  out[4] = msg.angular.y;
+  out[5] = msg.angular.z;
+}
+
 /** \brief Apply a geometry_msgs TransformStamped to an Eigen Affine3d transform.
  * This function is a specialization of the doTransform template defined in tf2/convert.h,
  * although it can not be used in tf2_ros::BufferInterface::transform because this
@@ -685,6 +702,12 @@ geometry_msgs::msg::Twist toMsg(const Eigen::Matrix<double, 6, 1> & in)
 
 inline
 void fromMsg(const geometry_msgs::msg::Twist & msg, Eigen::Matrix<double, 6, 1> & out)
+{
+  tf2::fromMsg(msg, out);
+}
+
+inline
+void fromMsg(const geometry_msgs::msg::Accel & msg, Eigen::Matrix<double, 6, 1> & out)
 {
   tf2::fromMsg(msg, out);
 }


### PR DESCRIPTION
Currently there are conversions available between Eigen and Twist but not Accel. With this PR, I wanted to add the same type of conversion for Accel as well.

I have added `fromMSg` but I also wish to add `toMsg` for Accel. However, since Eigen just uses a 6x1 matrix, there would be no distinction between a Twist Eigen matrix and an Acceleration Eigen matrix. Hence the `toMsg` for Accel would then have the same input as the Eigen to Twist `toMsg` and it would throw ambiguity error:

```
geometry_msgs::msg::Twist toMsg(const Eigen::Matrix<double, 6, 1> & in)
{
  geometry_msgs::msg::Twist msg;
  msg.linear.x = in[0];
  msg.linear.y = in[1];
  msg.linear.z = in[2];
  msg.angular.x = in[3];
  msg.angular.y = in[4];
  msg.angular.z = in[5];
  return msg;
}

geometry_msgs::msg::Accel toMsg(const Eigen::Matrix<double, 6, 1> & in)
{
  geometry_msgs::msg::Accel msg;
  msg.linear.x = in[0];
  msg.linear.y = in[1];
  msg.linear.z = in[2];
  msg.angular.x = in[3];
  msg.angular.y = in[4];
  msg.angular.z = in[5];
  return msg;
}
```

A workaround for this would be to also pass the output as reference for acceleration's `toMsg` hence keeping the api the same for Twist's `toMsg` while introducing a new one for Accel but that would be against the current design pattern for `toMsg` functions. Curious to know what you think:

```
void toMsg(const Eigen::Matrix<double, 6, 1> & in, geometry_msgs::msg::Accel& out )
{
  out.linear.x = in[0];
  out.linear.y = in[1];
  out.linear.z = in[2];
  out.angular.x = in[3];
  out.angular.y = in[4];
  out.angular.z = in[5];
}
```

If you think it is okay to allow such `toMsg` implementation for Eigen to Accel then I will extend the PR.