### PR TITLE
Skip tf2_ros_py test_buffer on Windows to avoid buildfarm aborted bui…

### DIFF
--- a/tf2_ros_py/test/test_buffer.py
+++ b/tf2_ros_py/test/test_buffer.py
@@ -28,6 +28,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import sys
 import pytest
 import rclpy
 
@@ -146,3 +147,9 @@ class TestBuffer:
         assert transform.transform.translation.x == output.transform.translation.x
         assert transform.transform.translation.y == output.transform.translation.y
         assert transform.transform.translation.z == output.transform.translation.z
+
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Flaky on Windows CI; contributes to aborted builds, see osrf/buildfarmer#360"
+)


### PR DESCRIPTION
This PR improves CI stability by skipping tf2_ros_py/test_buffer.py on Windows.

According to osrf/buildfarmer#360, several Windows Debug/Release buildfarm jobs abort because of this test.
On Linux (ROS 2 Jazzy) the test passes consistently, so the issue appears to be Windows-specific.

This PR adds a conditional skip:

pytest.mark.skipif(sys.platform == "win32", ...)


allowing the test to continue running on Linux while avoiding CI aborts on Windows.

Validation

Local verification done on Linux (WSL):

colcon test --packages-select tf2_ros_py
colcon test-result --verbose


Result:

202 tests, 0 errors, 0 failures, 51 skipped

Fixes

Fixes osrf/buildfarmer#360

Is this user-facing behavior change?

No — only affects CI test execution on Windows.

Did you use Generative AI?

Yes — ChatGPT was used to assist with debugging instructions and PR wording.
All code changes were written and verified manually.

Additional Information

This PR should reduce aborted Windows jobs on the ROS buildfarm while the root cause of the test flakiness is investigated.