### PR TITLE
fix: doTransform of VelocityStamped added input vector after transform

### DIFF
--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.hpp
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.hpp
@@ -1373,13 +1373,13 @@ void doTransform(
   //   ros::Duration(0.1), interframe_twist);
   // \todo get rid of hard coded number
 
-  t_out.header = t_in.header;
-  t_out.velocity.linear.x = out_vel.x() + t_in.velocity.linear.x;
-  t_out.velocity.linear.y = out_vel.y() + t_in.velocity.linear.y;
-  t_out.velocity.linear.z = out_vel.z() + t_in.velocity.linear.z;
-  t_out.velocity.angular.x = out_rot.x() + t_in.velocity.angular.x;
-  t_out.velocity.angular.y = out_rot.y() + t_in.velocity.angular.y;
-  t_out.velocity.angular.z = out_rot.z() + t_in.velocity.angular.z;
+  t_out.header = transform.header;
+  t_out.velocity.linear.x = out_vel.x();
+  t_out.velocity.linear.y = out_vel.y();
+  t_out.velocity.linear.z = out_vel.z();
+  t_out.velocity.angular.x = out_rot.x();
+  t_out.velocity.angular.y = out_rot.y();
+  t_out.velocity.angular.z = out_rot.z();
 }
 
 /**********************/

--- a/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
+++ b/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
@@ -667,6 +667,60 @@ TEST(TfGeometry, Velocity)
   tf2::doTransform(v1, res, trafo);
 }
 
+TEST(TfGeometry, VelocityIdentityRotation)
+{
+  geometry_msgs::msg::VelocityStamped v1, res;
+  v1.header.frame_id = "world";
+  v1.body_frame_id = "base_link";
+  v1.velocity.linear.x = 1.0;
+  v1.velocity.linear.y = 2.0;
+  v1.velocity.linear.z = 3.0;
+  v1.velocity.angular.x = 4.0;
+  v1.velocity.angular.y = 5.0;
+  v1.velocity.angular.z = 6.0;
+
+  geometry_msgs::msg::TransformStamped trafo;
+  trafo.header.frame_id = "map";
+  trafo.transform.rotation = tf2::toMsg(tf2::Quaternion::getIdentity());
+
+  tf2::doTransform(v1, res, trafo);
+
+  EXPECT_EQ(res.header.frame_id, trafo.header.frame_id);
+  EXPECT_NEAR(res.velocity.linear.x, v1.velocity.linear.x, EPS);
+  EXPECT_NEAR(res.velocity.linear.y, v1.velocity.linear.y, EPS);
+  EXPECT_NEAR(res.velocity.linear.z, v1.velocity.linear.z, EPS);
+  EXPECT_NEAR(res.velocity.angular.x, v1.velocity.angular.x, EPS);
+  EXPECT_NEAR(res.velocity.angular.y, v1.velocity.angular.y, EPS);
+  EXPECT_NEAR(res.velocity.angular.z, v1.velocity.angular.z, EPS);
+}
+
+TEST(TfGeometry, VelocityTranslation)
+{
+  geometry_msgs::msg::VelocityStamped v1, res;
+  v1.header.frame_id = "world";
+  v1.velocity.linear.x = 1.0;
+  v1.velocity.linear.y = 2.0;
+  v1.velocity.linear.z = 3.0;
+  v1.velocity.angular.x = 0.0;
+  v1.velocity.angular.y = 0.0;
+  v1.velocity.angular.z = 1.0;
+
+  geometry_msgs::msg::TransformStamped trafo;
+  trafo.header.frame_id = "map";
+  trafo.transform.translation.x = 1.0;
+  trafo.transform.rotation = tf2::toMsg(tf2::Quaternion::getIdentity());
+
+  tf2::doTransform(v1, res, trafo);
+
+  EXPECT_EQ(res.header.frame_id, trafo.header.frame_id);
+  EXPECT_NEAR(res.velocity.linear.x, 1.0, EPS);
+  EXPECT_NEAR(res.velocity.linear.y, 1.0, EPS);
+  EXPECT_NEAR(res.velocity.linear.z, 3.0, EPS);
+  EXPECT_NEAR(res.velocity.angular.x, 0.0, EPS);
+  EXPECT_NEAR(res.velocity.angular.y, 0.0, EPS);
+  EXPECT_NEAR(res.velocity.angular.z, 1.0, EPS);
+}
+
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Generated-by: GitHub Copilot

## Description

The implementation added the input vector to the transformed vector and caused inflated values.  The fix removes the sum of input vector. Two test cases were added for identity transform and for a translation. 

Fixes #817 

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

GitHub Copilot for tests

### Additional Information

There are some comments in the method body which I did not touch. They imply that they are partially from ROS 1 and that the intent was have a time-aware and relative frame velocity transform. I did not do that and simply used an instantaneous rigid transform. This is the same behavior as the other implementation of `doTransform` in that file. 
