### PR TITLE
Add generated version header for tf2_ros

### DIFF
--- a/tf2_ros/CMakeLists.txt
+++ b/tf2_ros/CMakeLists.txt
@@ -6,6 +6,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_gen_version_h REQUIRED)
 find_package(ament_cmake_ros_core REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(geometry_msgs REQUIRED)
@@ -261,3 +262,4 @@ ament_export_dependencies(
   tf2_msgs
 )
 ament_package()
+ament_generate_version_header(${PROJECT_NAME})

--- a/tf2_ros/package.xml
+++ b/tf2_ros/package.xml
@@ -16,6 +16,7 @@
   <author>Wim Meeussen</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_gen_version_h</buildtool_depend>
   <buildtool_depend>ament_cmake_ros_core</buildtool_depend>
 
   <depend>builtin_interfaces</depend>


### PR DESCRIPTION
## Description

There has been recent large API update in tf2_ros https://github.com/ros2/geometry2/pull/940, I would like to request adding version.h in tf2_ros, so we can check against the version

### Is this user-facing behavior change?

Yes

### Did you use Generative AI?

Yes, Codex

### Additional Information

If approved, could we please backport this to older distros?