### PR TITLE
Removed warning in tf2_tools

### DIFF
--- a/tf2_tools/tf2_tools/view_frames.py
+++ b/tf2_tools/tf2_tools/view_frames.py
@@ -113,7 +113,8 @@ def main():
         cli.destroy()
         node.destroy_node()
         rclpy.shutdown()
-        return ret
+
+    return ret
 
 
 def generate_dot(data, recorded_time):


### PR DESCRIPTION
## Description

Related with this warning:

```bash
--- stderr: tf2_tools
=============================== warnings summary ===============================
test/test_pep257.py::test_pep257
  Warning: 'return' in a 'finally' block

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
---
```