### PR TITLE
tf2_ros_py: Ignore ExternalShutdownException in background thread

### DIFF
--- a/tf2_ros_py/tf2_ros/transform_listener.py
+++ b/tf2_ros_py/tf2_ros/transform_listener.py
@@ -34,7 +34,7 @@ from typing import Optional
 from typing import Union
 
 from rclpy.callback_groups import ReentrantCallbackGroup
-from rclpy.executors import SingleThreadedExecutor
+from rclpy.executors import ExternalShutdownException, SingleThreadedExecutor
 from rclpy.node import Node
 from rclpy.qos import DurabilityPolicy
 from rclpy.qos import HistoryPolicy
@@ -112,7 +112,10 @@ class TransformListener:
 
             def run_func():
                 self.executor.add_node(self.node)
-                self.executor.spin()
+                try:
+                    self.executor.spin()
+                except ExternalShutdownException:
+                    pass
                 self.executor.remove_node(self.node)
 
             self.dedicated_listener_thread = Thread(target=run_func)


### PR DESCRIPTION
## Description

I've seen this exception when Ctrl-C-ing a program with `TransformListener` that uses background thread:

```
[exploration_evaluator-1] [occupancy_mapper-19] Exception in thread Thread-1 (run_func):
[exploration_evaluator-1] [occupancy_mapper-19] Traceback (most recent call last):
[exploration_evaluator-1] [occupancy_mapper-19]   File "/usr/lib/python3.12/threading.py", line 1073, in _bootstrap_inner
[exploration_evaluator-1] [occupancy_mapper-19]     self.run()
[exploration_evaluator-1] [occupancy_mapper-19]   File "/usr/lib/python3.12/threading.py", line 1010, in run
[exploration_evaluator-1] [occupancy_mapper-19]     self._target(*self._args, **self._kwargs)
[exploration_evaluator-1] [occupancy_mapper-19]   File "/opt/ros/kilted/lib/python3.12/site-packages/tf2_ros/transform_listener.py", line 115, in run_func
[exploration_evaluator-1] [occupancy_mapper-19]     self.executor.spin()
[exploration_evaluator-1] [occupancy_mapper-19]   File "/opt/ros/kilted/lib/python3.12/site-packages/rclpy/executors.py", line 374, in spin
[exploration_evaluator-1] [occupancy_mapper-19]     self.spin_once()
[exploration_evaluator-1] [occupancy_mapper-19]   File "/opt/ros/kilted/lib/python3.12/site-packages/rclpy/executors.py", line 968, in spin_once
[exploration_evaluator-1] [occupancy_mapper-19]     self._spin_once_impl(timeout_sec)
[exploration_evaluator-1] [occupancy_mapper-19]   File "/opt/ros/kilted/lib/python3.12/site-packages/rclpy/executors.py", line 951, in _spin_once_impl
[exploration_evaluator-1] [occupancy_mapper-19]     handler, entity, node = self.wait_for_ready_callbacks(
[exploration_evaluator-1] [occupancy_mapper-19]                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[exploration_evaluator-1] [occupancy_mapper-19]   File "/opt/ros/kilted/lib/python3.12/site-packages/rclpy/executors.py", line 921, in wait_for_ready_callbacks
[exploration_evaluator-1] [occupancy_mapper-19]     return next(self._cb_iter)
[exploration_evaluator-1] [occupancy_mapper-19]            ^^^^^^^^^^^^^^^^^^^
[exploration_evaluator-1] [occupancy_mapper-19]   File "/opt/ros/kilted/lib/python3.12/site-packages/rclpy/executors.py", line 827, in _wait_for_ready_callbacks
[exploration_evaluator-1] [occupancy_mapper-19]     raise ExternalShutdownException()
[exploration_evaluator-1] [occupancy_mapper-19] rclpy.executors.ExternalShutdownException
```

This PR silences this exception.

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No