### PR TITLE
Change constructor overloads to sidestep uncrustify differences

### DIFF
--- a/tf2_ros/include/tf2_ros/static_transform_broadcaster.hpp
+++ b/tf2_ros/include/tf2_ros/static_transform_broadcaster.hpp
@@ -89,18 +89,33 @@ public:
   template<class NodeT, class AllocatorT = std::allocator<void>,
     std::enable_if_t<rcpputils::is_pointer<NodeT>::value, bool> = true>
   [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of NodeT")]]
+  explicit StaticTransformBroadcaster(NodeT && node)
+  : StaticTransformBroadcaster(
+      RequiredInterfaces(node->get_node_parameters_interface(),
+      node->get_node_topics_interface()))
+  {
+  }
+
+  template<class NodeT, class AllocatorT = std::allocator<void>,
+    std::enable_if_t<rcpputils::is_pointer<NodeT>::value, bool> = true>
+  [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of NodeT")]]
   StaticTransformBroadcaster(
     NodeT && node,
-    const rclcpp::QoS & qos = StaticBroadcasterQoS(),
-    const rclcpp::PublisherOptionsWithAllocator<AllocatorT> & options = [] () {
-      rclcpp::PublisherOptionsWithAllocator<AllocatorT> options;
-      options.qos_overriding_options = rclcpp::QosOverridingOptions{
-        rclcpp::QosPolicyKind::Depth,
-        rclcpp::QosPolicyKind::History,
-        rclcpp::QosPolicyKind::Reliability};
-      return options;
-    } ())
-    : StaticTransformBroadcaster(
+    const rclcpp::QoS & qos)
+  : StaticTransformBroadcaster(
+      RequiredInterfaces(node->get_node_parameters_interface(),
+      node->get_node_topics_interface()), qos)
+  {
+  }
+
+  template<class NodeT, class AllocatorT = std::allocator<void>,
+    std::enable_if_t<rcpputils::is_pointer<NodeT>::value, bool> = true>
+  [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of NodeT")]]
+  StaticTransformBroadcaster(
+    NodeT && node,
+    const rclcpp::QoS & qos,
+    const rclcpp::PublisherOptionsWithAllocator<AllocatorT> & options)
+  : StaticTransformBroadcaster(
       RequiredInterfaces(node->get_node_parameters_interface(),
       node->get_node_topics_interface()), qos, options)
   {
@@ -111,17 +126,31 @@ public:
   [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of multiple interfaces")]]
   StaticTransformBroadcaster(
     NodeParametersInterface::SharedPtr node_parameters,
+    NodeTopicsInterface::SharedPtr node_topics)
+  : StaticTransformBroadcaster(
+      RequiredInterfaces(node_parameters, node_topics))
+  {
+  }
+
+  template<class AllocatorT = std::allocator<void>>
+  [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of multiple interfaces")]]
+  StaticTransformBroadcaster(
+    NodeParametersInterface::SharedPtr node_parameters,
     NodeTopicsInterface::SharedPtr node_topics,
-    const rclcpp::QoS & qos = StaticBroadcasterQoS(),
-    const rclcpp::PublisherOptionsWithAllocator<AllocatorT> & options = [] () {
-      rclcpp::PublisherOptionsWithAllocator<AllocatorT> options;
-      options.qos_overriding_options = rclcpp::QosOverridingOptions{
-        rclcpp::QosPolicyKind::Depth,
-        rclcpp::QosPolicyKind::History,
-        rclcpp::QosPolicyKind::Reliability};
-      return options;
-    } ())
-    : StaticTransformBroadcaster(
+    const rclcpp::QoS & qos)
+  : StaticTransformBroadcaster(
+      RequiredInterfaces(node_parameters, node_topics), qos)
+  {
+  }
+
+  template<class AllocatorT = std::allocator<void>>
+  [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of multiple interfaces")]]
+  StaticTransformBroadcaster(
+    NodeParametersInterface::SharedPtr node_parameters,
+    NodeTopicsInterface::SharedPtr node_topics,
+    const rclcpp::QoS & qos,
+    const rclcpp::PublisherOptionsWithAllocator<AllocatorT> & options)
+  : StaticTransformBroadcaster(
       RequiredInterfaces(node_parameters, node_topics), qos, options)
   {
   }

--- a/tf2_ros/include/tf2_ros/transform_broadcaster.hpp
+++ b/tf2_ros/include/tf2_ros/transform_broadcaster.hpp
@@ -91,19 +91,33 @@ public:
   template<class NodeT, class AllocatorT = std::allocator<void>,
     std::enable_if_t<rcpputils::is_pointer<NodeT>::value, bool> = true>
   [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of NodeT")]]
+  explicit TransformBroadcaster(NodeT && node)
+  : TransformBroadcaster(
+      RequiredInterfaces(node->get_node_parameters_interface(),
+      node->get_node_topics_interface()))
+  {
+  }
+
+  template<class NodeT, class AllocatorT = std::allocator<void>,
+    std::enable_if_t<rcpputils::is_pointer<NodeT>::value, bool> = true>
+  [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of NodeT")]]
   TransformBroadcaster(
     NodeT && node,
-    const rclcpp::QoS & qos = DynamicBroadcasterQoS(),
-    const rclcpp::PublisherOptionsWithAllocator<AllocatorT> & options = [] () {
-      rclcpp::PublisherOptionsWithAllocator<AllocatorT> options;
-      options.qos_overriding_options = rclcpp::QosOverridingOptions{
-        rclcpp::QosPolicyKind::Depth,
-        rclcpp::QosPolicyKind::Durability,
-        rclcpp::QosPolicyKind::History,
-        rclcpp::QosPolicyKind::Reliability};
-      return options;
-    } ())
-    : TransformBroadcaster(
+    const rclcpp::QoS & qos)
+  : TransformBroadcaster(
+      RequiredInterfaces(node->get_node_parameters_interface(),
+      node->get_node_topics_interface()), qos)
+  {
+  }
+
+  template<class NodeT, class AllocatorT = std::allocator<void>,
+    std::enable_if_t<rcpputils::is_pointer<NodeT>::value, bool> = true>
+  [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of NodeT")]]
+  TransformBroadcaster(
+    NodeT && node,
+    const rclcpp::QoS & qos,
+    const rclcpp::PublisherOptionsWithAllocator<AllocatorT> & options)
+  : TransformBroadcaster(
       RequiredInterfaces(node->get_node_parameters_interface(),
       node->get_node_topics_interface()), qos, options)
   {
@@ -114,18 +128,31 @@ public:
   [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of multiple interfaces")]]
   TransformBroadcaster(
     NodeParametersInterface::SharedPtr node_parameters,
+    NodeTopicsInterface::SharedPtr node_topics)
+  : TransformBroadcaster(
+      RequiredInterfaces(node_parameters, node_topics))
+  {
+  }
+
+  template<class AllocatorT = std::allocator<void>>
+  [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of multiple interfaces")]]
+  TransformBroadcaster(
+    NodeParametersInterface::SharedPtr node_parameters,
     NodeTopicsInterface::SharedPtr node_topics,
-    const rclcpp::QoS & qos = DynamicBroadcasterQoS(),
-    const rclcpp::PublisherOptionsWithAllocator<AllocatorT> & options = [] () {
-      rclcpp::PublisherOptionsWithAllocator<AllocatorT> options;
-      options.qos_overriding_options = rclcpp::QosOverridingOptions{
-        rclcpp::QosPolicyKind::Depth,
-        rclcpp::QosPolicyKind::Durability,
-        rclcpp::QosPolicyKind::History,
-        rclcpp::QosPolicyKind::Reliability};
-      return options;
-    } ())
-    : TransformBroadcaster(RequiredInterfaces(node_parameters, node_topics), qos, options)
+    const rclcpp::QoS & qos)
+  : TransformBroadcaster(
+      RequiredInterfaces(node_parameters, node_topics), qos)
+  {
+  }
+
+  template<class AllocatorT = std::allocator<void>>
+  [[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of multiple interfaces")]]
+  TransformBroadcaster(
+    NodeParametersInterface::SharedPtr node_parameters,
+    NodeTopicsInterface::SharedPtr node_topics,
+    const rclcpp::QoS & qos,
+    const rclcpp::PublisherOptionsWithAllocator<AllocatorT> & options)
+  : TransformBroadcaster(RequiredInterfaces(node_parameters, node_topics), qos, options)
   {
   }
 


### PR DESCRIPTION
## Description
  
This PR resolves the uncrustify failures on RHEL 10 for both StaticTransformBroadcaster and TransformBroadcaster.   
  
Fixes https://github.com/ros2/geometry2/issues/941
  
  
### Is this user-facing behavior change?

### Did you use Generative AI?

Yes, this pull request was prepared and verified with the assistance of Gemini CLI.

Assisted-by: Gemini CLI:Gemini 3.5 Flash [list_dir, list_permissions, run_command, view_file, grep_search, replace_file_content,  
read_url_content]

### Additional Information
