### PR TITLE
prevent AttributeError when static_only=true

### DIFF
--- a/tf2_ros_py/tf2_ros/transform_listener.py
+++ b/tf2_ros_py/tf2_ros/transform_listener.py
@@ -127,7 +127,8 @@ class TransformListener:
 
     def unregister(self) -> None:
         """Unregisters all tf subscribers."""
-        self.node.destroy_subscription(self.tf_sub)
+        if hasattr(self, 'tf_sub'):
+            self.node.destroy_subscription(self.tf_sub)
         self.node.destroy_subscription(self.tf_static_sub)
 
     def callback(self, data: TFMessage) -> None:


### PR DESCRIPTION
## Description

preventing AttributeError when the listener was created with static_only=True

### Did you use Generative AI?

Claude Sonnet 4.6
