### PR TITLE
Catching lookupTransform()

### DIFF
--- a/tf2_ros/include/tf2_ros/message_filter.hpp
+++ b/tf2_ros/include/tf2_ros/message_filter.hpp
@@ -497,14 +497,20 @@ public:
       const auto & handle = std::get<0>(param);
       const auto & stamp = std::get<1>(param);
       const auto & target_frame = std::get<2>(param);
-      tf2_ros::TransformStampedFuture future = buffer_.waitForTransform(
-        target_frame,
-        frame_id,
-        stamp,
-        buffer_timeout_,
-        std::bind(&MessageFilter::transformReadyCallback, this, std::placeholders::_1, handle));
+      tf2_ros::TransformStampedFuture future;
+      try {
+        future = buffer_.waitForTransform(
+          target_frame,
+          frame_id,
+          stamp,
+          buffer_timeout_,
+          std::bind(&MessageFilter::transformReadyCallback, this, std::placeholders::_1, handle));
+      } catch (const tf2::TransformException & ex) {
+        RCLCPP_ERROR(node->get_logger(), "waitForTransform failed: %s", ex.what());
+        continue;
+      }
 
-      // If handle of future is 0 or 0xffffffffffffffffULL, waitForTransform have already called
+      // If handle of future is 0 or 0xffffffffffffffffULL, waitForTransform has already called
       // the callback.
       if (0 != future.getHandle() && 0xffffffffffffffffULL != future.getHandle()) {
         std::unique_lock<std::mutex> lock(ts_futures_mutex_);


### PR DESCRIPTION
## Description

We had a scenario, in which a point cloud had timestamps sometimes older than 10 seconds. This caused problems for the Spatio Temporal Voxel Layer,  because when calling lookupTransform(), canTransform(), doTransform() it couldn't retrieve a transform for a point cloud this old since the tf buffer already timed out.

I didn't create an issue yet.
Fixes # (issue)

### Did you use Generative AI?

Claude Code Sonnet 4.6

### Additional Information

The original core dump was
```
#0  __pthread_kill_implementation (threadid=281472917954528, signo=signo@entry=6, no_tid=no_tid@entry=0) at ./nptl/pthread_kill.c:44
#1  0x0000ffffba3a7670 in __pthread_kill_internal (signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:78
#2  0x0000ffffba35cb3c in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#3  0x0000ffffba347e00 in __GI_abort () at ./stdlib/abort.c:79
#4  0x0000ffffba5cd4d8 in __gnu_cxx::__verbose_terminate_handler() () from /lib/aarch64-linux-gnu/libstdc++.so.6
#5  0x0000ffffba5ca570 [PAC] in ?? () from /lib/aarch64-linux-gnu/libstdc++.so.6
#6  0x0000ffffba5c0e04 [PAC] in std::terminate() () from /lib/aarch64-linux-gnu/libstdc++.so.6
#7  0x0000ffffba5ca908 [PAC] in __cxa_throw () from /lib/aarch64-linux-gnu/libstdc++.so.6
#8  0x0000ffffb94ee804 [PAC] in tf2::BufferCore::lookupTransformImpl(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > > const&, tf2::Transform&, std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >&) const () from /opt/ros/jazzy/lib/libtf2.so
#9  0x0000ffffb94ee86c [PAC] in tf2::BufferCore::lookupTransform(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > > const&) const ()
   from /opt/ros/jazzy/lib/libtf2.so
#10 0x0000ffffb9410d08 [PAC] in tf2_ros::Buffer::waitForTransform(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > > const&, std::chrono::duration<long, std::ratio<1l, 1000000000l> > const&, std::function<void (tf2_ros::TransformStampedFuture const&)>) () from /opt/ros/jazzy/lib/libtf2_ros.so
#11 0x0000ffff8af9ba80 [PAC] in ?? () from /opt/ros/jazzy/lib/libspatio_temporal_voxel_layer_core.so
#12 0x0000ffff8afc12fc [PAC] in ?? () from /opt/ros/jazzy/lib/libspatio_temporal_voxel_layer_core.so
#13 0x0000ffff8afac398 [PAC] in std::_Function_handler<void (std::shared_ptr<sensor_msgs::msg::PointCloud2_<std::allocator<void> > const>), message_filters::Subscriber<sensor_msgs::msg::PointCloud2_<std::allocator<void> >, rclcpp_lifecycle::LifecycleNode>::subscribe(rclcpp_lifecycle::LifecycleNode*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, rmw_qos_profile_s, rclcpp::SubscriptionOptionsWithAllocator<std::allocator<void> >)::{lambda(std::shared_ptr<sensor_msgs::msg::PointCloud2_<std::allocator<void> > const>)#1}>::_M_invoke(std::_Any_data const&, std::shared_ptr<sensor_msgs::msg::PointCloud2_<std::allocator<void> > const>&&) () from /opt/ros/jazzy/lib/libspatio_temporal_voxel_layer_core.so
#14 0x0000ffff8afc826c [PAC] in std::__detail::__variant::__gen_vtable_impl<std::__detail::__variant::_Multi_array<std::__detail::__variant::__deduce_visit_result<void> (*)(rclcpp::AnySubscriptionCallback<sensor_msgs::msg::PointCloud2_<std::allocator<void> >, std::allocator<void> >::dispatch<sensor_msgs::msg::PointCloud2_<std::allocator<void> > >(std::shared_ptr<sensor_msgs::msg::PointCloud2_<std::allocator<void> > >, rclcpp::MessageInfo const&)::{lambda(auto:1&&)#1}&&, std::variant<std::function<void (sensor_msgs::msg::PointCloud2_<std::allocator<void> > const&)>, std::function<void (sensor_msgs::msg::PointCloud2_<std::allocator<void> > const&, rclcpp::MessageInfo const&)>, std::function<void (rclcpp::SerializedMessage const&)>, std::function<void (rclcpp::SerializedMessage const&, rclcpp::MessageInfo const&)>, std::function<void (std::unique_ptr<sensor_msgs::msg::PointCloud2_<std::allocator<void> >, std::default_delete<sensor_msgs::msg::PointCloud2_<std::allocator<void> > > >)>, std::function<void (std::unique_ptr<sensor_msgs::msg::PointCloud2_<std::allocator<void> >, std::default_delete<sensor_msgs::msg::PointCloud2_<std::allocator<void> > > >, rclcpp::MessageInfo const&)>, std::function<void (std::unique_ptr<rclcpp::SerializedMessage, std::default_delete<rclcpp::SerializedMessage> >)>, std::function<void (std::unique_ptr<rclcpp::SerializedMessage, std::default_delete<rclcpp::SerializedMessage> >, rclcpp::MessageInfo const&)>, std::function<void (std::shared_ptr<sensor_msgs::msg::PointCloud2_<std::allocator<void> > const>)>, std::function<void (std::shared_ptr<sensor_msgs::msg::PointCloud2_<std::allocator<void> > const>, rclcpp::MessageInfo const&)>, std::function<void (std::shared_ptr<rclcpp::SerializedMessage const>)>, std::function<void (std::shared_ptr<rclcpp::SerializedMessage const>, rclcpp::MessageInfo const&)>, std::function<void (std::shared_ptr<sensor_msgs::msg::PointCloud2_<std::allocator<void> > const> const&)>, std::function<void (std::shared_ptr<sensor_msgs::msg::PointCloud2_<std::allocator<void> > const> const&, rclcpp::MessageInfo const&)>, std::function<void (std::shared_ptr<rclcpp::SerializedMessage const> const&)>, std::function<void (std::shared_ptr<rclcpp::SerializedMessage const> const&, rclcpp::MessageInfo const&)>, std::function<void (std::shared_ptr<sensor_msgs::msg::PointCloud2_<std::allocator<void> > >)>, std::function<void (std::shared_ptr<sensor_msgs::msg::PointCloud2_<std::allocator<void> > >, rclcpp::MessageInfo const&)>, std::function<void (std::shared_ptr<rclcpp::SerializedMessage>)>, std::function<void (std::shared_ptr<rclcpp::SerializedMessage>, rclcpp::MessageInfo const&)> >&)>, std::integer_sequence<unsigned long, 8ul> >::__visit_invoke(rclcpp::AnySubscriptionCallback<sensor_msgs::msg::PointCloud2_<std::allocator<void> >, std::allocator<void> >::dispatch<sensor_msgs::msg::PointCloud2_<std::allocator<void> > >(std::shared_ptr<sensor_msgs::msg::PointCloud2_<std::allocator<void> > >, rclcpp::MessageInfo const&)::{lambda(auto:1&&)#1}&&, std::variant<std::function<void (sensor_msgs::msg::PointCloud2_<std::allocator<void> > const&)>, std::function<void (sensor_msgs::msg::PointCloud2_<std::allocator<void> > const&, rclcpp::MessageInfo const&)>, std::function<void (rclcpp::SerializedMessage const&)>, std::function<void (rclcpp::SerializedMessage const&, rclcpp::MessageInfo const&)>, std::function<void (std::unique_ptr<sensor_msgs::msg::PointCloud2_<std::allocator<void> >, std::default_delete<sensor_msgs::msg::PointCloud2_<std::allocator<void> > > >)>, std::function<void (std::unique_ptr<sensor_msgs::msg::PointCloud2_<std::allocator<void> >, std::default_delete<sensor_msgs::msg::PointCloud2_<std::allocator<void> > > >, rclcpp::MessageInfo const&)>, std::function<void (std::unique_ptr<rclcpp::SerializedMessage, std::default_delete<rclcpp::SerializedMessage> >)>, std::function<void (std::unique_ptr<rclcpp::SerializedMessage, std::default_delete<rclcpp::SerializedMessage> >, rclcpp::MessageInfo const&)>, std::function<void (std::shared_ptr<sensor_msgs::msg::PointCloud2_<std::allocator<void> > const>)>, std::function<void (std::shared_ptr<sensor_msgs::msg::PointCloud2_<std::allocator<void> > const>, rclcpp::MessageInfo const&)>, std::function<void (std::shared_ptr<rclcpp::SerializedMessage const>)>, std::function<void (std::shared_ptr<rclcpp::SerializedMessage const>, rclcpp::MessageInfo const&)>, std::function<void (std::shared_ptr<sensor_msgs::msg::PointCloud2_<std::allocator<void> > const> const&)>, std::function<void (std::shared_ptr<sensor_msgs::msg::PointCloud2_<std::allocator<void> > const> const&, rclcpp::MessageInfo const&)>, std::function<void (std::shared_ptr<rclcpp::SerializedMessage const> const&)>, std::function<void (std::shared_ptr<rclcpp::SerializedMessage const> const&, rclcpp::MessageInfo const&)>, std::function<void (std::shared_ptr<sensor_msgs::msg::PointCloud2_<std::allocator<void> > >)>, std::function<void (std::shared_ptr<sensor_msgs::msg::PointCloud2_<std::allocator<void> > >, rclcpp::MessageInfo const&)>, std::function<void (std::shared_ptr<rclcpp::SerializedMessage>)>, std::function<void (std::shared_ptr<rclcpp::SerializedMessage>, rclcpp::MessageInfo const&)> >&) () from /opt/ros/jazzy/lib/libspatio_temporal_voxel_layer_core.so
#15 0x0000ffff8afc1b00 [PAC] in ?? () from /opt/ros/jazzy/lib/libspatio_temporal_voxel_layer_core.so
#16 0x0000ffffbaa6bc38 [PAC] in rclcpp::Executor::execute_subscription(std::shared_ptr<rclcpp::SubscriptionBase>) () from /opt/ros/jazzy/lib/librclcpp.so
#17 0x0000ffffbaa6c9b4 [PAC] in rclcpp::Executor::execute_any_executable(rclcpp::AnyExecutable&) () from /opt/ros/jazzy/lib/librclcpp.so
#18 0x0000ffffbaa8164c [PAC] in rclcpp::executors::SingleThreadedExecutor::spin() () from /opt/ros/jazzy/lib/librclcpp.so
#19 0x0000ffffba601ae0 [PAC] in ?? () from /lib/aarch64-linux-gnu/libstdc++.so.6
#20 0x0000ffffba3a595c [PAC] in start_thread (arg=0x0) at ./nptl/pthread_create.c:447
#21 0x0000ffffba40b8dc in thread_start () at ../sysdeps/unix/sysv/linux/aarch64/clone.S:79
```
