### PR TITLE
static function to crate quaternions directly from rotation added

### DIFF
--- a/tf2/include/tf2/LinearMath/Quaternion.hpp
+++ b/tf2/include/tf2/LinearMath/Quaternion.hpp
@@ -370,6 +370,45 @@ public:
 		return identityQuat;
 	}
 
+  /**@brief Creates a quaternion using fixed axis RPY
+   * @param roll Angle around X
+   * @param pitch Angle around Y
+   * @param yaw Angle around Z
+   * @return new created quaternion */
+        TF2_PUBLIC
+  static Quaternion createFromRPY(const tf2Scalar& roll, const tf2Scalar& pitch, const tf2Scalar& yaw)
+	{
+		Quaternion q;
+		q.setRPY(roll, pitch, yaw);
+		return q;
+	}
+
+  /**@brief Creates a quaternion using Euler angles
+   * @param yaw Angle around Y
+   * @param pitch Angle around X
+   * @param roll Angle around Z
+   * @return new created quaternion */
+        TF2_PUBLIC
+  static Quaternion createFromEuler(const tf2Scalar& roll, const tf2Scalar& pitch, const tf2Scalar& yaw)
+	{
+		Quaternion q;
+		q.setEuler(roll, pitch, yaw);
+		return q;
+	}
+	
+  /**@brief Creates a quaternion using axis angle notation
+   * @param axis The axis around which to rotate
+   * @param angle The magnitude of the rotation in Radians
+   * @return new created quaternion */
+        TF2_PUBLIC
+	static Quaternion createFromRotation(const Vector3& axis, const tf2Scalar& angle)
+	{
+		Quaternion q;
+		q.setRotation(axis, angle);
+		return q;
+	}
+
+
 	TF2SIMD_FORCE_INLINE const tf2Scalar& getW() const { return m_floats[3]; }
 
 	


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

Creating quaternions from rotations takes some extra lines of code.
```cpp
tf2::Transform t;
tf2::Quaternion q;
q.setRPY(roll, pitch, yaw);
t.setRotation(q);
....
```

With the change it is possible to create quaternions instantly like
```cpp
tf2::Transform t;
t.setRotation(tf2::Quaternion::createFromRPY(roll, pitch, yaw));
```

I am also happy and willing to add this feature also to tf2::Transforms and so on.

Or are there any reasons why no static functions are used in the geometry2 package?


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
