### PR TITLE
tf2: backport error code handling to humble

### DIFF
--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -434,7 +434,7 @@ tf2::TF2Error BufferCore::walkToTopParent(
                << "]";
             *error_string = ss.str();
           }
-          return extrapolation_error_code;
+          return tf2::TF2Error::TF2_EXTRAPOLATION_ERROR;
         }
       }
       if (error_string) {


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
Fixes build errors at Jenkins #[18548](https://ci.ros2.org/job/ci_launcher/18548) at #899
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

### Is this user-facing behavior change?
No
<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?
No... 
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information
The commit basically stops using `extrapolation_error_code` which seems to be used in later versions of geometry2, instead just return `tf2::TF2Error::TF2_EXTRAPOLATION_ERROR` 
<!--
If applicable, provide any additional context or details about the changes.
-->
