### PR TITLE
Spin TransformListener internal node callback groups

### DIFF
--- a/tf2_ros/CMakeLists.txt
+++ b/tf2_ros/CMakeLists.txt
@@ -177,6 +177,7 @@ if(BUILD_TESTING)
   ament_add_gtest(${PROJECT_NAME}_test_transform_listener test/test_transform_listener.cpp)
   target_link_libraries(${PROJECT_NAME}_test_transform_listener
     ${PROJECT_NAME}
+    ${rcl_interfaces_TARGETS}
     # Used, but not linked to test tf2_ros's exports:
     #   rclcpp::rclcpp
   )

--- a/tf2_ros/include/tf2_ros/transform_listener.hpp
+++ b/tf2_ros/include/tf2_ros/transform_listener.hpp
@@ -266,6 +266,9 @@ private:
       // Create executor with dedicated thread to spin.
       executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
       executor_->add_callback_group(callback_group_, node_base_interface_);
+      if (optional_default_node_) {
+        executor_->add_node(optional_default_node_);
+      }
       dedicated_listener_thread_ = std::make_unique<std::thread>([&]() {executor_->spin();});
       // Tell the buffer we have a dedicated thread to enable timeouts
       buffer_.setUsingDedicatedThread(true);
@@ -334,6 +337,9 @@ private:
 
       executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
       executor_->add_callback_group(callback_group_, node_base_interface_);
+      if (optional_default_node_) {
+        executor_->add_node(optional_default_node_);
+      }
       dedicated_listener_thread_ = std::make_unique<std::thread>([&]() {executor_->spin();});
       buffer_.setUsingDedicatedThread(true);
     } else {

--- a/tf2_ros/test/test_transform_listener.cpp
+++ b/tf2_ros/test/test_transform_listener.cpp
@@ -29,8 +29,12 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <chrono>
 #include <memory>
+#include <string>
+#include <thread>
+#include <vector>
 
 #include <tf2_ros/buffer.hpp>
 #include <tf2_ros/transform_listener.hpp>
@@ -38,6 +42,97 @@
 #include <tf2_ros/static_transform_broadcaster.hpp>
 
 #include "node_wrapper.hpp"
+#include "rcl_interfaces/msg/parameter.hpp"
+#include "rcl_interfaces/msg/parameter_event.hpp"
+#include "rcl_interfaces/msg/parameter_type.hpp"
+
+using namespace std::chrono_literals;
+
+template<typename PredicateT>
+bool wait_for(PredicateT predicate, std::chrono::seconds timeout = 5s)
+{
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (predicate()) {
+      return true;
+    }
+    std::this_thread::sleep_for(20ms);
+  }
+  return predicate();
+}
+
+void expect_internal_node_groups_are_spun(bool static_only)
+{
+  auto probe = rclcpp::Node::make_shared(
+    static_only ? "static_listener_callback_group_probe" : "listener_callback_group_probe");
+  const auto nodes_before = probe->get_node_names();
+  auto parameter_events = probe->create_publisher<rcl_interfaces::msg::ParameterEvent>(
+    "/parameter_events", rclcpp::ParameterEventsQoS());
+
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+  tf2_ros::Buffer buffer(clock);
+  tf2_ros::TransformListener listener(buffer, true, static_only);
+
+  std::string listener_node_name;
+  const auto listener_was_discovered = [&]() {
+      for (const auto & node_name : probe->get_node_names()) {
+        const bool is_listener =
+          node_name.find("transform_listener_impl_") != std::string::npos;
+        const bool is_new =
+          std::find(nodes_before.begin(), nodes_before.end(), node_name) == nodes_before.end();
+        if (is_listener && is_new) {
+          listener_node_name = node_name;
+          return true;
+        }
+      }
+      return false;
+    };
+  ASSERT_TRUE(wait_for(listener_was_discovered)) <<
+    "The TransformListener's internal node was not discovered";
+
+  const auto initial_clock_subscriptions = probe->count_subscribers("/clock");
+  rcl_interfaces::msg::ParameterEvent event;
+  event.stamp = probe->now();
+  event.node = listener_node_name;
+  rcl_interfaces::msg::Parameter use_sim_time;
+  use_sim_time.name = "use_sim_time";
+  use_sim_time.value.type = rcl_interfaces::msg::ParameterType::PARAMETER_BOOL;
+  use_sim_time.value.bool_value = true;
+  event.changed_parameters.push_back(use_sim_time);
+
+  const auto default_group_was_spun = [&]() {
+      parameter_events->publish(event);
+      return probe->count_subscribers("/clock") > initial_clock_subscriptions;
+    };
+  ASSERT_TRUE(wait_for(default_group_was_spun)) <<
+    "The internal node's default callback group was not spun";
+
+  geometry_msgs::msg::TransformStamped transform;
+  transform.header.stamp = probe->now();
+  transform.header.frame_id = static_only ? "static_parent" : "dynamic_parent";
+  transform.child_frame_id = static_only ? "static_child" : "dynamic_child";
+  transform.transform.rotation.w = 1.0;
+
+  if (static_only) {
+    tf2_ros::StaticTransformBroadcaster broadcaster(probe);
+    const auto static_transform_was_received = [&]() {
+        broadcaster.sendTransform(transform);
+        return buffer.canTransform(
+        transform.header.frame_id, transform.child_frame_id, tf2::TimePointZero);
+      };
+    EXPECT_TRUE(wait_for(static_transform_was_received)) <<
+      "The manually added /tf_static callback group was not spun";
+  } else {
+    tf2_ros::TransformBroadcaster broadcaster(probe);
+    const auto transform_was_received = [&]() {
+        broadcaster.sendTransform(transform);
+        return buffer.canTransform(
+        transform.header.frame_id, transform.child_frame_id, tf2::TimePointZero);
+      };
+    EXPECT_TRUE(wait_for(transform_was_received)) <<
+      "The manually added /tf callback group was not spun";
+  }
+}
 
 class CustomNode : public rclcpp::Node
 {
@@ -100,6 +195,11 @@ TEST(tf2_test_transform_listener, transform_listener_rclcpp_node)
   tf2_ros::TransformListener tfl(buffer, node, false);
 }
 
+TEST(tf2_test_transform_listener, internal_node_callback_groups)
+{
+  expect_internal_node_groups_are_spun(false);
+}
+
 TEST(tf2_test_transform_listener, transform_listener_custom_rclcpp_node)
 {
   auto node = std::make_shared<NodeWrapper>("tf2_ros_message_filter");
@@ -131,6 +231,11 @@ TEST(tf2_test_static_transform_listener, static_transform_listener_rclcpp_node)
   rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
   tf2_ros::Buffer buffer(clock);
   tf2_ros::StaticTransformListener stfl(buffer, node, false);
+}
+
+TEST(tf2_test_static_transform_listener, internal_node_callback_groups)
+{
+  expect_internal_node_groups_are_spun(true);
 }
 
 TEST(tf2_test_static_transform_listener, static_transform_listener_custom_rclcpp_node)


### PR DESCRIPTION
## Summary

- keep the dedicated `/tf` and `/tf_static` callback group registered with the
  listener's private executor
- also register the listener-owned internal node so its automatically added
  default callback group makes progress
- cover both dynamic and static-only internal listeners while leaving
  caller-owned node handling unchanged

Fixes #968.

## Root cause

The simplified `TransformListener(buffer)` constructor creates a private node.
With `spin_thread=true`, it creates a non-auto-added callback group for the TF
subscriptions and registers only that group with its private executor. On
Jazzy, the internal node also has a `TimeSource` parameter-event subscription
in its default callback group, but that group is never spun.

The fix retains the explicit TF callback-group registration and additionally
adds only `optional_default_node_`. Using `add_node()` alone would not register
the deliberately non-auto-added TF group.

## Testing

- reproduced the failure before the production change: the nine existing
  listener tests passed and both new dynamic/static cases failed at the
  default-group assertion
- clean-built pinned Jazzy source for `tf2`, `tf2_msgs`, and `tf2_ros`
- complete `tf2_ros` CTest: 14/14 passed
- targeted transform-listener CTest repeated 10 times: 10/10 passed
- cppcheck, cpplint, lint_cmake, and uncrustify passed
- `git diff --check` passed

The regression publishes a targeted `use_sim_time=true` parameter event and
checks that the internal node creates its `/clock` subscription. It also sends
a dynamic or static transform and verifies that the buffer receives it, which
guards the existing manually registered TF callback group.

## Scope

The observed `TimeSource` failure is Jazzy-specific. Current Rolling no longer
creates this parameter-event subscription. No public API, QoS setting, thread
count, caller-owned node path, or `spin_thread=false` behavior is changed.

## Generative tool disclosure

Generated-by: OpenAI Codex (GPT-5)
