### PR TITLE
Fix StaticCache::getData() returning true on empty cache

### DIFF
--- a/tf2/include/tf2/time_cache.hpp
+++ b/tf2/include/tf2/time_cache.hpp
@@ -192,6 +192,7 @@ public:
 
 private:
   TransformStorage storage_;
+  bool populated_{false};
 };
 }  // namespace tf2
 #endif  // TF2__TIME_CACHE_HPP_

--- a/tf2/src/static_cache.cpp
+++ b/tf2/src/static_cache.cpp
@@ -40,8 +40,16 @@ bool tf2::StaticCache::getData(
   tf2::TimePoint time,
   tf2::TransformStorage & data_out, std::string * error_str, TF2Error * error_code)
 {
-  (void)error_code;
-  (void)error_str;
+  (void)time;
+  if (!populated_) {
+    if (error_str) {
+      *error_str = "Static cache is empty";
+    }
+    if (error_code) {
+      *error_code = TF2Error::TF2_LOOKUP_ERROR;
+    }
+    return false;
+  }
   data_out = storage_;
   data_out.stamp_ = time;
   return true;
@@ -50,12 +58,13 @@ bool tf2::StaticCache::getData(
 bool tf2::StaticCache::insertData(const tf2::TransformStorage & new_data)
 {
   storage_ = new_data;
+  populated_ = true;
   return true;
 }
 
-void tf2::StaticCache::clearList() {}
+void tf2::StaticCache::clearList() {populated_ = false;}
 
-unsigned tf2::StaticCache::getListLength() {return 1;}
+unsigned tf2::StaticCache::getListLength() {return populated_ ? 1 : 0;}
 
 tf2::CompactFrameID tf2::StaticCache::getParent(
   tf2::TimePoint time, std::string * error_str,
@@ -64,7 +73,7 @@ tf2::CompactFrameID tf2::StaticCache::getParent(
   (void)time;
   (void)error_code;
   (void)error_str;
-  return storage_.frame_id_;
+  return populated_ ? storage_.frame_id_ : 0;
 }
 
 tf2::P_TimeAndFrameID tf2::StaticCache::getLatestTimeAndParent()


### PR DESCRIPTION
## Summary

Fixes #769

`StaticCache::getData()` unconditionally returned `true` even when no data had been inserted via `insertData()`. This caused callers to read uninitialized `TransformStorage`, leading to incorrect transform data.

**Changes:**
- Add a `populated_` flag to `StaticCache` that tracks whether `insertData()` has been called
- `getData()` now returns `false` with `TF2_LOOKUP_ERROR` when the cache is empty
- `clearList()` resets the `populated_` flag
- `getListLength()` returns 0 when empty (was hardcoded to 1)
- `getParent()` returns 0 when empty

## Test plan

- [x] Full tf2 test suite: 12/12 pass (100%)
- [x] `test_static_cache_unittest` passes — existing tests for populated cache still work
- [x] `test_cache_unittest` passes — dynamic cache unaffected
- [x] All linters pass (copyright, cppcheck, cpplint, uncrustify, xmllint)