### PR TITLE
Enable RMW isolation for single process tests

### DIFF
--- a/test_tf2/CMakeLists.txt
+++ b/test_tf2/CMakeLists.txt
@@ -15,6 +15,7 @@ endif()
 
 if (BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
+  find_package(ament_cmake_ros REQUIRED)
   find_package(ament_cmake_ros_core REQUIRED)
   find_package(builtin_interfaces REQUIRED)
 # Work around broken find module in AlmaLinux/RHEL eigen3-devel from PowerTools repo
@@ -34,7 +35,7 @@ if (BUILD_TESTING)
 
   ament_find_gtest()
 
-  ament_add_gtest(buffer_core_test test/buffer_core_test.cpp)
+  ament_add_ros_isolated_gtest(buffer_core_test test/buffer_core_test.cpp)
   if(TARGET buffer_core_test)
     target_link_libraries(buffer_core_test
       ament_cmake_ros_core::ament_ros_defaults
@@ -46,7 +47,7 @@ if (BUILD_TESTING)
       tf2_ros::tf2_ros)
   endif()
 
-  ament_add_gtest(test_message_filter test/test_message_filter.cpp)
+  ament_add_ros_isolated_gtest(test_message_filter test/test_message_filter.cpp)
   if(TARGET test_message_filter)
     target_link_libraries(test_message_filter
       ament_cmake_ros_core::ament_ros_defaults
@@ -118,7 +119,7 @@ if (BUILD_TESTING)
     add_launch_test(test/static_publisher.launch.py)
   endif()
 
-  ament_add_gtest(test_tf2_bullet test/test_tf2_bullet.cpp)
+  ament_add_ros_isolated_gtest(test_tf2_bullet test/test_tf2_bullet.cpp)
   if(TARGET test_tf2_bullet)
     target_link_libraries(test_tf2_bullet
       ament_cmake_ros_core::ament_ros_defaults

--- a/test_tf2/package.xml
+++ b/test_tf2/package.xml
@@ -29,6 +29,7 @@
   <depend>tf2_ros</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_cmake_ros_core</test_depend>
   <test_depend>launch_ros</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>

--- a/tf2_ros/CMakeLists.txt
+++ b/tf2_ros/CMakeLists.txt
@@ -146,7 +146,6 @@ if(BUILD_TESTING)
   ament_lint_cmake()
   ament_uncrustify(LANGUAGE "c++")
 
-  find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_cmake_ros REQUIRED)
 
   ament_add_ros_isolated_gtest(test_buffer test/test_buffer.cpp)

--- a/tf2_ros/CMakeLists.txt
+++ b/tf2_ros/CMakeLists.txt
@@ -147,8 +147,9 @@ if(BUILD_TESTING)
   ament_uncrustify(LANGUAGE "c++")
 
   find_package(ament_cmake_gtest REQUIRED)
+  find_package(ament_cmake_ros REQUIRED)
 
-  ament_add_gtest(test_buffer test/test_buffer.cpp)
+  ament_add_ros_isolated_gtest(test_buffer test/test_buffer.cpp)
   target_link_libraries(test_buffer
     ament_cmake_ros_core::ament_ros_defaults
     ${PROJECT_NAME}
@@ -156,7 +157,7 @@ if(BUILD_TESTING)
     #   rclcpp::rclcpp
   )
 
-  ament_add_gtest(test_buffer_server test/test_buffer_server.cpp)
+  ament_add_ros_isolated_gtest(test_buffer_server test/test_buffer_server.cpp)
   target_link_libraries(test_buffer_server
     ament_cmake_ros_core::ament_ros_defaults
     ${PROJECT_NAME}
@@ -166,7 +167,7 @@ if(BUILD_TESTING)
     #   tf2_msgs::tf2_msgs
   )
 
-  ament_add_gtest(test_buffer_client test/test_buffer_client.cpp)
+  ament_add_ros_isolated_gtest(test_buffer_client test/test_buffer_client.cpp)
   target_link_libraries(test_buffer_client
     ament_cmake_ros_core::ament_ros_defaults
     ${PROJECT_NAME}
@@ -178,7 +179,7 @@ if(BUILD_TESTING)
 
   # Adds a tf2_ros message_filter unittest that uses
   # multiple target frames and a non-zero time tolerance
-  ament_add_gtest(${PROJECT_NAME}_test_message_filter test/message_filter_test.cpp)
+  ament_add_ros_isolated_gtest(${PROJECT_NAME}_test_message_filter test/message_filter_test.cpp)
   target_link_libraries(${PROJECT_NAME}_test_message_filter
     ament_cmake_ros_core::ament_ros_defaults
     ${PROJECT_NAME}
@@ -188,7 +189,7 @@ if(BUILD_TESTING)
     #   rclcpp::rclcpp
   )
 
-  ament_add_gtest(${PROJECT_NAME}_test_transform_listener test/test_transform_listener.cpp)
+  ament_add_ros_isolated_gtest(${PROJECT_NAME}_test_transform_listener test/test_transform_listener.cpp)
   target_link_libraries(${PROJECT_NAME}_test_transform_listener
     ament_cmake_ros_core::ament_ros_defaults
     ${PROJECT_NAME}
@@ -196,7 +197,7 @@ if(BUILD_TESTING)
     #   rclcpp::rclcpp
   )
 
-  ament_add_gtest(${PROJECT_NAME}_test_static_transform_broadcaster test/test_static_transform_broadcaster.cpp)
+  ament_add_ros_isolated_gtest(${PROJECT_NAME}_test_static_transform_broadcaster test/test_static_transform_broadcaster.cpp)
   target_link_libraries(${PROJECT_NAME}_test_static_transform_broadcaster
     ament_cmake_ros_core::ament_ros_defaults
     ${PROJECT_NAME}
@@ -204,7 +205,7 @@ if(BUILD_TESTING)
     #   rclcpp::rclcpp
   )
 
-  ament_add_gtest(${PROJECT_NAME}_test_transform_broadcaster test/test_transform_broadcaster.cpp)
+  ament_add_ros_isolated_gtest(${PROJECT_NAME}_test_transform_broadcaster test/test_transform_broadcaster.cpp)
   target_link_libraries(${PROJECT_NAME}_test_transform_broadcaster
     ament_cmake_ros_core::ament_ros_defaults
     ${PROJECT_NAME}
@@ -212,7 +213,7 @@ if(BUILD_TESTING)
     #   rclcpp::rclcpp
   )
 
-  ament_add_gtest(${PROJECT_NAME}_test_time_reset test/time_reset_test.cpp)
+  ament_add_ros_isolated_gtest(${PROJECT_NAME}_test_time_reset test/time_reset_test.cpp)
   target_link_libraries(${PROJECT_NAME}_test_time_reset
     ament_cmake_ros_core::ament_ros_defaults
     ${PROJECT_NAME}
@@ -222,7 +223,7 @@ if(BUILD_TESTING)
     #   rclcpp::rclcpp
   )
 
-  ament_add_gtest(${PROJECT_NAME}_test_velocity test/velocity_test.cpp)
+  ament_add_ros_isolated_gtest(${PROJECT_NAME}_test_velocity test/velocity_test.cpp)
   target_link_libraries(${PROJECT_NAME}_test_velocity
     ament_cmake_ros_core::ament_ros_defaults
     ${PROJECT_NAME}
@@ -231,7 +232,7 @@ if(BUILD_TESTING)
     #   rclcpp::rclcpp
   )
 
-  ament_add_gtest(${PROJECT_NAME}_test_listener test/listener_unittest.cpp)
+  ament_add_ros_isolated_gtest(${PROJECT_NAME}_test_listener test/listener_unittest.cpp)
   target_link_libraries(${PROJECT_NAME}_test_listener
     ament_cmake_ros_core::ament_ros_defaults
     ${PROJECT_NAME}

--- a/tf2_ros/package.xml
+++ b/tf2_ros/package.xml
@@ -31,6 +31,7 @@
   <depend>tf2_msgs</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>rosgraph_msgs</test_depend>

--- a/tf2_ros/package.xml
+++ b/tf2_ros/package.xml
@@ -30,7 +30,6 @@
   <depend>tf2</depend>
   <depend>tf2_msgs</depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/tf2_ros_py/conftest.py
+++ b/tf2_ros_py/conftest.py
@@ -1,0 +1,25 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from rmw_test_fixture_implementation import rmw_test_isolation_start
+from rmw_test_fixture_implementation import rmw_test_isolation_stop
+
+
+@pytest.fixture(autouse=True, scope='session')
+def rmw_isolation():
+    """Start RMW isolation before any ROS context is created."""
+    rmw_test_isolation_start()
+    yield
+    rmw_test_isolation_stop()

--- a/tf2_ros_py/package.xml
+++ b/tf2_ros_py/package.xml
@@ -27,6 +27,7 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>rmw_test_fixture_implementation</test_depend>
 
   <export>
     <build_type>ament_python</build_type>


### PR DESCRIPTION
## Description

https://github.com/ros2/geometry2/pull/960 enabled RMW isolation for `test_tf2` **launch** tests but not single process tests that call `rclcpp::init` / `rclpy.init`. 

When testing with `rmw_zenoh`, those still connect to default `tcp/localhost:7447` with an infinite peer connect timeout, so session open can hang and ctest reports `gtest.missing_result`.

That showed up as an intermittent zenoh nightly failure: [119](https://build.ros2.org/job/Rci__nightly-zenoh_ubuntu_resolute_amd64/119/) passed, [120](https://build.ros2.org/job/Rci__nightly-zenoh_ubuntu_resolute_amd64/120/) failed on `test_message_filter` with no source changes.

This PR wraps remaining ROS-init tests with the fixture:

- `test_tf2` / `tf2_ros`: `ament_add_ros_isolated_gtest` for gtests that call `rclcpp::init`
- `tf2_ros_py`: session-scoped `conftest.py` (ament_python has no CMake isolated runner)

Fixes # (issue)

### Is this user-facing behavior change?

No

### Did you use Generative AI?

Yes. Cursor (Grok 4.6) for diagnosis and the isolation wiring.

### Additional Information

Launch isolation from #960 is unchanged.