### PR TITLE
address RHEL uncrustify warnings.

### DIFF
--- a/tf2_ros/include/tf2_ros/static_transform_broadcaster.hpp
+++ b/tf2_ros/include/tf2_ros/static_transform_broadcaster.hpp
@@ -100,7 +100,7 @@ public:
         rclcpp::QosPolicyKind::Reliability};
       return options;
     } ())
-    : StaticTransformBroadcaster(
+  : StaticTransformBroadcaster(
       RequiredInterfaces(node->get_node_parameters_interface(),
       node->get_node_topics_interface()), qos, options)
   {
@@ -121,7 +121,7 @@ public:
         rclcpp::QosPolicyKind::Reliability};
       return options;
     } ())
-    : StaticTransformBroadcaster(
+  : StaticTransformBroadcaster(
       RequiredInterfaces(node_parameters, node_topics), qos, options)
   {
   }

--- a/tf2_ros/include/tf2_ros/transform_broadcaster.hpp
+++ b/tf2_ros/include/tf2_ros/transform_broadcaster.hpp
@@ -103,7 +103,7 @@ public:
         rclcpp::QosPolicyKind::Reliability};
       return options;
     } ())
-    : TransformBroadcaster(
+  : TransformBroadcaster(
       RequiredInterfaces(node->get_node_parameters_interface(),
       node->get_node_topics_interface()), qos, options)
   {
@@ -125,7 +125,7 @@ public:
         rclcpp::QosPolicyKind::Reliability};
       return options;
     } ())
-    : TransformBroadcaster(RequiredInterfaces(node_parameters, node_topics), qos, options)
+  : TransformBroadcaster(RequiredInterfaces(node_parameters, node_topics), qos, options)
   {
   }
 


### PR DESCRIPTION
## Description

see https://ci.ros2.org/job/ci_linux-rhel/8929/testReport/

```console
-- run_test.py: invoking following command in '/home/jenkins-agent/workspace/ci_linux-rhel/ws/src/ros2/geometry2/tf2_ros':
 - /home/jenkins-agent/workspace/ci_linux-rhel/ws/install/ament_uncrustify/bin/ament_uncrustify --xunit-file /home/jenkins-agent/workspace/ci_linux-rhel/ws/build/tf2_ros/test_results/tf2_ros/uncrustify.xunit.xml --language C++
Code style divergence in file 'include/tf2_ros/static_transform_broadcaster.hpp':

--- include/tf2_ros/static_transform_broadcaster.hpp
+++ include/tf2_ros/static_transform_broadcaster.hpp.uncrustify
@@ -103 +103 @@
-    : StaticTransformBroadcaster(
+  : StaticTransformBroadcaster(
@@ -124 +124 @@
-    : StaticTransformBroadcaster(
+  : StaticTransformBroadcaster(

Code style divergence in file 'include/tf2_ros/transform_broadcaster.hpp':

--- include/tf2_ros/transform_broadcaster.hpp
+++ include/tf2_ros/transform_broadcaster.hpp.uncrustify
@@ -106 +106 @@
-    : TransformBroadcaster(
+  : TransformBroadcaster(
@@ -128 +128 @@
-    : TransformBroadcaster(RequiredInterfaces(node_parameters, node_topics), qos, options)
+  : TransformBroadcaster(RequiredInterfaces(node_parameters, node_topics), qos, options)

2 files with code style divergence
```

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
