### PR TITLE
Fix deadlock in buffer core

### DIFF
--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -1397,13 +1397,8 @@ TransformableRequestHandle BufferCore::addTransformableRequest(
     req.request_handle = 1;
   }
 
-  if (req.target_id == 0) {
-    req.target_string = target_frame;
-  }
-
-  if (req.source_id == 0) {
-    req.source_string = source_frame;
-  }
+  req.target_string = req.target_id == 0 ? target_frame : lookupFrameString(req.target_id);
+  req.source_string = req.source_id == 0 ? source_frame : lookupFrameString(req.source_id);
 
   transformable_requests_.push_back(req);
 
@@ -1537,24 +1532,35 @@ void BufferCore::testTransformableRequests()
     }
 
     if (do_cb) {
+      M_TransformableCallback::node_type callback_node;
+      const TransformableRequestHandle request_handle = req.request_handle;
+      std::string target_frame = std::move(req.target_string);
+      std::string source_frame = std::move(req.source_string);
+      const TimePoint request_time = req.time;
       {
         std::unique_lock<std::mutex> lock2(transformable_callbacks_mutex_);
         M_TransformableCallback::iterator cb_it = transformable_callbacks_.find(req.cb_handle);
         if (cb_it != transformable_callbacks_.end()) {
-          const TransformableCallback & cb = cb_it->second;
-          cb(
-            req.request_handle, lookupFrameString(req.target_id), lookupFrameString(
-              req.source_id), req.time, result);
-          transformable_callbacks_.erase(req.cb_handle);
+          callback_node = transformable_callbacks_.extract(cb_it);
         }
       }
 
-      // Swap with the last element and pop to remove in O(1).
-      // Do not advance i: the element swapped in from the back is examined in the next iteration.
+      // Remove this request before invoking application code, since the callback may re-enter
+      // BufferCore and mutate the request vector.
       if (i < transformable_requests_.size() - 1) {
         transformable_requests_[i] = transformable_requests_.back();
       }
       transformable_requests_.pop_back();
+
+      if (!callback_node.empty()) {
+        // Application callbacks may re-enter BufferCore from this or another thread. Invoke the
+        // callback without holding either transformable-request mutex.
+        lock.unlock();
+        callback_node.mapped()(request_handle, target_frame, source_frame, request_time, result);
+        lock.lock();
+        // The callback or another thread may have changed the request vector.
+        i = 0;
+      }
     } else {
       ++i;
     }

--- a/tf2/test/simple_tf2_core.cpp
+++ b/tf2/test/simple_tf2_core.cpp
@@ -31,8 +31,10 @@
 #include <algorithm>
 #include <array>
 #include <chrono>
+#include <future>
 #include <numeric>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "builtin_interfaces/msg/time.hpp"
@@ -114,6 +116,173 @@ TEST(tf2, setTransformValidWithCallback)
   EXPECT_EQ(received_source_frame, source_frame);
   EXPECT_EQ(received_time_point, time_point);
   EXPECT_TRUE(transform_available);
+}
+
+TEST(tf2, transformableCallbackCanAddAnotherRequest)
+{
+  tf2::BufferCore buffer;
+
+  const std::string target_frame = "target";
+  const std::string first_source_frame = "first_source";
+  const std::string second_source_frame = "second_source";
+  const tf2::TimePoint time_point = tf2::timeFromSec(1.0);
+  bool second_callback_called = false;
+
+  auto second_callback = [&second_callback_called](
+    tf2::TransformableRequestHandle, const std::string &, const std::string &,
+    tf2::TimePoint, tf2::TransformableResult result)
+    {
+      second_callback_called = result == tf2::TransformAvailable;
+    };
+
+  auto first_callback = [&buffer, &second_callback, &target_frame, &second_source_frame,
+      time_point](
+    tf2::TransformableRequestHandle, const std::string &, const std::string &,
+    tf2::TimePoint, tf2::TransformableResult)
+    {
+      // Transformable callbacks are application code and may re-enter BufferCore.
+      EXPECT_NE(
+        buffer.addTransformableRequest(
+          second_callback, target_frame, second_source_frame, time_point),
+        0u);
+    };
+
+  ASSERT_NE(
+    buffer.addTransformableRequest(
+      first_callback, target_frame, first_source_frame, time_point),
+    0u);
+
+  geometry_msgs::msg::TransformStamped transform_msg;
+  transform_msg.header.frame_id = target_frame;
+  transform_msg.header.stamp.sec = 1;
+  transform_msg.child_frame_id = first_source_frame;
+  transform_msg.transform.rotation.w = 1;
+  ASSERT_TRUE(buffer.setTransform(transform_msg, "authority1"));
+
+  transform_msg.child_frame_id = second_source_frame;
+  ASSERT_TRUE(buffer.setTransform(transform_msg, "authority1"));
+  EXPECT_TRUE(second_callback_called);
+}
+
+TEST(tf2, transformableCallbackCanCancelAnotherRequest)
+{
+  tf2::BufferCore buffer;
+  const auto time_point = tf2::timeFromSec(1.0);
+  bool cancelled_callback_called = false;
+
+  const auto cancelled_handle = buffer.addTransformableRequest(
+    [&cancelled_callback_called](
+      tf2::TransformableRequestHandle, const std::string &, const std::string &,
+      tf2::TimePoint, tf2::TransformableResult)
+    {
+      cancelled_callback_called = true;
+    },
+    "target", "cancelled_source", time_point);
+  ASSERT_NE(cancelled_handle, 0u);
+
+  ASSERT_NE(
+    buffer.addTransformableRequest(
+      [&buffer, cancelled_handle](
+        tf2::TransformableRequestHandle, const std::string &, const std::string &,
+        tf2::TimePoint, tf2::TransformableResult)
+      {
+        buffer.cancelTransformableRequest(cancelled_handle);
+      },
+      "target", "first_source", time_point),
+    0u);
+
+  geometry_msgs::msg::TransformStamped transform;
+  transform.header.frame_id = "target";
+  transform.header.stamp.sec = 1;
+  transform.child_frame_id = "first_source";
+  transform.transform.rotation.w = 1;
+  ASSERT_TRUE(buffer.setTransform(transform, "authority1"));
+
+  transform.child_frame_id = "cancelled_source";
+  ASSERT_TRUE(buffer.setTransform(transform, "authority1"));
+  EXPECT_FALSE(cancelled_callback_called);
+}
+
+TEST(tf2, transformableCallbackCanSetAnotherTransform)
+{
+  tf2::BufferCore buffer;
+  const auto time_point = tf2::timeFromSec(1.0);
+  bool nested_callback_called = false;
+
+  ASSERT_NE(
+    buffer.addTransformableRequest(
+      [&nested_callback_called](
+        tf2::TransformableRequestHandle, const std::string &, const std::string &,
+        tf2::TimePoint, tf2::TransformableResult result)
+      {
+        nested_callback_called = result == tf2::TransformAvailable;
+      },
+      "target", "nested_source", time_point),
+    0u);
+
+  ASSERT_NE(
+    buffer.addTransformableRequest(
+      [&buffer](
+        tf2::TransformableRequestHandle, const std::string &, const std::string &,
+        tf2::TimePoint, tf2::TransformableResult)
+      {
+        geometry_msgs::msg::TransformStamped nested_transform;
+        nested_transform.header.frame_id = "target";
+        nested_transform.header.stamp.sec = 1;
+        nested_transform.child_frame_id = "nested_source";
+        nested_transform.transform.rotation.w = 1;
+        EXPECT_TRUE(buffer.setTransform(nested_transform, "authority1"));
+      },
+      "target", "first_source", time_point),
+    0u);
+
+  geometry_msgs::msg::TransformStamped transform;
+  transform.header.frame_id = "target";
+  transform.header.stamp.sec = 1;
+  transform.child_frame_id = "first_source";
+  transform.transform.rotation.w = 1;
+  ASSERT_TRUE(buffer.setTransform(transform, "authority1"));
+  EXPECT_TRUE(nested_callback_called);
+}
+
+TEST(tf2, transformableCallbackDoesNotBlockRequestFromAnotherThread)
+{
+  using namespace std::chrono_literals;
+
+  tf2::BufferCore buffer;
+  const auto time_point = tf2::timeFromSec(1.0);
+  std::promise<void> request_added;
+  auto request_added_future = request_added.get_future();
+  std::thread request_thread;
+
+  ASSERT_NE(
+    buffer.addTransformableRequest(
+      [&](tf2::TransformableRequestHandle, const std::string &, const std::string &,
+      tf2::TimePoint, tf2::TransformableResult)
+      {
+        // A transform-ready callback can synchronously depend on work dispatched to another
+        // executor thread. That thread must be able to enter BufferCore while this callback runs.
+        request_thread = std::thread(
+          [&buffer, &request_added, time_point]() {
+            buffer.addTransformableRequest(
+              [](tf2::TransformableRequestHandle, const std::string &, const std::string &,
+              tf2::TimePoint, tf2::TransformableResult) {},
+              "target", "second_source", time_point);
+            request_added.set_value();
+          });
+        EXPECT_EQ(request_added_future.wait_for(1s), std::future_status::ready);
+      },
+      "target", "first_source", time_point),
+    0u);
+
+  geometry_msgs::msg::TransformStamped transform;
+  transform.header.frame_id = "target";
+  transform.header.stamp.sec = 1;
+  transform.child_frame_id = "first_source";
+  transform.transform.rotation.w = 1;
+  ASSERT_TRUE(buffer.setTransform(transform, "authority1"));
+
+  request_thread.join();
 }
 
 TEST(tf2, CancelTransformableRequest)


### PR DESCRIPTION
## Description

This came up when I switch the default executor to EventsCBGExecutor in Nav2, tf2, and rclcpp. I have summarized my issue to my agent, and asks it to create some regression tests, one can verify that, without modifying anything in buffer core, the tests should end with a deadlock.

I also asked my agent to summarize the issue and changes:

```
## Summary

This change prevents `tf2::BufferCore` from invoking transformable callbacks while holding
`transformable_requests_mutex_`.

## Problem

`BufferCore::testTransformableRequests()` previously called application code while holding the
request mutex. A callback that re-entered `BufferCore`, or depended on another thread that needed to
add or cancel a request, could deadlock.

The issue is executor-independent, but EventsCBG exposed it consistently in Nav2 by increasing the
overlap between TF delivery and sensor callbacks. Nav2 remained active while `map -> odom` stopped
advancing and TF readiness events accumulated.

For example, AMCL uses a `MessageFilter<LaserScan>`. The TF listener delivers a ready transform
synchronously through the filter into `AmclNode::laserReceived()`, while another executor thread
may receive the next scan and call:


MessageFilter::add()
  -> Buffer::waitForTransform()
    -> BufferCore::addTransformableRequest()


Holding the request mutex across the first application callback unnecessarily blocks the next
request and can form a lock convoy or dependency cycle.

## Changes

When a request is ready, `testTransformableRequests()` now:

1. Saves the callback arguments locally.
2. Extracts the callback from its map.
3. Removes the completed request.
4. Releases the request mutex.
5. Invokes the callback.
6. Reacquires the mutex and restarts scanning because callback execution may have changed the
   request vector.

Removing the request before invocation establishes a clear cancellation boundary: cancellation
either removes a pending request first, or delivery has already been claimed and the callback runs
once. No container reference or iterator survives the unlocked region.

Resolved frame names are stored when the request is registered so callback arguments remain stable
after the request is removed. `unordered_map::extract()` retains callback ownership without copying
the `std::function`.

```

I have verified that this pass all regression tests I added, and also works in Nav2 + tf2 + rclcpp when using EventsCBGExecutor by default.

### Is this user-facing behavior change?

Yes, previously there is a deadlock, so this is a bugfix

### Did you use Generative AI?

Yes, Codex Sol 5.6

### Additional Information


