### PR TITLE
tf2_ros_py: Make node parameter optional in TransformListener

### DIFF
--- a/tf2_ros_py/tf2_ros/transform_listener.py
+++ b/tf2_ros_py/tf2_ros/transform_listener.py
@@ -90,11 +90,11 @@ class TransformListener:
         self.buffer = buffer
         if node is None:
             # Sim time is definitely not needed in TF listener node
-            params = [Parameter("use_sim_time", value=False)]
+            params = [Parameter('use_sim_time', value=False)]
             # create a unique name for the node
             # but specify its name in cli_args to override any __node passed on the command line.
-            name = f"transform_listener_impl_{id(self):010x}"
-            cli = ["--ros-args", "-r", "__node:=" + name]
+            name = f'transform_listener_impl_{id(self):010x}'
+            cli = ['--ros-args', '-r', '__node:=' + name]
             node = Node(name,
                         cli_args=cli,
                         enable_rosout=False,

--- a/tf2_ros_py/tf2_ros/transform_listener.py
+++ b/tf2_ros_py/tf2_ros/transform_listener.py
@@ -59,7 +59,7 @@ class TransformListener:
     def __init__(
         self,
         buffer: Buffer,
-        node: Node,
+        node: Optional[Node],
         *,
         spin_thread: bool = False,
         qos: Optional[Union[QoSProfile, int]] = None,
@@ -72,7 +72,7 @@ class TransformListener:
         Construct the TransformListener.
 
         :param buffer: The buffer to propagate changes to when tf info updates.
-        :param node: The ROS2 node.
+        :param node: The ROS2 node. Pass None to automatically create one.
         :param spin_thread: Whether to create a dedidcated thread to spin this node.
         :param qos: A QoSProfile or a history depth to apply to subscribers.
         :param static_qos: A QoSProfile or a history depth to apply to tf_static subscribers.
@@ -87,6 +87,13 @@ class TransformListener:
                 history=HistoryPolicy.KEEP_LAST,
                 )
         self.buffer = buffer
+        if node is None:
+            # Sim time is definitely not needed in TF listener node
+            params = [rclpy.Parameter("use_sim_time", value=False)]
+            node = rclpy.node.Node(f"transform_listener_impl_{id(self):010x}",
+                                   enable_rosout=False,
+                                   start_parameter_services=False,
+                                   parameter_overrides=params)
         self.node = node
         # Default callback group is mutually exclusive, which would prevent waiting for transforms
         # from another callback in the same group.

--- a/tf2_ros_py/tf2_ros/transform_listener.py
+++ b/tf2_ros_py/tf2_ros/transform_listener.py
@@ -36,6 +36,7 @@ from typing import Union
 from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.executors import ExternalShutdownException, SingleThreadedExecutor
 from rclpy.node import Node
+from rclpy.parameter import Parameter
 from rclpy.qos import DurabilityPolicy
 from rclpy.qos import HistoryPolicy
 from rclpy.qos import QoSProfile
@@ -89,11 +90,11 @@ class TransformListener:
         self.buffer = buffer
         if node is None:
             # Sim time is definitely not needed in TF listener node
-            params = [rclpy.Parameter("use_sim_time", value=False)]
-            node = rclpy.node.Node(f"transform_listener_impl_{id(self):010x}",
-                                   enable_rosout=False,
-                                   start_parameter_services=False,
-                                   parameter_overrides=params)
+            params = [Parameter("use_sim_time", value=False)]
+            node = Node(f"transform_listener_impl_{id(self):010x}",
+                        enable_rosout=False,
+                        start_parameter_services=False,
+                        parameter_overrides=params)
         self.node = node
         # Default callback group is mutually exclusive, which would prevent waiting for transforms
         # from another callback in the same group.

--- a/tf2_ros_py/tf2_ros/transform_listener.py
+++ b/tf2_ros_py/tf2_ros/transform_listener.py
@@ -91,7 +91,12 @@ class TransformListener:
         if node is None:
             # Sim time is definitely not needed in TF listener node
             params = [Parameter("use_sim_time", value=False)]
-            node = Node(f"transform_listener_impl_{id(self):010x}",
+            # create a unique name for the node
+            # but specify its name in cli_args to override any __node passed on the command line.
+            name = f"transform_listener_impl_{id(self):010x}"
+            cli = ["--ros-args", "-r", "__node:=" + name]
+            node = Node(name,
+                        cli_args=cli,
                         enable_rosout=False,
                         start_parameter_services=False,
                         parameter_overrides=params)


### PR DESCRIPTION
## Description

In the current tutorials, TransformListener is always created like this:

    self.tfl = TransformListener(self.buffer, self, spin_thread=True)

This leads to two problems:

- even though people might think that spin_thread will make it possible to wait for TFs in callbacks spun by SingleThreadedExecutor, that's not true because the spin thread spins the same node which is used for other callbacks
- users are not warned enough that spin_thread will actually already spin their node, so they might mistakenly spin the node in a second place... although I'm not sure this is 100% wrong, I definitely think that spinning the same node from 2 different threads is not intended

This PR adds possibility to pass `None` as the `node` argument, which leads to the same logic as in C++ - creating a dedicated node just for the TF subscriptions and spinning just this node (if `spin_thread` is set).

### Is this user-facing behavior change?

It adds a new option that wasn't allowed before. All existing code should work exactly as it did.

### Did you use Generative AI?

No

### Additional Information

This finally allows to run a node with SingleThreadedExecutor whose callbacks can actually lookup TFs with timeouts.

I'm not sure is the autocreated `self.node` has to be explicitly destroyed, or if it will get destroyed automatically when the listener goes away.