### PR TITLE
Add regression test for waitForTransform/testTransformableRequests deadlock

### DIFF
--- a/tf2_ros/test/test_buffer.cpp
+++ b/tf2_ros/test/test_buffer.cpp
@@ -28,10 +28,12 @@
  */
 
 #include <chrono>
+#include <cstdlib>
 #include <exception>
 #include <functional>
 #include <future>
 #include <memory>
+#include <string>
 #include <thread>
 #include <unordered_map>
 
@@ -615,6 +617,114 @@ TEST(test_buffer, wait_for_transform_race_during_setup)
     ASSERT_EQ(status, std::future_status::ready) << "Failed at iteration " << i;
     ASSERT_FALSE(callback_timeout) << "Failed at iteration " << i;
   }
+}
+
+// Reproduces the ABBA deadlock introduced by ros2/geometry2#966 (#973 on jazzy):
+//
+//   Thread A – waitForTransform:
+//     holds timer_to_request_map_mutex_
+//       -> BufferCore::addTransformableRequest
+//         -> waits for transformable_requests_mutex_
+//
+//   Thread B – setTransform -> testTransformableRequests:
+//     holds transformable_requests_mutex_
+//       -> waitForTransform ready-callback
+//         -> waits for timer_to_request_map_mutex_
+//
+// Before #966, addTransformableRequest ran outside timer_to_request_map_mutex_, so the
+// two mutexes were never held in opposite order. ros2/geometry2#979 fixes this by
+// invoking transformable callbacks without holding transformable_requests_mutex_.
+TEST(test_buffer, wait_for_transform_does_not_deadlock_with_set_transform)
+{
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+  tf2_ros::Buffer buffer(clock);
+  buffer.setUsingDedicatedThread(true);
+  auto mock_create_timer = std::make_shared<MockCreateTimer>();
+  buffer.setCreateTimerInterface(mock_create_timer);
+
+  const tf2::TimePoint time_point = tf2::timeFromSec(1.0);
+  const std::string target_frame = "foo";
+  const std::string source_frame = "bar";
+
+  std::promise<void> in_transformable_callback;
+  std::promise<void> waiter_finished;
+  auto waiter_finished_future = waiter_finished.get_future();
+  std::thread waiter_thread;
+
+  // First request becomes ready together with the waitForTransform below. While
+  // testTransformableRequests still holds transformable_requests_mutex_ (pre-#979),
+  // this callback starts a concurrent waitForTransform that takes
+  // timer_to_request_map_mutex_ and then blocks in addTransformableRequest.
+  auto gate_cb =
+    [&buffer, &in_transformable_callback, &waiter_thread, &waiter_finished, time_point,
+      target_frame](
+    tf2::TransformableRequestHandle, const std::string &, const std::string &,
+    tf2::TimePoint, tf2::TransformableResult)
+    {
+      waiter_thread = std::thread(
+        [&buffer, &in_transformable_callback, &waiter_finished, time_point, target_frame]()
+        {
+          // Wait until the gate callback is running so addTransformableRequest
+          // contends with testTransformableRequests.
+          in_transformable_callback.get_future().wait();
+          buffer.waitForTransform(
+            target_frame, "other", time_point, tf2::durationFromSec(1.0),
+            [](const tf2_ros::TransformStampedFuture &) {});
+          waiter_finished.set_value();
+        });
+      in_transformable_callback.set_value();
+      // Give the waiter time to enter waitForTransform. Without #979 it holds
+      // timer_to_request_map_mutex_ while blocked in addTransformableRequest; returning
+      // into testTransformableRequests then deadlocks on that mutex. With #979 the
+      // waiter finishes this sleep without blocking.
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    };
+
+  ASSERT_NE(
+    buffer.addTransformableRequest(gate_cb, target_frame, source_frame, time_point),
+    0u);
+
+  bool wait_callback_called = false;
+  auto future = buffer.waitForTransform(
+    target_frame, source_frame, time_point, tf2::durationFromSec(1.0),
+    [&wait_callback_called](const tf2_ros::TransformStampedFuture &) {
+      wait_callback_called = true;
+    });
+
+  geometry_msgs::msg::TransformStamped transform;
+  transform.header.frame_id = target_frame;
+  transform.header.stamp.sec = 1;
+  transform.child_frame_id = source_frame;
+  transform.transform.rotation.w = 1.0;
+
+  std::promise<void> set_transform_done;
+  std::thread setter([&buffer, &transform, &set_transform_done]() {
+      EXPECT_TRUE(buffer.setTransform(transform, "unittest"));
+      set_transform_done.set_value();
+    });
+
+  const auto set_status = set_transform_done.get_future().wait_for(std::chrono::seconds(5));
+  EXPECT_EQ(set_status, std::future_status::ready) <<
+    "Deadlock between waitForTransform (timer_to_request_map_mutex_ -> "
+    "transformable_requests_mutex_) and testTransformableRequests "
+    "(transformable_requests_mutex_ -> timer_to_request_map_mutex_). "
+    "See ros2/geometry2#966 / #979.";
+  if (set_status != std::future_status::ready) {
+    // Threads still hold the two mutexes; abort so gtest does not hang on join.
+    std::_Exit(1);
+  }
+
+  setter.join();
+  ASSERT_TRUE(waiter_thread.joinable());
+  const auto waiter_status = waiter_finished_future.wait_for(std::chrono::seconds(1));
+  EXPECT_EQ(waiter_status, std::future_status::ready);
+  if (waiter_status != std::future_status::ready) {
+    std::_Exit(1);
+  }
+  waiter_thread.join();
+
+  EXPECT_TRUE(wait_callback_called);
+  EXPECT_EQ(future.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
## Description

The test forces the interleaving deterministically: 

 1. Register a plain BufferCore::addTransformableRequest("foo"→"bar", t=1s) whose callback, when fired, spawns a  thread that calls buffer.waitForTransform("foo"→"other", …) and then sleeps 50 ms before returning. 
 2. Call buffer.waitForTransform("foo"→"bar", t=1s, cb) 
  3. In another thread publish the transform: call buffer.setTransform(foo→bar @1s). 
 
This leads to the deadlock with #966, and works fine before, and also works fine with #966 + #979

Relates to https://github.com/ros2/geometry2/pull/966

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

grok 4.6 + claude fable 5

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
