### PR TITLE
Extend eigen-accel conversions

### DIFF
--- a/test_tf2/test/test_convert.cpp
+++ b/test_tf2/test/test_convert.cpp
@@ -191,6 +191,38 @@ TEST(tf2Convert, PointVectorOtherMessagetype)
   }
 }
 
+TEST(tf2Convert, AccelEigenConversion)
+{
+  geometry_msgs::msg::Accel accel_msg;
+  accel_msg.linear.x = 1.0;
+  accel_msg.linear.y = 2.0;
+  accel_msg.linear.z = 3.0;
+  accel_msg.angular.x = 4.0;
+  accel_msg.angular.y = 5.0;
+  accel_msg.angular.z = 6.0;
+
+  Eigen::Matrix<double, 6, 1> accel_eigen;
+  tf2::fromMsg(accel_msg, accel_eigen);
+
+  EXPECT_EQ(accel_eigen[0], accel_msg.linear.x);
+  EXPECT_EQ(accel_eigen[1], accel_msg.linear.y);
+  EXPECT_EQ(accel_eigen[2], accel_msg.linear.z);
+  EXPECT_EQ(accel_eigen[3], accel_msg.angular.x);
+  EXPECT_EQ(accel_eigen[4], accel_msg.angular.y);
+  EXPECT_EQ(accel_eigen[5], accel_msg.angular.z);
+
+  geometry_msgs::msg::Accel accel_msg_converted;
+  auto & accel_msg_converted_ref = tf2::toMsg(accel_eigen, accel_msg_converted);
+
+  EXPECT_EQ(&accel_msg_converted_ref, &accel_msg_converted);
+  EXPECT_EQ(accel_msg.linear.x, accel_msg_converted.linear.x);
+  EXPECT_EQ(accel_msg.linear.y, accel_msg_converted.linear.y);
+  EXPECT_EQ(accel_msg.linear.z, accel_msg_converted.linear.z);
+  EXPECT_EQ(accel_msg.angular.x, accel_msg_converted.angular.x);
+  EXPECT_EQ(accel_msg.angular.y, accel_msg_converted.angular.y);
+  EXPECT_EQ(accel_msg.angular.z, accel_msg_converted.angular.z);
+}
+
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/tf2_eigen/include/tf2_eigen/tf2_eigen.hpp
+++ b/tf2_eigen/include/tf2_eigen/tf2_eigen.hpp
@@ -537,8 +537,28 @@ void fromMsg(const geometry_msgs::msg::Twist & msg, Eigen::Matrix<double, 6, 1> 
   out[5] = msg.angular.z;
 }
 
+/** \brief Convert an Eigen 6x1 Matrix type to an Accel message.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
+ * \param in The 6x1 Eigen Matrix to convert.
+ * \param out The Eigen Matrix converted to an Accel message.
+ * \return The Eigen Matrix converted to an Accel message.
+ */
+inline
+geometry_msgs::msg::Accel & toMsg(
+  const Eigen::Matrix<double, 6, 1> & in,
+  geometry_msgs::msg::Accel & out)
+{
+  out.linear.x = in[0];
+  out.linear.y = in[1];
+  out.linear.z = in[2];
+  out.angular.x = in[3];
+  out.angular.y = in[4];
+  out.angular.z = in[5];
+  return out;
+}
+
 /** \brief Convert an Accel message transform type to an Eigen 6x1 Matrix.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param msg The Accel message to convert.
  * \param out The accel converted to an Eigen 6x1 Matrix.
  */
@@ -706,6 +726,14 @@ inline
 void fromMsg(const geometry_msgs::msg::Twist & msg, Eigen::Matrix<double, 6, 1> & out)
 {
   tf2::fromMsg(msg, out);
+}
+
+inline
+geometry_msgs::msg::Accel & toMsg(
+  const Eigen::Matrix<double, 6, 1> & in,
+  geometry_msgs::msg::Accel & out)
+{
+  return tf2::toMsg(in, out);
 }
 
 inline


### PR DESCRIPTION
As promised in my [previous PR](https://github.com/ros2/geometry2/pull/844), I have extended the conversions by introducing the `toMsg` for converting an Eigen matrix to an Accel message. I kept the function signature similar to other `toMsg` ones that have ambiguity with other types (e.g.,  [Vector3d and Point](https://github.com/ros2/geometry2/blob/rolling/tf2_eigen/include/tf2_eigen/tf2_eigen.hpp#L217) or [Vector3 and Point32](https://github.com/ros2/geometry2/blob/rolling/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.hpp#L280)).

Furthuremore, I added some tests for both `fromMsg` as well as `toMsg` functions of eigen-accel conversions.

The only thing that I am a bit doubting is why in docstrings of such `toMsg` functions it is always said:
`This function is a specialization of the toMsg template defined in tf2/convert.h.`
I could not find any `toMsg` template with such function signature i.e., two inputs. [There's only this](https://github.com/ros2/geometry2/blob/rolling/tf2/include/tf2/convert.hpp#L131):

```
template<typename A, typename B>
B toMsg(const A & a);
```

 Am I missing something? In any case, I have kept the docstring the same also here.