### PR TITLE
Prevent stale MessageFilter futures after callback race

### DIFF
--- a/tf2_ros/include/tf2_ros/message_filter.hpp
+++ b/tf2_ros/include/tf2_ros/message_filter.hpp
@@ -41,6 +41,7 @@
 #include <list>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <ratio>
 #include <sstream>
 #include <string>
@@ -298,7 +299,9 @@ public:
     {
       std::unique_lock<std::mutex> lock(ts_futures_mutex_);
       for (auto & kv : ts_futures_) {
-        buffer_.cancel(kv.second);
+        if (kv.second) {
+          buffer_.cancel(*kv.second);
+        }
       }
       ts_futures_.clear();
     }
@@ -391,18 +394,37 @@ public:
       const auto & handle = std::get<0>(param);
       const auto & stamp = std::get<1>(param);
       const auto & target_frame = std::get<2>(param);
-      tf2_ros::TransformStampedFuture future = buffer_.waitForTransform(
-        target_frame,
-        frame_id,
-        stamp,
-        buffer_timeout_,
-        std::bind(&MessageFilter::transformReadyCallback, this, std::placeholders::_1, handle));
+
+      {
+        std::unique_lock<std::mutex> lock(ts_futures_mutex_);
+        ts_futures_.insert({handle, std::nullopt});
+      }
+
+      std::optional<tf2_ros::TransformStampedFuture> future;
+      try {
+        future.emplace(buffer_.waitForTransform(
+            target_frame,
+            frame_id,
+            stamp,
+            buffer_timeout_,
+            std::bind(
+              &MessageFilter::transformReadyCallback, this, std::placeholders::_1, handle)));
+      } catch (...) {
+        std::unique_lock<std::mutex> lock(ts_futures_mutex_);
+        ts_futures_.erase(handle);
+        throw;
+      }
 
       // If handle of future is 0 or 0xffffffffffffffffULL, waitForTransform have already called
       // the callback.
-      if (0 != future.getHandle() && 0xffffffffffffffffULL != future.getHandle()) {
-        std::unique_lock<std::mutex> lock(ts_futures_mutex_);
-        ts_futures_.insert({handle, std::move(future)});
+      std::unique_lock<std::mutex> lock(ts_futures_mutex_);
+      auto iter = ts_futures_.find(handle);
+      if (iter != ts_futures_.end()) {
+        if (0 != future->getHandle() && 0xffffffffffffffffULL != future->getHandle()) {
+          iter->second.emplace(std::move(*future));
+        } else {
+          ts_futures_.erase(iter);
+        }
       }
     }
   }
@@ -738,9 +760,9 @@ private:
   ///< The mutex used for locking TransformStampedFuture map operations
   std::mutex ts_futures_mutex_;
 
-  ///< Store the TransformStampedFuture returned by 'waitForTransform',
-  // to clear the callback in the Buffer if MessageFiltered object is destroyed.
-  std::unordered_map<uint64_t, tf2_ros::TransformStampedFuture> ts_futures_;
+  ///< Store futures so their callbacks can be cancelled when the filter is cleared. A null
+  // optional marks a request whose future has not returned from 'waitForTransform' yet.
+  std::unordered_map<uint64_t, std::optional<tf2_ros::TransformStampedFuture>> ts_futures_;
 };
 }  // namespace tf2_ros
 

--- a/tf2_ros/test/message_filter_test.cpp
+++ b/tf2_ros/test/message_filter_test.cpp
@@ -31,6 +31,7 @@
 #include <chrono>
 #include <memory>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "gtest/gtest.h"
@@ -48,6 +49,43 @@
 #include "rclcpp/rclcpp.hpp"
 #include "geometry_msgs/msg/point_stamped.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
+
+class CallbackBeforeWaitReturnsBuffer : public tf2_ros::Buffer
+{
+public:
+  using tf2_ros::Buffer::Buffer;
+
+  tf2_ros::TransformStampedFuture waitForTransform(
+    const std::string & target_frame,
+    const std::string & source_frame,
+    const tf2::TimePoint & time,
+    const tf2::Duration & timeout,
+    tf2_ros::TransformReadyCallback callback) override
+  {
+    (void)target_frame;
+    (void)source_frame;
+    (void)time;
+    (void)timeout;
+
+    auto promise = std::make_shared<std::promise<geometry_msgs::msg::TransformStamped>>();
+    tf2_ros::TransformStampedFuture future(promise->get_future());
+    future.setHandle(1u);
+    promise->set_exception(
+      std::make_exception_ptr(tf2::LookupException("Test transform unavailable")));
+
+    std::thread callback_thread([&callback, &future]() {callback(future);});
+    callback_thread.join();
+    return future;
+  }
+
+  void cancel(const tf2_ros::TransformStampedFuture & future) override
+  {
+    (void)future;
+    ++cancel_count;
+  }
+
+  std::atomic<size_t> cancel_count {0u};
+};
 
 std::atomic<uint8_t> filter_callback_fired = 0;
 void filter_callback(const geometry_msgs::msg::PointStamped & msg)
@@ -138,6 +176,25 @@ TEST(tf2_ros_message_filter, get_target_frames)
   frames.push_back("map");
   filter.setTargetFrames(frames);
   ASSERT_STREQ(filter.getTargetFramesString().c_str(), "odom, map");
+}
+
+TEST(tf2_ros_message_filter, callback_before_wait_returns_does_not_leave_stale_future)
+{
+  auto node = rclcpp::Node::make_shared("test_message_filter_callback_race");
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+  CallbackBeforeWaitReturnsBuffer buffer(
+    clock, tf2::Duration(tf2::BUFFER_CORE_DEFAULT_CACHE_TIME), *node);
+  tf2_ros::MessageFilter<
+    geometry_msgs::msg::PointStamped,
+    CallbackBeforeWaitReturnsBuffer> filter(buffer, "map", 10, *node);
+
+  auto point = std::make_shared<geometry_msgs::msg::PointStamped>();
+  point->header.frame_id = "base";
+  point->header.stamp = clock->now();
+  filter.add(point);
+
+  filter.clear();
+  EXPECT_EQ(0u, buffer.cancel_count.load());
 }
 
 TEST(tf2_ros_message_filter, multiple_frames_and_time_tolerance)


### PR DESCRIPTION
## Description

`MessageFilter::add()` currently stores the future returned by `waitForTransform()` after that call returns. A transform callback running on another thread can complete in the gap between the return and insertion, fail to find its future, and leave the subsequently inserted future stale until `clear()` or destruction.

This change registers a pending entry before calling `waitForTransform()`. The callback can erase that entry whether it runs before or after the returned future is installed. Exceptions remove the pending entry, and `clear()` only cancels entries that contain a realized future.

A deterministic regression test uses a test buffer that invokes the callback from another thread before `waitForTransform()` returns, then verifies that `clear()` does not try to cancel the already-completed request.

Fixes #827

### Is this user-facing behavior change?

No. This fixes internal future bookkeeping and prevents completed transform requests from remaining registered.

### Did you use Generative AI?

Yes. OpenAI Codex assisted with implementation and test construction; the change was reviewed and validated in a clean ROS 2 Rolling container.

### Additional Information

Validated on `ros:rolling-ros-base` (arm64):

- `colcon build --packages-up-to tf2_ros --cmake-args -DBUILD_TESTING=ON -DCMAKE_CXX_FLAGS=-Werror`
- `colcon test --packages-select tf2_ros`
- 228 tests/checks reported, 0 errors, 0 failures (56 cppcheck entries skipped because the installed cppcheck version is intentionally disabled by ament)