### PR TITLE
Copy child_frame_id from input

### DIFF
--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.hpp
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.hpp
@@ -1179,6 +1179,7 @@ void doTransform(
     t_out.transform.rotation.z, t_out.transform.rotation.w);
   t_out.header.stamp = transform.header.stamp;
   t_out.header.frame_id = transform.header.frame_id;
+  t_out.child_frame_id = t_in.child_frame_id;
 }
 
 /** \brief Trivial "conversion" function for Transform message type.


### PR DESCRIPTION
## Description

Copy the child_frame_id from the input transform message in doTransform of TransformStamped to make it work even if the input and output arguments are not the same object.

Fixes #888 

### Is this user-facing behavior change?

Minor. 
The behavior differs only the case where the field was previously not set. If a user sets its themself there would still be no difference, if the user does not use the field they are not affected by the change.

### Did you use Generative AI?
No

