### PR TITLE
[tf2_ros] Fixed sub 10ms timeout

### DIFF
--- a/tf2_ros/src/buffer.cpp
+++ b/tf2_ros/src/buffer.cpp
@@ -167,7 +167,11 @@ Buffer::canTransform(
     (clock_->now() + rclcpp::Duration(3, 0) >= start_time) &&  // don't wait bag loop detected
     (rclcpp::ok()))  // Make sure we haven't been stopped (won't work for pytf)
   {
-    clock_->sleep_for(std::chrono::milliseconds(10));
+    auto remaining_ns = ((start_time + rclcpp_timeout) - clock_->now()).nanoseconds();
+    if (remaining_ns > 0) {
+      clock_->sleep_for(std::chrono::nanoseconds(std::min(remaining_ns,
+          static_cast<int64_t>(10000000))));
+    }
   }
   bool retval = canTransform(target_frame, source_frame, time, errstr);
   rclcpp::Time current_time = clock_->now();
@@ -196,7 +200,11 @@ Buffer::canTransform(
     (clock_->now() + rclcpp::Duration(3, 0) >= start_time) &&  // don't wait bag loop detected
     (rclcpp::ok()))  // Make sure we haven't been stopped (won't work for pytf)
   {
-    clock_->sleep_for(std::chrono::milliseconds(10));
+    auto remaining_ns = ((start_time + rclcpp_timeout) - clock_->now()).nanoseconds();
+    if (remaining_ns > 0) {
+      clock_->sleep_for(std::chrono::nanoseconds(std::min(remaining_ns,
+          static_cast<int64_t>(10000000))));
+    }
   }
   bool retval = canTransform(
     target_frame, target_time,

--- a/tf2_ros/test/test_buffer.cpp
+++ b/tf2_ros/test/test_buffer.cpp
@@ -338,6 +338,34 @@ TEST(test_buffer, can_transform_without_dedicated_thread)
   EXPECT_DOUBLE_EQ(transform.transform.translation.z, output_rclcpp.transform.translation.z);
 }
 
+// Regression test: timeout must be always respected regardless of duration
+TEST(test_buffer, can_transform_timeout_is_respected)
+{
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+  tf2_ros::Buffer buffer(clock);
+  buffer.setUsingDedicatedThread(true);
+
+  struct TestCase
+  {
+    double timeout_s;
+    double max_s;
+  };
+  for (const auto & tc : std::vector<TestCase>{
+    {0.000, 0.001},    // zero: returns immediately, no sleep
+    {0.002, 0.004},    // sub-10ms: must not inflate to hardcoded 10ms sleep
+    {0.020, 0.040},    // above 10ms: loop runs multiple 10ms sleep iterations
+  })
+  {
+    const rclcpp::Time start = clock->now();
+    EXPECT_FALSE(buffer.canTransform(
+        "nonexistent_target", "nonexistent_source",
+        tf2::TimePointZero,
+        tf2::durationFromSec(tc.timeout_s)));
+    const rclcpp::Duration elapsed = clock->now() - start;
+    EXPECT_LT(elapsed, rclcpp::Duration::from_seconds(tc.max_s)) << "timeout=" << tc.timeout_s;
+  }
+}
+
 TEST(test_buffer, wait_for_transform_valid)
 {
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);


### PR DESCRIPTION
## Description

Currently, `canTransform` loops with hardcoded 10ms sleeps until it reaches the timeout. Now the problem is, if someone wants to use a lower-than-10ms timeout, it wouldn't be respected. I noticed this personally when I wanted to run my planner at 100hz but I noticed that the tf lookups with 2ms timeouts were instead timing out after ~10ms hence causing my planner frequency to drop from 100hz.

### Did you use Generative AI?

Yes, Claude Sonnet 4.6
