### PR TITLE
[tf2_ros] Fix `waitForTransform` race condition

### DIFF
--- a/tf2_ros/src/buffer.cpp
+++ b/tf2_ros/src/buffer.cpp
@@ -255,30 +255,39 @@ Buffer::waitForTransform(
       callback(future);
     };
 
-  auto handle = addTransformableRequest(cb, target_frame, source_frame, time);
-  future.setHandle(handle);
-  if (0 == handle) {
-    // Immediately transformable
-    geometry_msgs::msg::TransformStamped msg_stamped = lookupTransform(
-      target_frame, source_frame, time);
-    promise->set_value(msg_stamped);
-    callback(future);
-  } else if (0xffffffffffffffffULL == handle) {
-    // Never transformable
-    promise->set_exception(
-      std::make_exception_ptr(
-        tf2::LookupException(
-          "Failed to transform from " + source_frame + " to " + target_frame)));
-    callback(future);
-  } else {
+  bool call_callback = false;
+  {
+    // Putting the lock here to avoid a race condition where the callback is called before
+    // the timer handle is inserted into timer_to_request_map_. Otherwise, it gets wrongly
+    // discarded.
     std::lock_guard<std::mutex> lock(timer_to_request_map_mutex_);
-    auto timer_handle = timer_interface_->createTimer(
-      clock_,
-      timeout,
-      std::bind(&Buffer::timerCallback, this, std::placeholders::_1, promise, future, callback));
+    auto handle = addTransformableRequest(cb, target_frame, source_frame, time);
+    future.setHandle(handle);
+    if (0 == handle) {
+      // Immediately transformable
+      geometry_msgs::msg::TransformStamped msg_stamped = lookupTransform(
+        target_frame, source_frame, time);
+      promise->set_value(msg_stamped);
+      call_callback = true;
+    } else if (0xffffffffffffffffULL == handle) {
+      // Never transformable
+      promise->set_exception(
+        std::make_exception_ptr(
+          tf2::LookupException(
+            "Failed to transform from " + source_frame + " to " + target_frame)));
+      call_callback = true;
+    } else {
+      auto timer_handle = timer_interface_->createTimer(
+        clock_,
+        timeout,
+        std::bind(&Buffer::timerCallback, this, std::placeholders::_1, promise, future, callback));
 
-    // Save association between timer and request handle
-    timer_to_request_map_[timer_handle] = handle;
+      // Save association between timer and request handle
+      timer_to_request_map_[timer_handle] = handle;
+    }
+  }
+  if (call_callback) {
+    callback(future);
   }
   return future;
 }

--- a/tf2_ros/test/test_buffer.cpp
+++ b/tf2_ros/test/test_buffer.cpp
@@ -31,6 +31,7 @@
 #include <exception>
 #include <future>
 #include <memory>
+#include <thread>
 #include <unordered_map>
 
 #include "gtest/gtest.h"
@@ -544,6 +545,47 @@ TEST(test_buffer, timer_ros_wait_for_transform_race)
   EXPECT_EQ(status, std::future_status::ready);
   EXPECT_FALSE(callback_timeout);
   rclcpp::shutdown();
+}
+
+// Regression test: setTransform arriving after addTransformableRequest registers cb but
+// before the timer handle is inserted into timer_to_request_map_ must not be silently
+// dropped. This is a race condition that does not always occur hence high number of iterations.
+// To reliably reproduce the race condition, add a short sleep before creating the timer
+// in buffer.cpp
+TEST(test_buffer, wait_for_transform_race_during_setup)
+{
+  constexpr int iterations = 100;
+  for (int i = 0; i < iterations; ++i) {
+    rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+    tf2_ros::Buffer buffer(clock);
+    buffer.setUsingDedicatedThread(true);
+    auto mock_create_timer = std::make_shared<MockCreateTimer>();
+    buffer.setCreateTimerInterface(mock_create_timer);
+    rclcpp::Time rclcpp_time = clock->now();
+    tf2::TimePoint tf2_time(std::chrono::nanoseconds(rclcpp_time.nanoseconds()));
+    geometry_msgs::msg::TransformStamped transform;
+    transform.header.frame_id = "foo";
+    transform.header.stamp = builtin_interfaces::msg::Time(rclcpp_time);
+    transform.child_frame_id = "bar";
+    transform.transform.rotation.w = 1.0;
+    bool callback_timeout = false;
+    std::thread tf_thread([&]() {
+        buffer.setTransform(transform, "unittest");
+      });
+    auto future = buffer.waitForTransform(
+      "foo", "bar", tf2_time, tf2::durationFromSec(0.1),
+      [&callback_timeout](const tf2_ros::TransformStampedFuture & future) {
+        try {
+          future.get();
+        } catch (...) {
+          callback_timeout = true;
+        }
+      });
+    tf_thread.join();
+    const auto status = future.wait_for(std::chrono::milliseconds(200));
+    ASSERT_EQ(status, std::future_status::ready) << "Failed at iteration " << i;
+    ASSERT_FALSE(callback_timeout) << "Failed at iteration " << i;
+  }
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
## Description
Hi,

I was facing a race condition as following:

- use `waitForTransform` to lookup a tf
- parallely create and publish that tf from a different node exactly at the same time
- sometimes, even though the transform becomes available, `waitForTransform` would eventually timeout.
 
After taking a deeper look at it I noticed that the problem is that there is a slight delay between [`addTransformableRequest` ](https://github.com/ros2/geometry2/blob/rolling/tf2_ros/src/buffer.cpp#L258) and [ceating the timer](https://github.com/ros2/geometry2/blob/rolling/tf2_ros/src/buffer.cpp#L275). If the transform becomes available in between, then `cb` would get triggered, finds an empty map (since timer is not yet added to `timer_to_request_map_`) so it incorrectly assumes [timeout is occured and returns silently](https://github.com/ros2/geometry2/blob/rolling/tf2_ros/src/buffer.cpp#L241). Which means `waitForTransform` never resolves and it eventually timeouts.

Now my proposal is to basically use `timer_to_request_map_mutex_` for both adding the `cb` as well as adding the timer. This way, `cb` would not be triggered in between.

Recreating this issue only via testing is a bit difficult, because as you can immagine, the race condition happens only in the time between those few lines. That's why I have made a test to repeat the process 100 times. But again, not really a test if sometimes it may or may not happen. To guarantee reproducing it, then you can edit `buffer.cpp` by adding a small sleep before [creating timer's lock](https://github.com/ros2/geometry2/blob/rolling/tf2_ros/src/buffer.cpp#L274) such that the callback is added, requested transform is set and only then timer is added. Then you can see the issue without my fixes.

